### PR TITLE
Fix osusub.py for UserDir and UserList modes

### DIFF
--- a/Configuration/python/mergeUtilities.py
+++ b/Configuration/python/mergeUtilities.py
@@ -175,7 +175,7 @@ def MakeFilesForSkimDirectory(Directory, DirectoryOut, TotalNumber, SkimNumber, 
 ###############################################################################
 #           Produce a pickle file containing the skim input tags.             #
 ###############################################################################
-def GetSkimInputTags(File, ignoreSkimmedCollections=False):
+def GetSkimInputTags(File):
     print "Getting skim input tags..."
     eventContent = subprocess.check_output (["edmDumpEventContent", "--all", os.getcwd () + "/" + File])
     parsing = False
@@ -191,25 +191,11 @@ def GetSkimInputTags(File, ignoreSkimmedCollections=False):
             continue
         splitLine = line.split ()
         cppTypes.append (splitLine[0])
-        if splitLine[0] in inputTags:
-            inputTags[splitLine[0]].append ( cms.InputTag (splitLine[1][1:-1], splitLine[2][1:-1], splitLine[3][1:-1]) )
-        else:
-            inputTags[splitLine[0]] = [ cms.InputTag (splitLine[1][1:-1], splitLine[2][1:-1], splitLine[3][1:-1]) ]
-
-    # Figure out which collection map we're using to determine priority in input tag determination
-    from OSUT3Analysis.AnaTools.osuAnalysis_cfi import dataFormat, collectionMap, collectionMapMiniAOD2017, collectionMapAOD
-    if dataFormat.startswith ("MINI_AOD") and "2017" not in dataFormat:
-        collectionMap = collectionMap
-    elif dataFormat.startswith ("MINI_AOD_2017"):
-        collectionMap = collectionMapMiniAOD2017
-    elif dataFormat.startswith ("AOD"):
-        collectionmap = collectionMapAOD
-    else:
-        print "Unknown data type, use either AOD or MINI_AOD! Cannot create SkimInputTags.pkl!"
-	return
+        inputTags[splitLine[0]] = cms.InputTag (splitLine[1][1:-1], splitLine[2][1:-1], splitLine[3][1:-1])
 
     collectionTypes = subprocess.check_output (["getCollectionType"] + cppTypes)
-    # Save only the collections for which there is a valid type.
+    # Save only the collections for which there is a valid type, and only framework collections
+    # Future jobs on this skim will use the user's collectionMap collections, overwritten only for framework collections
     for i in range (0, len (cppTypes)):
         if cppTypes[i] not in inputTags:
             continue
@@ -217,51 +203,9 @@ def GetSkimInputTags(File, ignoreSkimmedCollections=False):
         if collectionType == "INVALID_TYPE":
             inputTags.pop (cppTypes[i])
         else:
-            # There may be multiple instances of the same cpp type, for example we now store both the skimmed/selected framework objects
-            # and the original (mini)AOD collections for a full skim. Another example is that slimmedJetsAK8PFPuppiSoftDropPacked and 
-            # slimmedJets exist in miniAOD and are of type pat::Jet.
-            # There is a clear hierarchy of what to use as in input: OSUAnalysis types > (mini)AOD types used in CollectionProducer_cff > (mini)AOD types > anything
-            availableTags = inputTags.pop (cppTypes[i])
-
-            # If there's nothing of this type available, we're in trouble
-            if len(availableTags) == 0:
-                print "The collection \"" + collectionType + "\" has C++ class \"" + cppTypes[i]  + "\" and is expected in this skim file, yet no object of this C++ class is found. Something has broken, and no SkimInputTags.pkl can be created!"
-                return
-
-            # If there's only one of this type available, take it
-            if len(availableTags) == 1:
-                inputTags[collectionType] = availableTags[0]
-                continue
-
-            if not ignoreSkimmedCollections:    
-                # If there's something with process name OSUAnalysis, take that
-                foundPreferredTag = False
-                for tag in availableTags:
-                    if "OSUAnalysis" in tag.getProcessName ():
-                        inputTags[collectionType] = tag
-                        foundPreferredTag = True
-                        break
-                if foundPreferredTag:
-                    continue
-    
-            # If there's no OSUAnalysis type available, take what's in osuAnalysis_cfi's collection map
-            for tag in availableTags:
-                if hasattr (collectionMap, collectionType):
-                    if getattr (collectionMap, collectionType).getModuleLabel () == tag.getModuleLabel ():
-                        productInstanceLabel = getattr (collectionMap, collectionType).getProductInstanceLabel ()
-                        processName = getattr (collectionMap, collectionType).getProcessName ()
-                        if productInstanceLabel != '' and productInstanceLabel != tag.getProductInstanceLabel ():
-                            continue
-                        if processName != '' and processName != tag.getProcessName ():
-                            continue
-                        inputTags[collectionType] = tag
-                        foundPreferredTag = True
-                        break
-            if foundPreferredTag:
-                continue
-    
-            # If we still don't have anything, take whatever is available for this class
-            inputTags[collectionType] = availableTags[0]
+            thisTag = inputTags.pop (cppTypes[i])
+            if "OSUAnalysis" in thisTag.getProcessName ():
+                inputTags[collectionType] = thisTag
 
     if os.path.exists("SkimInputTags.pkl"):
         os.remove("SkimInputTags.pkl")

--- a/Configuration/python/mergeUtilities.py
+++ b/Configuration/python/mergeUtilities.py
@@ -218,14 +218,15 @@ def GetSkimInputTags(File):
             inputTags.pop (cppTypes[i])
         else:
             # There may be multiple instances of the same cpp type, for example we now store both the skimmed/selected framework objects
-	        # and the original (mini)AOD collections for a full skim. Another example is that slimmedJetsAK8PFPuppiSoftDropPacked and 
-	        # slimmedJets exist in miniAOD and are of type pat::Jet.
-	        # There is a clear hierarchy of what to use as in input: OSUAnalysis types > (mini)AOD types used in CollectionProducer_cff > (mini)AOD types > anything
-	        availableTags = inputTags.pop (cppTypes[i])
+            # and the original (mini)AOD collections for a full skim. Another example is that slimmedJetsAK8PFPuppiSoftDropPacked and 
+            # slimmedJets exist in miniAOD and are of type pat::Jet.
+            # There is a clear hierarchy of what to use as in input: OSUAnalysis types > (mini)AOD types used in CollectionProducer_cff > (mini)AOD types > anything
+            availableTags = inputTags.pop (cppTypes[i])
 
-	        # If there's nothing of this type available, we're in trouble
-	        if len(availableTags) == 0:
+            # If there's nothing of this type available, we're in trouble
+            if len(availableTags) == 0:
                 print "The collection \"" + collectionType + "\" has C++ class \"" + cppTypes[i]  + "\" and is expected in this skim file, yet no object of this C++ class is found. Something has broken, and no SkimInputTags.pkl can be created!"
+                return
 
             # If there's only one of this type available, take it
             if len(availableTags) == 1:
@@ -235,31 +236,31 @@ def GetSkimInputTags(File):
             # If there's something with process name OSUAnalysis, take that
             foundPreferredTag = False
             for tag in availableTags:
-            if "OSUAnalysis" in tag.getProcessName ():
-                inputTags[collectionType] = tag
-                foundPreferredTag = True
-                break
-	       if foundPreferredTag:
-               continue
+                if "OSUAnalysis" in tag.getProcessName ():
+                    inputTags[collectionType] = tag
+                    foundPreferredTag = True
+                    break
+            if foundPreferredTag:
+                continue
     
-	       # If there's no OSUAnalysis type available, take what's in osuAnalysis_cfi's collection map
-	       for tag in availableTags:
-               if hasattr (collectionMap, collectionType):
-                   if getattr (collectionMap, collectionType).getModuleLabel () == tag.getModuleLabel ():
-                       productInstanceLabel = getattr (collectionMap, collectionType).getProductInstanceLabel ()
-                       processName = getattr (collectionMap, collectionType).getProcessName ()
-                       if productInstanceLabel != '' and productInstanceLabel != tag.getProductInstanceLabel ():
-                           continue
-                       if processName != '' and processName != tag.getProcessName ():
-                           continue
-                       inputTags[collectionType] = tag
-                       foundPreferredTag = True
-                       break
-	       if foundPreferredTag:
-               continue
+            # If there's no OSUAnalysis type available, take what's in osuAnalysis_cfi's collection map
+            for tag in availableTags:
+                if hasattr (collectionMap, collectionType):
+                    if getattr (collectionMap, collectionType).getModuleLabel () == tag.getModuleLabel ():
+                        productInstanceLabel = getattr (collectionMap, collectionType).getProductInstanceLabel ()
+                        processName = getattr (collectionMap, collectionType).getProcessName ()
+                        if productInstanceLabel != '' and productInstanceLabel != tag.getProductInstanceLabel ():
+                            continue
+                        if processName != '' and processName != tag.getProcessName ():
+                            continue
+                        inputTags[collectionType] = tag
+                        foundPreferredTag = True
+                        break
+            if foundPreferredTag:
+                continue
     
-	       # If we still don't have anything, take whatever is available for this class
-	       inputTags[collectionType] = availableTags[0]
+            # If we still don't have anything, take whatever is available for this class
+            inputTags[collectionType] = availableTags[0]
 
     if os.path.exists("SkimInputTags.pkl"):
         os.remove("SkimInputTags.pkl")

--- a/Configuration/python/mergeUtilities.py
+++ b/Configuration/python/mergeUtilities.py
@@ -175,7 +175,7 @@ def MakeFilesForSkimDirectory(Directory, DirectoryOut, TotalNumber, SkimNumber, 
 ###############################################################################
 #           Produce a pickle file containing the skim input tags.             #
 ###############################################################################
-def GetSkimInputTags(File):
+def GetSkimInputTags(File, ignoreSkimmedCollections=False):
     print "Getting skim input tags..."
     eventContent = subprocess.check_output (["edmDumpEventContent", "--all", os.getcwd () + "/" + File])
     parsing = False
@@ -232,16 +232,17 @@ def GetSkimInputTags(File):
             if len(availableTags) == 1:
                 inputTags[collectionType] = availableTags[0]
                 continue
-    
-            # If there's something with process name OSUAnalysis, take that
-            foundPreferredTag = False
-            for tag in availableTags:
-                if "OSUAnalysis" in tag.getProcessName ():
-                    inputTags[collectionType] = tag
-                    foundPreferredTag = True
-                    break
-            if foundPreferredTag:
-                continue
+
+            if not ignoreSkimmedCollections:    
+                # If there's something with process name OSUAnalysis, take that
+                foundPreferredTag = False
+                for tag in availableTags:
+                    if "OSUAnalysis" in tag.getProcessName ():
+                        inputTags[collectionType] = tag
+                        foundPreferredTag = True
+                        break
+                if foundPreferredTag:
+                    continue
     
             # If there's no OSUAnalysis type available, take what's in osuAnalysis_cfi's collection map
             for tag in availableTags:

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -722,10 +722,16 @@ def add_channels (process, channels, histogramSets = None, weights = None, scali
                 # Don't add extra drop commands, we already have one at the beginning
                 if outputCommand != 'drop *':
                     outputCommands.append(outputCommand)
-            # Grody hack to keep extra collections in DisappTrks signal MC
+            # Grody hack to keep extra collections for specific analyses
             try:
                 from DisappTrks.CandidateTrackProducer.customize import disappTrksOutputCommands
                 outputCommands.extend(disappTrksOutputCommands)
+            except ImportError:
+                pass
+            try:
+                from StoppPtls.Collection.outputCommands import delayedMuonsOutputCommands, stoppedParticlesJetsOutputCommands
+                outputCommands.extend(delayedMuonsOutputCommands)
+                outputCommands.extend(stoppedParticlesJetsOutputCommands)
             except ImportError:
                 pass
         elif dataFormat.startswith ("AOD"):

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -188,7 +188,16 @@ def get_collections (cuts):
     ############################################################################
 
 #def add_channels (process, channels, histogramSets, weights, scalingfactorproducers, collections, variableProducers, skim = True, branchSets):
-def add_channels (process, channels, histogramSets = None, weights = None, scalingfactorproducers = None, collections = None, variableProducers = None, skim = None, branchSets = None):
+def add_channels (process, 
+                  channels, 
+                  histogramSets = None, 
+                  weights = None, 
+                  scalingfactorproducers = None, 
+                  collections = None, 
+                  variableProducers = None, 
+                  skim = None, 
+                  branchSets = None,
+                  ignoreSkimmedCollections = False):
     if skim is not None:
         print "# The \"skim\" parameter of add_channels is obsolete and will soon be deprecated."
         print "# Please remove from your config files."
@@ -241,18 +250,21 @@ def add_channels (process, channels, histogramSets = None, weights = None, scali
     if fileName.find ("file:") == 0:
         fileName = fileName[5:]
     skimDirectory = os.path.dirname (os.path.realpath (fileName))
-    if os.path.isfile (skimDirectory + "/SkimInputTags.pkl"):
-        fin = open (skimDirectory + "/SkimInputTags.pkl")
-        inputTags = pickle.load (fin)
-        fin.close ()
-        for tag in inputTags:
-            setattr (collections, tag, inputTags[tag])
+    if not ignoreSkimmedCollections:
+        if os.path.isfile (skimDirectory + "/SkimInputTags.pkl"):
+            fin = open (skimDirectory + "/SkimInputTags.pkl")
+            inputTags = pickle.load (fin)
+            fin.close ()
+            for tag in inputTags:
+                setattr (collections, tag, inputTags[tag])
+        else:
+            if rootFile.find("skim_") == 0:
+                print "ERROR:  The input file appears to be a skim file but no SkimInputTags.pkl file found."
+                print "Input file is", fileName
+                print "Be sure that you have run mergeOut.py."
+                sys.exit(1)
     else:
-        if rootFile.find("skim_") == 0:
-            print "ERROR:  The input file appears to be a skim file but no SkimInputTags.pkl file found."
-            print "Input file is", fileName
-            print "Be sure that you have run mergeOut.py."
-            sys.exit(1)
+        print "INFO: user has set ignoreSkimmedCollections, meaning that the original data collections will be used instead of skimmed framework collections."
 
     ############################################################################
 

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -764,7 +764,6 @@ def add_channels (process, channels, histogramSets = None, weights = None, scali
     # If MINIAOD is being used, and the egmGsfElectronIDSequence step hasn't
     # yet been added, add it here.
     ########################################################################
-#    from OSUT3Analysis.AnaTools.osuAnalysis_cfi import dataFormat
     if dataFormat.startswith ("MINI_AOD") and not hasattr (process, "egmGsfElectronIDSequence_step"):
         process = customizeMINIAODElectronVID(process, collections)
 

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -722,6 +722,12 @@ def add_channels (process, channels, histogramSets = None, weights = None, scali
                 # Don't add extra drop commands, we already have one at the beginning
                 if outputCommand != 'drop *':
                     outputCommands.append(outputCommand)
+            # Grody hack to keep extra collections in DisappTrks signal MC
+            try:
+                from DisappTrks.CandidateTrackProducer.customize import disappTrksOutputCommands
+                outputCommands.extend(disappTrksOutputCommands)
+            except ImportError:
+                pass
         elif dataFormat.startswith ("AOD"):
             from Configuration.EventContent.EventContent_cff import AODSIMEventContent
             for outputCommand in AODSIMEventContent.outputCommands:

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -714,12 +714,28 @@ def add_channels (process, channels, histogramSets = None, weights = None, scali
         if cutCollections:
             SelectEvents = cms.vstring (channelName)
         skimFilePrefix = "skim"
+
+        from OSUT3Analysis.AnaTools.osuAnalysis_cfi import dataFormat
+        if dataFormat.startswith ("MINI_AOD"):
+            from Configuration.EventContent.EventContent_cff import MINIAODSIMEventContent
+            for outputCommand in MINIAODSIMEventContent.outputCommands:
+                # Don't add extra drop commands, we already have one at the beginning
+                if outputCommand != 'drop *':
+                    outputCommands.append(outputCommand)
+        elif dataFormat.startswith ("AOD"):
+            from Configuration.EventContent.EventContent_cff import AODSIMEventContent
+            for outputCommand in AODSIMEventContent.outputCommands:
+                # Don't add extra drop commands, we already have one at the beginning
+                if outputCommand != 'drop *':
+                    outputCommands.append(outputCommand)
+
         # if running over a full skim, do not recreate a full skim for passing
         # events, but rather create an empty skim (no event content, just
         # metadata)
         if makeEmptySkim:
             skimFilePrefix = "emptySkim"
             outputCommands.append ("drop *")
+
         poolOutputModule = cms.OutputModule ("PoolOutputModule",
             overrideInputFileSplitLevels = cms.untracked.bool (True),
             splitLevel = cms.untracked.int32 (0),
@@ -742,7 +758,7 @@ def add_channels (process, channels, histogramSets = None, weights = None, scali
     # If MINIAOD is being used, and the egmGsfElectronIDSequence step hasn't
     # yet been added, add it here.
     ########################################################################
-    from OSUT3Analysis.AnaTools.osuAnalysis_cfi import dataFormat
+#    from OSUT3Analysis.AnaTools.osuAnalysis_cfi import dataFormat
     if dataFormat.startswith ("MINI_AOD") and not hasattr (process, "egmGsfElectronIDSequence_step"):
         process = customizeMINIAODElectronVID(process, collections)
 

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -734,24 +734,16 @@ def add_channels (process,
                 # Don't add extra drop commands, we already have one at the beginning
                 if outputCommand != 'drop *':
                     outputCommands.append(outputCommand)
-            # Grody hack to keep extra collections for specific analyses
-            try:
-                from DisappTrks.CandidateTrackProducer.customize import disappTrksOutputCommands
-                outputCommands.extend(disappTrksOutputCommands)
-            except ImportError:
-                pass
-            try:
-                from StoppPtls.Collection.outputCommands import delayedMuonsOutputCommands, stoppedParticlesJetsOutputCommands
-                outputCommands.extend(delayedMuonsOutputCommands)
-                outputCommands.extend(stoppedParticlesJetsOutputCommands)
-            except ImportError:
-                pass
         elif dataFormat.startswith ("AOD"):
             from Configuration.EventContent.EventContent_cff import AODSIMEventContent
             for outputCommand in AODSIMEventContent.outputCommands:
                 # Don't add extra drop commands, we already have one at the beginning
                 if outputCommand != 'drop *':
                     outputCommands.append(outputCommand)
+
+        if not hasattr (add_channels, "customOutputCommands"):
+            add_channels.customOutputCommands = []
+        outputCommands.extend (add_channels.customOutputCommands)
 
         # if running over a full skim, do not recreate a full skim for passing
         # events, but rather create an empty skim (no event content, just

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -742,6 +742,7 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
                     f = "root://cmsxrootd.fnal.gov/" + f
                 text += '"' + f + '",\n'
             text += ']\n'
+        text += 'listOfSecondaryFiles = []\n'
         text += 'crossSection = ' + str(crossSection) + '\n'
         fnew = open(datasetInfoName, "w")
         fnew.write(text)
@@ -781,6 +782,7 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
                     f = "root://cmsxrootd.fnal.gov/" + f
                 text += '"' + f + '",\n'
             text += ']\n'
+        text += 'listOfSecondaryFiles = []\n'
         text += 'crossSection = ' + str(crossSection) + '\n'
         fnew = open(datasetInfoName, "w")
         fnew.write(text)


### PR DESCRIPTION
Write an empty listOfSecondaryFiles for these cases. Used in MC production when there are no secondary inputs from skims.