### PR TITLE
Fix compile error in TrackBase for 80X

### DIFF
--- a/Collections/interface/TrackBase.h
+++ b/Collections/interface/TrackBase.h
@@ -283,6 +283,7 @@ namespace osu {
 #endif // IS_VALID(secondaryTracks)
 #else
   typedef TYPE(tracks) Track;
+  typedef TYPE(secondaryTracks) SecondaryTrack;
 #endif // IS_VALID(tracks)
 }
 #endif // ifndef DISAPP_TRKS


### PR DESCRIPTION
If TYPE(tracks) is invalid, you would skip over the typedef of Secondary tracks. It's needed to explicitly do that in this case.