### PR TITLE
2 unrelated but minor fixes

### DIFF
--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -8269,7 +8269,7 @@ crossSections = {
     'ZJetsToNuNu_HT2500toInf' : 0.006945,
 #############################################################
     # Cross sections below obatined with crossSectionExtractor.py
-    'DYJetsToLL_5to50'         :              71310.0 # LO from https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#DY_Z
+    'DYJetsToLL_5to50'         :              71310.0, # LO from https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns#DY_Z
     'DYJetsToLL_10to50'        :              18610.0,
     'DYBBJetsToLL'             :                11.37,
     'DYJetsToLL_10to50_50ns'   :              18610.0,

--- a/Configuration/scripts/makeCutFlows.py
+++ b/Configuration/scripts/makeCutFlows.py
@@ -500,7 +500,7 @@ def addExtraColumn(table, option):
     table.datasets.append(newcol)
 
 def getLumiLabel():
-    lumiStr = str(intLumi / 1000.) # convert /pb to /fb
+    lumiStr = str('%.3g'%(intLumi / 1000.)) # convert /pb to /fb, set precision to 3 and remove insignificant zeros
     label = "$\\mathrm{L} = " + lumiStr + "\\,\\mathrm{fb}^{-1}$"
     if arguments.rawYields:
         label = "Raw event counts"


### PR DESCRIPTION
- add comma, as Andrew meant to do yesterday, to configurationOptions.py
- print out a reasonable number of sig figs when we display the integrated lumi in cutflow tables
This PR should be straightforward. Tested. It works.