### PR TITLE
Fix osusub.py for UserDir and UserList modes

### DIFF
--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -742,6 +742,7 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
                     f = "root://cmsxrootd.fnal.gov/" + f
                 text += '"' + f + '",\n'
             text += ']\n'
+        text += 'listOfSecondaryFiles = []\n'
         text += 'crossSection = ' + str(crossSection) + '\n'
         fnew = open(datasetInfoName, "w")
         fnew.write(text)
@@ -781,6 +782,7 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
                     f = "root://cmsxrootd.fnal.gov/" + f
                 text += '"' + f + '",\n'
             text += ']\n'
+        text += 'listOfSecondaryFiles = []\n'
         text += 'crossSection = ' + str(crossSection) + '\n'
         fnew = open(datasetInfoName, "w")
         fnew.write(text)


### PR DESCRIPTION
Write an empty listOfSecondaryFiles for these modes. They are used in
signal MC generation where there are no secondary files.

PR try 2 after a rebase.