### PR TITLE
Produce d0 smearing value in OSUElectronProducer

### DIFF
--- a/Collections/interface/Electron.h
+++ b/Collections/interface/Electron.h
@@ -24,7 +24,8 @@ namespace osu
         const double sumChargedHadronPtCorr () const;
         const double sumPUPtCorr () const;
         const int electronPVIndex () const;
-	const double genD0 () const;
+        const double genD0 () const;
+        const double d0SmearingVal () const;
         const float dEtaInSeed () const;
         const bool pass_GsfEleHadronicOverEMEnergyScaledCut (const float c0, const float cE, const float cR) const;
 
@@ -52,6 +53,7 @@ namespace osu
         void set_sumPUPtCorr (double value) { sumPUPtCorr_  = value; };
         void set_electronPVIndex (int value) { electronPVIndex_  = value; };
         void set_genD0 (double value) { genD0_  = value; };
+        void set_d0SmearingVal (double value) { d0SmearingVal_  = value; };
         void set_passesTightID_noIsolation (const reco::BeamSpot &, const TYPE(primaryvertexs) &, const edm::Handle<vector<reco::Conversion> > &);
         void set_passesVID_vetoID (const bool);
         void set_passesVID_looseID (const bool);
@@ -99,7 +101,8 @@ namespace osu
         double sumChargedHadronPtCorr_;
         int electronPVIndex_;
         double sumPUPtCorr_;
-	double genD0_;
+        double genD0_;
+        double d0SmearingVal_;
         bool passesTightID_noIsolation_;
 
         bool passesVID_vetoID_;

--- a/Collections/interface/Muon.h
+++ b/Collections/interface/Muon.h
@@ -23,14 +23,16 @@ namespace osu
         const double sumChargedHadronPtCorr () const;
         const double sumPUPtCorr () const;
         const int muonPVIndex () const;
-	const double genD0 () const;
+        const double genD0 () const;
+        const double d0SmearingVal () const;
         const bool isTightMuonWRTVtx() const { return isTightMuonWRTVtx_; }
         void set_isTightMuonWRTVtx(const bool isTightMuon);
         void set_pfdBetaIsoCorr (double value) { pfdBetaIsoCorr_  = value; };
         void set_sumChargedHadronPtCorr (double value) { sumChargedHadronPtCorr_  = value; };
         void set_sumPUPtCorr (double value) { sumPUPtCorr_  = value; };
         void set_muonPVIndex (int value) { muonPVIndex_  = value; };
-	void set_genD0 (double value) { genD0_  = value; };
+        void set_genD0 (double value) { genD0_  = value; };
+        void set_d0SmearingVal (double value) { d0SmearingVal_  = value; };
 
 	void set_match_HLT_IsoMu27_v (const bool);
         void set_match_HLT_IsoMu24_v (const bool);
@@ -64,7 +66,8 @@ namespace osu
         double sumChargedHadronPtCorr_;
         int muonPVIndex_;
         double sumPUPtCorr_;
-	double genD0_;
+        double genD0_;
+        double d0SmearingVal_;
 
         double metMinusOnePt_;
         double metMinusOnePx_;

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -147,7 +147,10 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	}
 
       // produce random d0 value to use in d0 smearing
-      double d0SmearingVal = random->Gaus(0, 0.00142); // todo: remove magic number
+      double d0SmearingVal = 0.0;
+      if (!event.isRealData()) {
+        d0SmearingVal = random->Gaus(0, 0.00142); // todo: remove magic number
+      }
       electron.set_d0SmearingVal(d0SmearingVal);
 
       double pfdRhoIsoCorr = 0;

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -152,7 +152,7 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 
       // produce random d0 value to use in d0 smearing
       double d0SmearingVal = 0.0;
