### PR TITLE
Produce error if PUScaleFactorProducer denominator histogram is empty

### DIFF
--- a/AnaTools/plugins/PUScalingFactorProducer.cc
+++ b/AnaTools/plugins/PUScalingFactorProducer.cc
@@ -46,7 +46,7 @@ PUScalingFactorProducer::AddVariables (const edm::Event &event) {
           edm::LogError ("PUScalingFactorProducer") << "ERROR [PUScalingFactorProducer]: Could not find histogram: " << dataset_ << "; will cause a seg fault." << endl;
           exit(1);
         }
-        if (mc->Integral() == 0.0) {
+        if (mc->GetEntries() == 0.0) {
           edm::LogError ("PUScalingFactorProducer") << "ERROR [PUScalingFactorProducer]: Histogram " << dataset_ << " is empty and will result in infinite scale factors." << endl;
           exit(1);
         }

--- a/AnaTools/plugins/PUScalingFactorProducer.cc
+++ b/AnaTools/plugins/PUScalingFactorProducer.cc
@@ -46,6 +46,10 @@ PUScalingFactorProducer::AddVariables (const edm::Event &event) {
           edm::LogError ("PUScalingFactorProducer") << "ERROR [PUScalingFactorProducer]: Could not find histogram: " << dataset_ << "; will cause a seg fault." << endl;
           exit(1);
         }
+        if (mc->Integral() == 0.0) {
+          edm::LogError ("PUScalingFactorProducer") << "ERROR [PUScalingFactorProducer]: Histogram " << dataset_ << " is empty and will result in infinite scale factors." << endl;
+          exit(1);
+        }
         if (!puWeight_) {
           edm::LogError ("PUScalingFactorProducer") << "ERROR [PUScalingFactorProducer]: Could not find histogram: " << target_ <<", will cause a seg fault." << endl;
           exit(1);


### PR DESCRIPTION
Tested interactively with empty and non-empty MC PU histograms. Behavior is unchanged with non-empty histograms and cmsRun exits with expected error for empty histograms.