### PR TITLE
ele VID fixes for DisappTrk track methods

### DIFF
--- a/Collections/interface/Track.h
+++ b/Collections/interface/Track.h
@@ -3,6 +3,7 @@
 
 #include <random>
 #include <chrono>
+#include <assert.h>
 
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
@@ -247,6 +248,9 @@ namespace osu
         double dRToMatchedCandidateTrack_;
 
         double maxDeltaR_candidateTrackMatching_;
+
+        vector<double> eleVtx_d0Cuts_barrel_, eleVtx_d0Cuts_endcap_;
+        vector<double> eleVtx_dzCuts_barrel_, eleVtx_dzCuts_endcap_;
 
         float deltaRToClosestElectron_;
         float deltaRToClosestVetoElectron_;

--- a/Collections/interface/Track.h
+++ b/Collections/interface/Track.h
@@ -107,9 +107,10 @@ namespace osu
         const edm::Ref<vector<CandidateTrack> > matchedCandidateTrack () const { return matchedCandidateTrack_; };
         const double dRToMatchedCandidateTrack () const { return (IS_INVALID(dRToMatchedCandidateTrack_)) ? MAX_DR : dRToMatchedCandidateTrack_; };
 
-        void set_minDeltaRToElectrons(const edm::Handle<edm::View<TYPE(electrons)> > &, 
-                                      const edm::Handle<edm::ValueMap<bool> > &, 
-                                      const edm::Handle<edm::ValueMap<bool> > &, 
+        void set_minDeltaRToElectrons(const edm::Handle<edm::View<TYPE(electrons)> > &,
+                                      const edm::Handle<vector<TYPE(primaryvertexs)> > &,
+                                      const edm::Handle<edm::ValueMap<bool> > &,
+                                      const edm::Handle<edm::ValueMap<bool> > &,
                                       const edm::Handle<edm::ValueMap<bool> > &,
                                       const edm::Handle<edm::ValueMap<bool> > &);
         void set_minDeltaRToMuons(const edm::Handle<vector<TYPE(muons)> > &, const edm::Handle<vector<TYPE(primaryvertexs)> > &);

--- a/Collections/plugins/OSUGenericTrackProducer.cc
+++ b/Collections/plugins/OSUGenericTrackProducer.cc
@@ -276,7 +276,7 @@ OSUGenericTrackProducer<T>::produce (edm::Event &event, const edm::EventSetup &s
         }
 #endif // DATA_FORMAT_IS_CUSTOM
 
-        track.set_minDeltaRToElectrons(electrons, eleVIDVetoIdMap, eleVIDLooseIdMap, eleVIDMediumIdMap, eleVIDTightIdMap);
+        track.set_minDeltaRToElectrons(electrons, vertices, eleVIDVetoIdMap, eleVIDLooseIdMap, eleVIDMediumIdMap, eleVIDTightIdMap);
         track.set_minDeltaRToMuons(muons, vertices);
         track.set_minDeltaRToTaus(taus);
 

--- a/Collections/src/Track.cc
+++ b/Collections/src/Track.cc
@@ -331,7 +331,7 @@ osu::Track::set_minDeltaRToElectrons (const edm::Handle<edm::View<TYPE(electrons
     // Note in below, these remain false if |eta| >= 2.5; thus an eta cut is also being applied here as intended
 #if CMSSW_VERSION_CODE < CMSSW_VERSION(9,4,0)
     // https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2Archive#Spring15_selection_25ns
-    if(fabs(electron.superCluster ()->eta()) <= 1.479) {
+    if(fabs(ele.superCluster ()->eta()) <= 1.479) {
       passesVeto_dxy = (fabs(ele.gsfTrack()->dxy(vertices->at(0).position())) < 0.0564);
       passesVeto_dz  = (fabs(ele.gsfTrack()->dz(vertices->at(0).position()))  < 0.472);
 
@@ -344,7 +344,7 @@ osu::Track::set_minDeltaRToElectrons (const edm::Handle<edm::View<TYPE(electrons
       passesTight_dxy = (fabs(ele.gsfTrack()->dxy(vertices->at(0).position())) < 0.0111);
       passesTight_dz  = (fabs(ele.gsfTrack()->dz(vertices->at(0).position()))  < 0.0466);
     }
-    else if(fabs(electron.superCluster()->eta()) < 2.5) {
+    else if(fabs(ele.superCluster()->eta()) < 2.5) {
       passesVeto_dxy = (fabs(ele.gsfTrack()->dxy(vertices->at(0).position())) < 0.222);
       passesVeto_dz  = (fabs(ele.gsfTrack()->dz(vertices->at(0).position()))  < 0.921);
 
@@ -359,11 +359,11 @@ osu::Track::set_minDeltaRToElectrons (const edm::Handle<edm::View<TYPE(electrons
     }
 #else
     // https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Working_points_for_92X_and_later
-    if(fabs(electron.superCluster ()->eta()) <= 1.479) {
+    if(fabs(ele.superCluster ()->eta()) <= 1.479) {
       passesVeto_dxy = passesLoose_dxy = passesMedium_dxy = passesTight_dxy = (fabs(ele.gsfTrack()->dxy(vertices->at(0).position())) < 0.05);
       passesVeto_dz  = passesLoose_dz  = passesMedium_dz  = passesTight_dz  = (fabs(ele.gsfTrack()->dz(vertices->at(0).position()))  < 0.10);
     }
-    else if(fabs(electron.superCluster()->eta()) < 2.5) {
+    else if(fabs(ele.superCluster()->eta()) < 2.5) {
       passesVeto_dxy = passesLoose_dxy = passesMedium_dxy = passesTight_dxy = (fabs(ele.gsfTrack()->dxy(vertices->at(0).position())) < 0.10);
       passesVeto_dz  = passesLoose_dz  = passesMedium_dz  = passesTight_dz  = (fabs(ele.gsfTrack()->dz(vertices->at(0).position()))  < 0.20);
       }

--- a/Collections/src/Track.cc
+++ b/Collections/src/Track.cc
@@ -230,12 +230,13 @@ osu::Track::Track (const TYPE(tracks) &track,
                    const map<DetId, vector<int> > * const EcalAllDeadChannelsBitMap,
                    const bool dropHits,
                    const edm::Handle<vector<CandidateTrack> > &candidateTracks) :
-  Track(track, particles, pfCandidates, jets, cfg, gsfTracks, electronVetoList, muonVetoList, EcalAllDeadChannelsValMap, EcalAllDeadChannelsBitMap, dropHits),
-  eleVtx_d0Cuts_barrel_(cfg.getParameter<vector<double> > ("eleVtx_d0Cuts_barrel")),
-  eleVtx_dzCuts_barrel_(cfg.getParameter<vector<double> > ("eleVtx_dzCuts_barrel")),
-  eleVtx_d0Cuts_endcap_(cfg.getParameter<vector<double> > ("eleVtx_d0Cuts_endcap")),
-  eleVtx_dzCuts_endcap_(cfg.getParameter<vector<double> > ("eleVtx_dzCuts_endcap"))
+  Track(track, particles, pfCandidates, jets, cfg, gsfTracks, electronVetoList, muonVetoList, EcalAllDeadChannelsValMap, EcalAllDeadChannelsBitMap, dropHits)
 {
+  eleVtx_d0Cuts_barrel_ = cfg.getParameter<vector<double> > ("eleVtx_d0Cuts_barrel");
+  eleVtx_dzCuts_barrel_ = cfg.getParameter<vector<double> > ("eleVtx_dzCuts_barrel");
+  eleVtx_d0Cuts_endcap_ = cfg.getParameter<vector<double> > ("eleVtx_d0Cuts_endcap");
+  eleVtx_dzCuts_endcap_ = cfg.getParameter<vector<double> > ("eleVtx_dzCuts_endcap");
+
   assert(eleVtx_d0Cuts_barrel_.size() == 4);
   assert(eleVtx_dzCuts_barrel_.size() == 4);
   assert(eleVtx_d0Cuts_endcap_.size() == 4);
@@ -253,10 +254,10 @@ osu::Track::Track (const TYPE(tracks) &track,
 osu::Track::~Track ()
 {
 #ifdef DISAPP_TRKS
-  eleVtx_dxy_barrel_.clear();
-  eleVtx_dxy_endcap_.clear();
-  eleVtx_dz_barrel_.clear();
-  eleVtx_dz_endcap_.clear();
+  eleVtx_d0Cuts_barrel_.clear();
+  eleVtx_dzCuts_barrel_.clear();
+  eleVtx_d0Cuts_endcap_.clear();
+  eleVtx_dzCuts_endcap_.clear();
 #endif
 }
 

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -228,18 +228,34 @@ collectionProducer.tracks = cms.EDProducer ("OSUTrackProducer",
     originalMuons     = cms.InputTag ("slimmedMuons"),
     originalTaus      = cms.InputTag ("slimmedTaus"),
 
-    eleVIDVetoIdMap = collectionProducer.electrons.vidVetoIdMap,
-    eleVIDLooseIdMap = collectionProducer.electrons.vidLooseIdMap,
+    eleVIDVetoIdMap   = collectionProducer.electrons.vidVetoIdMap,
+    eleVIDLooseIdMap  = collectionProducer.electrons.vidLooseIdMap,
     eleVIDMediumIdMap = collectionProducer.electrons.vidMediumIdMap,
-    eleVIDTightIdMap = collectionProducer.electrons.vidTightIdMap,
+    eleVIDTightIdMap  = collectionProducer.electrons.vidTightIdMap,
+
+    # https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2Archive#Spring15_selection_25ns
+    eleVtx_d0Cuts_barrel = cms.vdouble(0.0564, 0.0261, 0.0118, 0.0111),
+    eleVtx_dzCuts_barrel = cms.vdouble(0.472, 0.41, 0.373, 0.0466),
+    eleVtx_d0Cuts_endcap = cms.vdouble(0.222, 0.118, 0.0739, 0.0351),
+    eleVtx_dzCuts_endcap = cms.vdouble(0.921, 0.822, 0.602, 0.417),
 )
+
 if osusub.batchMode and types[osusub.datasetLabel] == "data":
-    if "Run2016" in osusub.dataset or "Run2017" in osusub.dataset:
+    if "Run2016" in osusub.dataset:
         collectionProducer.tracks.fiducialMaps.electrons[0].histFile = cms.FileInPath ("OSUT3Analysis/Configuration/data/electronFiducialMap_2016_data.root")
         collectionProducer.tracks.fiducialMaps.muons[0].histFile = cms.FileInPath ("OSUT3Analysis/Configuration/data/muonFiducialMap_2016_data.root")
+    elif "Run2017" in osusub.dataset:
+        collectionProducer.tracks.fiducialMaps.electrons[0].histFile = cms.FileInPath ("OSUT3Analysis/Configuration/data/electronFiducialMap_2017_data.root")
+        collectionProducer.tracks.fiducialMaps.muons[0].histFile = cms.FileInPath ("OSUT3Analysis/Configuration/data/muonFiducialMap_2017_data.root")
     else:
         collectionProducer.tracks.fiducialMaps.electrons[0].histFile = cms.FileInPath ("OSUT3Analysis/Configuration/data/electronFiducialMap_2015_data.root")
         collectionProducer.tracks.fiducialMaps.muons[0].histFile = cms.FileInPath ("OSUT3Analysis/Configuration/data/muonFiducialMap_2015_data.root")
+if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4"):
+    # https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Working_points_for_92X_and_later
+    eleVtx_d0Cuts_barrel = cms.vdouble(0.05, 0.05, 0.05, 0.05)
+    eleVtx_dzCuts_barrel = cms.vdouble(0.10, 0.10, 0.10, 0.10)
+    eleVtx_d0Cuts_endcap = cms.vdouble(0.10, 0.10, 0.10, 0.10)
+    eleVtx_dzCuts_endcap = cms.vdouble(0.20, 0.20, 0.20, 0.20)
 
 copyConfiguration (collectionProducer.tracks, collectionProducer.genMatchables)
 #-------------------------------------------------------------------------------

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -233,6 +233,7 @@ collectionProducer.tracks = cms.EDProducer ("OSUTrackProducer",
     eleVIDMediumIdMap = collectionProducer.electrons.vidMediumIdMap,
     eleVIDTightIdMap  = collectionProducer.electrons.vidTightIdMap,
 
+    # Cut values are ordered by ID, as: veto, loose, medium, tight
     # https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2Archive#Spring15_selection_25ns
     eleVtx_d0Cuts_barrel = cms.vdouble(0.0564, 0.0261, 0.0118, 0.0111),
     eleVtx_dzCuts_barrel = cms.vdouble(0.472, 0.41, 0.373, 0.0466),
@@ -250,12 +251,13 @@ if osusub.batchMode and types[osusub.datasetLabel] == "data":
     else:
         collectionProducer.tracks.fiducialMaps.electrons[0].histFile = cms.FileInPath ("OSUT3Analysis/Configuration/data/electronFiducialMap_2015_data.root")
         collectionProducer.tracks.fiducialMaps.muons[0].histFile = cms.FileInPath ("OSUT3Analysis/Configuration/data/muonFiducialMap_2015_data.root")
-if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4"):
+if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
+    # Cut values are ordered by ID, as: veto, loose, medium, tight
     # https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Working_points_for_92X_and_later
-    eleVtx_d0Cuts_barrel = cms.vdouble(0.05, 0.05, 0.05, 0.05)
-    eleVtx_dzCuts_barrel = cms.vdouble(0.10, 0.10, 0.10, 0.10)
-    eleVtx_d0Cuts_endcap = cms.vdouble(0.10, 0.10, 0.10, 0.10)
-    eleVtx_dzCuts_endcap = cms.vdouble(0.20, 0.20, 0.20, 0.20)
+    collectionProducer.tracks.eleVtx_d0Cuts_barrel = cms.vdouble(0.05, 0.05, 0.05, 0.05)
+    collectionProducer.tracks.eleVtx_dzCuts_barrel = cms.vdouble(0.10, 0.10, 0.10, 0.10)
+    collectionProducer.tracks.eleVtx_d0Cuts_endcap = cms.vdouble(0.10, 0.10, 0.10, 0.10)
+    collectionProducer.tracks.eleVtx_dzCuts_endcap = cms.vdouble(0.20, 0.20, 0.20, 0.20)
 
 copyConfiguration (collectionProducer.tracks, collectionProducer.genMatchables)
 #-------------------------------------------------------------------------------

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -907,15 +907,15 @@ def customizeMINIAODElectronVID(process, collections, usedCollections):
     # In the case where tracks are being used in a skim where electron cuts are applied, 
     # there's now two different electron collections of interest. We need to duplicate
     # the VID producer for the original collection
-    if 'tracks' in usedCollections and collections.electrons.getProcessName().startswith('OSUAnalsysis'):
+    if 'tracks' in usedCollections and collections.electrons.getProcessName().startswith('OSUAnalysis'):
         setattr(process, 'egmGsfElectronIDsOriginalElectrons', copy.deepcopy(getattr(process, 'egmGsfElectronIDs')))
         process.egmGsfElectronIDTaskOriginalElectrons = cms.Task(process.egmGsfElectronIDsOriginalElectrons)
         process.egmGsfElectronIDSequenceOriginalElectrons = cms.Sequence(process.egmGsfElectronIDTaskOriginalElectrons)
         process.egmGsfElectronIDSequenceOriginalElectrons_step = cms.Path(process.egmGsfElectronIDSequenceOriginalElectrons)
         process.schedule.insert(0, process.egmGsfElectronIDSequenceOriginalElectrons_step)
 
-    # Change the InputTags for the track producers to use these duplicated VID results
-    for a in dir(process):
+        # Change the InputTags for the track producers to use these duplicated VID results
+        for a in dir(process):
             x = getattr(process, a)
             if not hasattr(x, "type_"):
                 continue


### PR DESCRIPTION
Remove MVA and HEEP ID VIDs for electrons
Fix specific case for DisappTrks with electrons + tracks
Require vertexing for DisappTrks track::deltaRToClosest*Electron methods