-      if (!event.isRealData()) {
+      if (!event.isRealData() && d0SmearingWidth_ != 0.0) {
         d0SmearingVal = rng->Gaus(0, d0SmearingWidth_);
       }
       electron.set_d0SmearingVal(d0SmearingVal);

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -5,16 +5,17 @@
 #include "OSUT3Analysis/AnaTools/interface/CommonUtils.h"
 
 OSUElectronProducer::OSUElectronProducer (const edm::ParameterSet &cfg) :
-  collections_    (cfg.getParameter<edm::ParameterSet> ("collections")),
-  cfg_            (cfg),
-  pfCandidate_    (cfg.getParameter<edm::InputTag>     ("pfCandidate")),
-  conversions_    (cfg.getParameter<edm::InputTag>     ("conversions")),
-  rho_            (cfg.getParameter<edm::InputTag>     ("rho")),
-  vidVetoIdMap_   (cfg.getParameter<edm::InputTag>     ("vidVetoIdMap")),
-  vidLooseIdMap_  (cfg.getParameter<edm::InputTag>     ("vidLooseIdMap")),
-  vidMediumIdMap_ (cfg.getParameter<edm::InputTag>     ("vidMediumIdMap")),
-  vidTightIdMap_  (cfg.getParameter<edm::InputTag>     ("vidTightIdMap")),
-  effectiveAreas_ ((cfg.getParameter<edm::FileInPath>  ("effAreasPayload")).fullPath())
+  collections_     (cfg.getParameter<edm::ParameterSet> ("collections")),
+  cfg_             (cfg),
+  pfCandidate_     (cfg.getParameter<edm::InputTag>     ("pfCandidate")),
+  conversions_     (cfg.getParameter<edm::InputTag>     ("conversions")),
+  rho_             (cfg.getParameter<edm::InputTag>     ("rho")),
+  vidVetoIdMap_    (cfg.getParameter<edm::InputTag>     ("vidVetoIdMap")),
+  vidLooseIdMap_   (cfg.getParameter<edm::InputTag>     ("vidLooseIdMap")),
+  vidMediumIdMap_  (cfg.getParameter<edm::InputTag>     ("vidMediumIdMap")),
+  vidTightIdMap_   (cfg.getParameter<edm::InputTag>     ("vidTightIdMap")),
+  effectiveAreas_  ((cfg.getParameter<edm::FileInPath>  ("effAreasPayload")).fullPath()),
+  d0SmearingWidth_ (cfg.getParameter<double>            ("d0SmearingWidth"))
 {
   collection_ = collections_.getParameter<edm::InputTag> ("electrons");
   produces<vector<osu::Electron> > (collection_.instance ());
@@ -149,7 +150,7 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
       // produce random d0 value to use in d0 smearing
       double d0SmearingVal = 0.0;
       if (!event.isRealData()) {
-        d0SmearingVal = random->Gaus(0, 0.00142); // todo: remove magic number
+        d0SmearingVal = random->Gaus(0, d0SmearingWidth_);
       }
       electron.set_d0SmearingVal(d0SmearingVal);
 

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -19,7 +19,9 @@ OSUElectronProducer::OSUElectronProducer (const edm::ParameterSet &cfg) :
 {
   collection_ = collections_.getParameter<edm::InputTag> ("electrons");
   produces<vector<osu::Electron> > (collection_.instance ());
-  random = new TRandom3();
+
+  // RNG for gaussian d0 smearing
+  rng = new TRandom3();
 
   token_ = consumes<edm::View<TYPE(electrons)> > (collection_);
   mcparticleToken_ = consumes<vector<osu::Mcparticle> > (collections_.getParameter<edm::InputTag> ("mcparticles"));
@@ -41,6 +43,7 @@ OSUElectronProducer::OSUElectronProducer (const edm::ParameterSet &cfg) :
 
 OSUElectronProducer::~OSUElectronProducer ()
 {
+  delete rng;
 }
 
 void
@@ -150,7 +153,7 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
       // produce random d0 value to use in d0 smearing
       double d0SmearingVal = 0.0;
       if (!event.isRealData()) {
-        d0SmearingVal = random->Gaus(0, d0SmearingWidth_);
+        d0SmearingVal = rng->Gaus(0, d0SmearingWidth_);
       }
       electron.set_d0SmearingVal(d0SmearingVal);
 

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -21,7 +21,7 @@ OSUElectronProducer::OSUElectronProducer (const edm::ParameterSet &cfg) :
   produces<vector<osu::Electron> > (collection_.instance ());
 
   // RNG for gaussian d0 smearing
-  rng = new TRandom3(0);
+  if (d0SmearingWidth_ >= 0) rng = new TRandom3(0);
 
   token_ = consumes<edm::View<TYPE(electrons)> > (collection_);
   mcparticleToken_ = consumes<vector<osu::Mcparticle> > (collections_.getParameter<edm::InputTag> ("mcparticles"));
@@ -43,7 +43,7 @@ OSUElectronProducer::OSUElectronProducer (const edm::ParameterSet &cfg) :
 
 OSUElectronProducer::~OSUElectronProducer ()
 {
-  delete rng;
+  if (rng) delete rng;
 }
 
 void

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -18,6 +18,7 @@ OSUElectronProducer::OSUElectronProducer (const edm::ParameterSet &cfg) :
 {
   collection_ = collections_.getParameter<edm::InputTag> ("electrons");
   produces<vector<osu::Electron> > (collection_.instance ());
+  random = new TRandom3();
 
   token_ = consumes<edm::View<TYPE(electrons)> > (collection_);
   mcparticleToken_ = consumes<vector<osu::Mcparticle> > (collections_.getParameter<edm::InputTag> ("mcparticles"));
@@ -144,6 +145,10 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	      electron.set_genD0(gen_d0);
 	    }
 	}
+
+      // produce random d0 value to use in d0 smearing
+      double d0SmearingVal = random->Gaus(0, 0.00142); // todo: remove magic number
+      electron.set_d0SmearingVal(d0SmearingVal);
 
       double pfdRhoIsoCorr = 0;
       double chargedHadronPt = 0;

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -152,7 +152,7 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 
       // produce random d0 value to use in d0 smearing
       double d0SmearingVal = 0.0;
-      if (!event.isRealData() && d0SmearingWidth_ != 0.0) {
+      if (!event.isRealData() && d0SmearingWidth_ >= 0) {
         d0SmearingVal = rng->Gaus(0, d0SmearingWidth_);
       }
       electron.set_d0SmearingVal(d0SmearingVal);

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -21,7 +21,7 @@ OSUElectronProducer::OSUElectronProducer (const edm::ParameterSet &cfg) :
   produces<vector<osu::Electron> > (collection_.instance ());
 
   // RNG for gaussian d0 smearing
-  rng = new TRandom3();
+  rng = new TRandom3(0);
 
   token_ = consumes<edm::View<TYPE(electrons)> > (collection_);
   mcparticleToken_ = consumes<vector<osu::Mcparticle> > (collections_.getParameter<edm::InputTag> ("mcparticles"));

--- a/Collections/plugins/OSUElectronProducer.h
+++ b/Collections/plugins/OSUElectronProducer.h
@@ -7,6 +7,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "OSUT3Analysis/Collections/interface/Electron.h"
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
+#include "TRandom3.h"
 
 class OSUElectronProducer : public edm::EDProducer
 {
@@ -48,6 +49,8 @@ class OSUElectronProducer : public edm::EDProducer
     edm::InputTag      vidMediumIdMap_;
     edm::InputTag      vidTightIdMap_;
     EffectiveAreas     effectiveAreas_;
+
+    TRandom3* random;
 
     ////////////////////////////////////////////////////////////////////////////
 

--- a/Collections/plugins/OSUElectronProducer.h
+++ b/Collections/plugins/OSUElectronProducer.h
@@ -49,6 +49,7 @@ class OSUElectronProducer : public edm::EDProducer
     edm::InputTag      vidMediumIdMap_;
     edm::InputTag      vidTightIdMap_;
     EffectiveAreas     effectiveAreas_;
+    double             d0SmearingWidth_;
 
     TRandom3* random;
 

--- a/Collections/plugins/OSUElectronProducer.h
+++ b/Collections/plugins/OSUElectronProducer.h
@@ -51,7 +51,7 @@ class OSUElectronProducer : public edm::EDProducer
     EffectiveAreas     effectiveAreas_;
     double             d0SmearingWidth_;
 
-    TRandom3* random;
+    TRandom3* rng;
 
     ////////////////////////////////////////////////////////////////////////////
 

--- a/Collections/plugins/OSUMuonProducer.cc
+++ b/Collections/plugins/OSUMuonProducer.cc
@@ -106,7 +106,7 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 
       // produce random d0 value to use in d0 smearing
       double d0SmearingVal = 0.0;
-      if (!event.isRealData() && d0SmearingWidth_ != 0.0) {
+      if (!event.isRealData() && d0SmearingWidth_ >= 0) {
         d0SmearingVal = rng->Gaus(0, d0SmearingWidth_);
       }
       muon.set_d0SmearingVal(d0SmearingVal);

--- a/Collections/plugins/OSUMuonProducer.cc
+++ b/Collections/plugins/OSUMuonProducer.cc
@@ -19,7 +19,7 @@ OSUMuonProducer::OSUMuonProducer (const edm::ParameterSet &cfg) :
   produces<vector<osu::Muon> > (collection_.instance ());
 
   // RNG for gaussian d0 smearing
-  rng = new TRandom3();
+  rng = new TRandom3(0);
 
   token_ = consumes<vector<TYPE(muons)> > (collection_);
   mcparticleToken_ = consumes<vector<osu::Mcparticle> > (collections_.getParameter<edm::InputTag> ("mcparticles"));

--- a/Collections/plugins/OSUMuonProducer.cc
+++ b/Collections/plugins/OSUMuonProducer.cc
@@ -19,7 +19,7 @@ OSUMuonProducer::OSUMuonProducer (const edm::ParameterSet &cfg) :
   produces<vector<osu::Muon> > (collection_.instance ());
 
   // RNG for gaussian d0 smearing
-  rng = new TRandom3(0);
+  if (d0SmearingWidth_ >= 0) rng = new TRandom3(0);
 
   token_ = consumes<vector<TYPE(muons)> > (collection_);
   mcparticleToken_ = consumes<vector<osu::Mcparticle> > (collections_.getParameter<edm::InputTag> ("mcparticles"));
@@ -34,7 +34,7 @@ OSUMuonProducer::OSUMuonProducer (const edm::ParameterSet &cfg) :
 
 OSUMuonProducer::~OSUMuonProducer ()
 {
-  delete rng;
+  if (rng) delete rng;
 }
 
 void

--- a/Collections/plugins/OSUMuonProducer.cc
+++ b/Collections/plugins/OSUMuonProducer.cc
@@ -106,7 +106,7 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 
       // produce random d0 value to use in d0 smearing
       double d0SmearingVal = 0.0;
-      if (!event.isRealData()) {
+      if (!event.isRealData() && d0SmearingWidth_ != 0.0) {
         d0SmearingVal = rng->Gaus(0, d0SmearingWidth_);
       }
       muon.set_d0SmearingVal(d0SmearingVal);

--- a/Collections/plugins/OSUMuonProducer.h
+++ b/Collections/plugins/OSUMuonProducer.h
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "OSUT3Analysis/Collections/interface/Muon.h"
+#include "TRandom3.h"
 
 
 class OSUMuonProducer : public edm::EDProducer
@@ -34,6 +35,9 @@ class OSUMuonProducer : public edm::EDProducer
 
     edm::ParameterSet  cfg_;
     edm::InputTag      pfCandidate_;
+    double             d0SmearingWidth_;
+
+    TRandom3* rng;
 
     ////////////////////////////////////////////////////////////////////////////
 

--- a/Collections/src/Electron.cc
+++ b/Collections/src/Electron.cc
@@ -19,6 +19,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron) :
   electronPVIndex_                      (INVALID_VALUE),
   sumPUPtCorr_                          (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
+  d0SmearingVal_                        (INVALID_VALUE),
   passesTightID_noIsolation_            (false),
   passesVID_vetoID_                     (false),
   passesVID_looseID_                    (false),
@@ -54,6 +55,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   electronPVIndex_                      (INVALID_VALUE),
   sumPUPtCorr_                          (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
+  d0SmearingVal_                        (INVALID_VALUE),
   passesTightID_noIsolation_            (false),
   passesVID_vetoID_                     (false),
   passesVID_looseID_                    (false),
@@ -89,6 +91,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   electronPVIndex_                      (INVALID_VALUE),
   sumPUPtCorr_                          (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
+  d0SmearingVal_                        (INVALID_VALUE),
   passesTightID_noIsolation_            (false),
   passesVID_vetoID_                     (false),
   passesVID_looseID_                    (false),
@@ -124,6 +127,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   electronPVIndex_                      (INVALID_VALUE),
   sumPUPtCorr_                          (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
+  d0SmearingVal_                        (INVALID_VALUE),
   passesTightID_noIsolation_            (false),
   passesVID_vetoID_                     (false),
   passesVID_looseID_                    (false),
@@ -266,6 +270,12 @@ const double
 osu::Electron::genD0 () const
 {
   return genD0_;
+}
+
+const double
+osu::Electron::d0SmearingVal () const
+{
+  return d0SmearingVal_;
 }
 
 const bool

--- a/Collections/src/Muon.cc
+++ b/Collections/src/Muon.cc
@@ -17,6 +17,7 @@ osu::Muon::Muon (const TYPE(muons) &muon) :
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
   genD0_                   (INVALID_VALUE),
+  d0SmearingVal_           (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
   metMinusOnePx_           (INVALID_VALUE),
   metMinusOnePy_           (INVALID_VALUE),
@@ -42,6 +43,7 @@ osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcpartic
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
   genD0_                   (INVALID_VALUE),
+  d0SmearingVal_           (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
   metMinusOnePx_           (INVALID_VALUE),
   metMinusOnePy_           (INVALID_VALUE),
@@ -67,6 +69,7 @@ osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcpartic
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
   genD0_                   (INVALID_VALUE),
+  d0SmearingVal_           (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
   metMinusOnePx_           (INVALID_VALUE),
   metMinusOnePy_           (INVALID_VALUE),
@@ -91,6 +94,7 @@ osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcpartic
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
   genD0_                   (INVALID_VALUE),
+  d0SmearingVal_           (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
   metMinusOnePx_           (INVALID_VALUE),
   metMinusOnePy_           (INVALID_VALUE),
@@ -154,6 +158,12 @@ const double
 osu::Muon::genD0 () const
 {
   return genD0_;
+}
+
+const double
+osu::Muon::d0SmearingVal () const
+{
+  return d0SmearingVal_;
 }
 
 void

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -75,6 +75,9 @@ collectionProducer.electrons = cms.EDProducer ("OSUElectronProducer",
     ESClusters      = cms.InputTag ("reducedEgamma", "reducedESClusters",      ""),
     ootEBEEClusters = cms.InputTag ("reducedEgamma", "reducedOOTEBEEClusters", ""),
     ootESClusters   = cms.InputTag ("reducedEgamma", "reducedOOTESClusters",   ""),
+
+    d0SmearingWidth = cms.double (0.0),
+
 )
 
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0"):

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -146,6 +146,8 @@ collectionProducer.mets = cms.EDProducer ("OSUMetProducer",
 
 collectionProducer.muons = cms.EDProducer ("OSUMuonProducer",
     pfCandidate =  cms.InputTag  ('packedPFCandidates','',''),
+
+    d0SmearingWidth = cms.double (0.0),
 )
 copyConfiguration (collectionProducer.muons, collectionProducer.genMatchables)
 

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -76,7 +76,7 @@ collectionProducer.electrons = cms.EDProducer ("OSUElectronProducer",
     ootEBEEClusters = cms.InputTag ("reducedEgamma", "reducedOOTEBEEClusters", ""),
     ootESClusters   = cms.InputTag ("reducedEgamma", "reducedOOTESClusters",   ""),
 
-    d0SmearingWidth = cms.double (0.0),
+    d0SmearingWidth = cms.double (-1.0),
 
 )
 
@@ -147,7 +147,7 @@ collectionProducer.mets = cms.EDProducer ("OSUMetProducer",
 collectionProducer.muons = cms.EDProducer ("OSUMuonProducer",
     pfCandidate =  cms.InputTag  ('packedPFCandidates','',''),
 
-    d0SmearingWidth = cms.double (0.0),
+    d0SmearingWidth = cms.double (-1.0),
 )
 copyConfiguration (collectionProducer.muons, collectionProducer.genMatchables)
 

--- a/Configuration/python/cutUtilities.py
+++ b/Configuration/python/cutUtilities.py
@@ -57,10 +57,14 @@ electronD0WRTBeamspotErr = "hypot(electron.gsfTrack.d0Error, hypot(beamspot.x0Er
 electronD0WRTBeamspotSig = "(((electron.vx - beamspot.x0) * electron.py - (electron.vy - beamspot.y0) * electron.px) / electron.pt) / (hypot(electron.gsfTrack.d0Error, hypot(beamspot.x0Error, beamspot.y0Error)))"
 electronD0WRTPV       = "((electron.vx - eventvariable.leadingPV_x) * electron.py - (electron.vy - eventvariable.leadingPV_y) * electron.px) / electron.pt"
 
+electronSmearedD0WRTBeamspot = "(electron.d0SmearingVal + ((electron.vx - beamspot.x0) * electron.py - (electron.vy - beamspot.y0) * electron.px) / electron.pt)"
+
 muonD0WRTBeamspot = "((muon.vx - beamspot.x0) * muon.py - (muon.vy - beamspot.y0) * muon.px) / muon.pt"
 muonD0WRTBeamspotErr = "hypot(muon.innerTrack.d0Error, hypot(beamspot.x0Error, beamspot.y0Error))"
 muonD0WRTBeamspotSig = "(((muon.vx - beamspot.x0) * muon.py - (muon.vy - beamspot.y0) * muon.px) / muon.pt) / (hypot(muon.innerTrack.d0Error, hypot(beamspot.x0Error, beamspot.y0Error)))"
 muonD0WRTPV       = "((muon.vx - eventvariable.leadingPV_x) * muon.py - (muon.vy - eventvariable.leadingPV_y) * muon.px) / muon.pt"
+
+muonSmearedD0WRTBeamspot = "(muon.d0SmearingVal + ((muon.vx - beamspot.x0) * muon.py - (muon.vy - beamspot.y0) * muon.px) / muon.pt)"
 
 
 # Calculation from https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/DataFormats/TrackReco/interface/TrackBase.h#L674


### PR DESCRIPTION
This PR isn't ready to be merged, but I'd be interested in feedback if anyone has time.

I'm looking to smear the d0 values of electrons and muons by randomly sampling a Gaussian of a specified width and adding the result to the original d0 value. This PR currently only deals with electrons; I'll mimic the implementation in muons once everything comes together.

I initially thought to do this in DisplacedSUSYEventVariableProducer, but I was unable to figure out how to store d0 smearing values for each of the arbitrary number of electrons or muons in each event. I then switched to producing the d0 smearing value for each electron in OSUElectronProducer and adding it to the initial d0 when making histograms. This basic approach works, but there are a couple necessary features that I'm not sure how to implement. I'll keep working on it, but I figured I'd ask in case anyone has a quick answer.

Specifically, I have the following questions:
- In OSUElectronProducer, how can I check if an electron is from data or MC?
- Can I read in a value from a config file so I don't have to hard code magic numbers? In DisplacedSUSYEventVariableProducer I would use `cfg.getParameter`, but doing this here would force all analyses to include something like `d0SmearingWidth = 0.0` in their config files. Is there a better way?