### PR TITLE
add back electron and muon gen d0 calculated from prunedGenParticles

### DIFF
--- a/Collections/interface/Electron.h
+++ b/Collections/interface/Electron.h
@@ -23,6 +23,7 @@ namespace osu
         const double sumChargedHadronPtCorr () const;
         const double sumPUPtCorr () const;
         const int electronPVIndex () const;
+	const double genD0 () const;
         const int missingInnerHitsFromAllHits () const;
         const int missingInnerHitsFromTrackerLayersWithoutMeasurements () const;
         const int missingMiddleHitsFromTrackerLayersWithoutMeasurements () const;
@@ -36,6 +37,7 @@ namespace osu
         void set_sumChargedHadronPtCorr (double value) { sumChargedHadronPtCorr_  = value; };
         void set_sumPUPtCorr (double value) { sumPUPtCorr_  = value; };
         void set_electronPVIndex (int value) { electronPVIndex_  = value; };
+	void set_genD0 (double value) { genD0_  = value; };
         void set_passesTightID_noIsolation (const reco::BeamSpot &, const TYPE(primaryvertexs) &, const edm::Handle<vector<reco::Conversion> > &);
         void set_match_HLT_Ele25_eta2p1_WPTight_Gsf_v (const bool);
         void set_match_HLT_Ele22_eta2p1_WPLoose_Gsf_v (const bool);
@@ -78,6 +80,7 @@ namespace osu
         double sumChargedHadronPtCorr_;
         int electronPVIndex_;
         double sumPUPtCorr_;
+	double genD0_;
         bool passesTightID_noIsolation_;
         bool match_HLT_Ele25_eta2p1_WPTight_Gsf_v_;
         bool match_HLT_Ele22_eta2p1_WPLoose_Gsf_v_;

--- a/Collections/interface/Muon.h
+++ b/Collections/interface/Muon.h
@@ -23,12 +23,14 @@ namespace osu
         const double sumChargedHadronPtCorr () const;
         const double sumPUPtCorr () const;
         const int muonPVIndex () const;
+	const double genD0 () const;
         const bool isTightMuonWRTVtx() const { return isTightMuonWRTVtx_; }
         void set_isTightMuonWRTVtx(const bool isTightMuon);
         void set_pfdBetaIsoCorr (double value) { pfdBetaIsoCorr_  = value; };
         void set_sumChargedHadronPtCorr (double value) { sumChargedHadronPtCorr_  = value; };
         void set_sumPUPtCorr (double value) { sumPUPtCorr_  = value; };
         void set_muonPVIndex (int value) { muonPVIndex_  = value; };
+	void set_genD0 (double value) { genD0_  = value; };
 
         void set_match_HLT_IsoMu24_v (const bool);
         void set_match_HLT_IsoTkMu24_v (const bool);
@@ -60,6 +62,7 @@ namespace osu
         double sumChargedHadronPtCorr_;
         int muonPVIndex_;
         double sumPUPtCorr_;
+	double genD0_;
 
         double metMinusOnePt_;
         double metMinusOnePx_;

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -106,6 +106,17 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
         effectiveArea = 0.2687;
       electron.set_AEff(effectiveArea);
 
+      //generator D0 must be done with prunedGenParticles because vertex is only right in this collection, not right in packedGenParticles
+      if(prunedParticles.isValid() && beamspot.isValid())
+	{
+	  for (auto cand = prunedParticles->begin(); cand != prunedParticles->end(); cand++)
+	    {
+	      if (!(abs(cand->pdgId()) == 11 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < 0.1))
+		continue;
+	      double gen_d0 = ((-(cand->vx() - beamspot->x0())*cand->py() + (cand->vy() - beamspot->y0())*cand->px())/cand->pt());
+	      electron.set_genD0(gen_d0);
+	    }
+	}
 
       double pfdRhoIsoCorr = 0;
       double chargedHadronPt = 0;

--- a/Collections/plugins/OSUMuonProducer.cc
+++ b/Collections/plugins/OSUMuonProducer.cc
@@ -86,6 +86,18 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
           muon.set_match_HLT_IsoTkMu20_v (anatools::isMatchedToTriggerObject (event, *triggers, object, *trigobjs, "hltHighPtTkMuonCands::HLT", "hltL3fL1sMu16L1f0Tkf20QL3trkIsoFiltered0p09"));
         }
 
+      //generator D0 must be done with prunedGenParticles because vertex is only right in this collection, not right in packedGenParticles
+      if(prunedParticles.isValid() && beamspot.isValid())
+	{
+	  for (auto cand = prunedParticles->begin(); cand != prunedParticles->end(); cand++)
+	    {
+	      if (!(abs(cand->pdgId()) == 13 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < 0.1))
+		continue;
+	      double gen_d0 = ((-(cand->vx() - beamspot->x0())*cand->py() + (cand->vy() - beamspot->y0())*cand->px())/cand->pt());
+	      muon.set_genD0(gen_d0);
+	    }
+	}
+
       double pfdBetaIsoCorr = 0;
       double chargedHadronPt = 0;
       double puPt = 0;

--- a/Collections/src/Electron.cc
+++ b/Collections/src/Electron.cc
@@ -18,6 +18,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron) :
   sumChargedHadronPtCorr_     (INVALID_VALUE),
   electronPVIndex_            (INVALID_VALUE),
   sumPUPtCorr_                (INVALID_VALUE),
