### PR TITLE
Change environment var name for CMSSW_10_

### DIFF
--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -447,7 +447,10 @@ def MakeCondorSubmitScript(Dataset,NumberOfJobs,Directory,Label, SkimChannelName
     SubmitScript.write ("eval `scramv1 runtime -sh`\n")
     SubmitScript.write ("cd -\n\n")
 
-    SubmitScript.write ("PYTHONPATH=$PYTHONPATH:./" + os.environ["CMSSW_VERSION"] + "/python:.\n\n")
+    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_"):
+        SubmitScript.write ("PYTHON27PATH=$PYTHON27PATH:./" + os.environ["CMSSW_VERSION"] + "/python:.\n\n")
+    else:
+        SubmitScript.write ("PYTHONPATH=$PYTHONPATH:./" + os.environ["CMSSW_VERSION"] + "/python:.\n\n")
 
     SubmitScript.write ("(>&2 echo \"Arguments passed to this script are: $@\")\n")
     SubmitScript.write (cmsRunExecutable + " $@\n")


### PR DESCRIPTION
Tested with CMSSW_10_2_1 on 2018 data. Without this, condor jobs fail immediately before any events are processed with:

```
----- Begin Fatal Exception 09-Aug-2018 12:43:02 EDT-----------------------
An exception of category 'ConfigFileReadError' occurred while
   [0] Processing the python configuration file named config_cfg.py
Exception Message:
python encountered the error: <type 'exceptions.ImportError'>
No module named datasetInfo_SingleMu_2018B_cfg
----- End Fatal Exception -------------------------------------------------
```

Despite that module being right there on disk. CMSSW 10 now separates PYTHONPATH into 2.7 and 3 versions. Changing this name makes condor jobs run in 10.