+  genD0_                      (INVALID_VALUE),
   passesTightID_noIsolation_  (false),
   match_HLT_Ele25_eta2p1_WPTight_Gsf_v_ (false),
   match_HLT_Ele22_eta2p1_WPLoose_Gsf_v_ (false),
@@ -47,6 +48,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   sumChargedHadronPtCorr_     (INVALID_VALUE),
   electronPVIndex_            (INVALID_VALUE),
   sumPUPtCorr_                (INVALID_VALUE),
+  genD0_                      (INVALID_VALUE),
   passesTightID_noIsolation_  (false),
   match_HLT_Ele25_eta2p1_WPTight_Gsf_v_ (false),
   match_HLT_Ele22_eta2p1_WPLoose_Gsf_v_ (false),
@@ -76,6 +78,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   sumChargedHadronPtCorr_     (INVALID_VALUE),
   electronPVIndex_            (INVALID_VALUE),
   sumPUPtCorr_                (INVALID_VALUE),
+  genD0_                      (INVALID_VALUE),
   passesTightID_noIsolation_  (false),
   match_HLT_Ele25_eta2p1_WPTight_Gsf_v_ (false),
   match_HLT_Ele22_eta2p1_WPLoose_Gsf_v_ (false),
@@ -105,6 +108,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   sumChargedHadronPtCorr_     (INVALID_VALUE),
   electronPVIndex_            (INVALID_VALUE),
   sumPUPtCorr_                (INVALID_VALUE),
+  genD0_                      (INVALID_VALUE),
   passesTightID_noIsolation_  (false),
   match_HLT_Ele25_eta2p1_WPTight_Gsf_v_ (false),
   match_HLT_Ele22_eta2p1_WPLoose_Gsf_v_ (false),
@@ -213,6 +217,12 @@ const double
 osu::Electron::sumPUPtCorr () const
 {
   return sumPUPtCorr_;
+}
+
+const double
+osu::Electron::genD0 () const
+{
+  return genD0_;
 }
 
 const bool

--- a/Collections/src/Muon.cc
+++ b/Collections/src/Muon.cc
@@ -16,6 +16,7 @@ osu::Muon::Muon (const TYPE(muons) &muon) :
   sumChargedHadronPtCorr_  (INVALID_VALUE),
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
+  genD0_                   (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
   metMinusOnePx_           (INVALID_VALUE),
   metMinusOnePy_           (INVALID_VALUE),
@@ -38,6 +39,7 @@ osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcpartic
   sumChargedHadronPtCorr_  (INVALID_VALUE),
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
+  genD0_                   (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
   metMinusOnePx_           (INVALID_VALUE),
   metMinusOnePy_           (INVALID_VALUE),
@@ -60,6 +62,7 @@ osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcpartic
   sumChargedHadronPtCorr_  (INVALID_VALUE),
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
+  genD0_                   (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
   metMinusOnePx_           (INVALID_VALUE),
   metMinusOnePy_           (INVALID_VALUE),
@@ -82,6 +85,7 @@ osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcpartic
   sumChargedHadronPtCorr_  (INVALID_VALUE),
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
+  genD0_                   (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
   metMinusOnePx_           (INVALID_VALUE),
   metMinusOnePy_           (INVALID_VALUE),
@@ -138,6 +142,12 @@ const double
 osu::Muon::sumPUPtCorr () const
 {
   return sumPUPtCorr_;
+}
+
+const double
+osu::Muon::genD0 () const
+{
+  return genD0_;
 }
 
 void

--- a/Configuration/python/cutUtilities.py
+++ b/Configuration/python/cutUtilities.py
@@ -62,9 +62,6 @@ muonD0WRTBeamspotErr = "hypot(muon.innerTrack.d0Error, hypot(beamspot.x0Error, b
 muonD0WRTBeamspotSig = "(((muon.vx - beamspot.x0) * muon.py - (muon.vy - beamspot.y0) * muon.px) / muon.pt) / (hypot(muon.innerTrack.d0Error, hypot(beamspot.x0Error, beamspot.y0Error)))"
 muonD0WRTPV       = "((muon.vx - eventvariable.leadingPV_x) * muon.py - (muon.vy - eventvariable.leadingPV_y) * muon.px) / muon.pt"
 
-genElectronD0WRTBeamspot = "((electron.genMatchedParticle.bestMatch.vx - beamspot.x0) * electron.genMatchedParticle.bestMatch.py - (electron.genMatchedParticle.bestMatch.vy - beamspot.y0) * electron.genMatchedParticle.bestMatch.px) / electron.genMatchedParticle.bestMatch.pt"
-genMuonD0WRTBeamspot = "((muon.genMatchedParticle.bestMatch.vx - beamspot.x0) * muon.genMatchedParticle.bestMatch.py - (muon.genMatchedParticle.bestMatch.vy - beamspot.y0) * muon.genMatchedParticle.bestMatch.px) / muon.genMatchedParticle.bestMatch.pt"
-
 
 # Calculation from https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/DataFormats/TrackReco/interface/TrackBase.h#L674
 electronDZWRTBeamspot = "(electron.vz - beamspot.z0) \


### PR DESCRIPTION
As we discussed, the generator d0 needs to be calculated from prunedGenParticles, not GenMatchable packedGenParticles, because otherwise the vertex information is wrong.