### PR TITLE
Handle secondary input files for remote running over empty skims

### DIFF
--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -1015,20 +1015,23 @@ def SkimModifier(Label, Directory, crossSection, isRemote = False):
             add += '"file:' + os.path.realpath (s) + '",\n'
     add += ']\n'
 
-    add += 'listOfSecondaryFiles = [\n'
-    tempdir = tempfile.mkdtemp ()
-    sys.path.append (tempdir)
-    cwd = os.getcwd ()
-    os.chdir (tempdir)
-    if lpcCAF:
-        for s in getOriginalFiles (skimFiles, tempdir):
-            add += '"' + re.sub (r"/eos/uscms/store/", r"root://cmseos.fnal.gov//store/", os.path.realpath (s)) + '",\n'
+    if isRemote:
+        add += 'listOfSecondaryFiles = originalListOfSecondaryFiles if len(originalListOfSecondaryFiles) > 0 else originalListOfFiles\n'
     else:
-        for s in getOriginalFiles (skimFiles, tempdir):
-            add += '"file:' + os.path.realpath (s) + '",\n'
-    shutil.rmtree (tempdir)
-    os.chdir (cwd)
-    add += ']\n'
+        add += 'listOfSecondaryFiles = [\n'
+        tempdir = tempfile.mkdtemp ()
+        sys.path.append (tempdir)
+        cwd = os.getcwd ()
+        os.chdir (tempdir)
+        if lpcCAF:
+            for s in getOriginalFiles (skimFiles, tempdir):
+                add += '"' + re.sub (r"/eos/uscms/store/", r"root://cmseos.fnal.gov//store/", os.path.realpath (s)) + '",\n'
+        else:
+            for s in getOriginalFiles (skimFiles, tempdir):
+                add += '"file:' + os.path.realpath (s) + '",\n'
+        shutil.rmtree (tempdir)
+        os.chdir (cwd)
+        add += ']\n'
 
     add += 'originalNumberOfEvents = ' + str(OriginalNumberOfEvents) + '\n'
     add += 'skimNumberOfEvents = ' + str(SkimNumberOfEvents) + '\n'


### PR DESCRIPTION
Currently SkimModifier calls getOriginalFile(s) to figure out the list of secondary input files, in cases where you're submitting a job over an empty skim. This function tries to open a local file `SkimDirectory.txt` to know where the original non-empty skim is stored. If you're submitting a job over a remote skim, ie `-s root://...`, then we never transferred `SkimDirectory.txt`.

You could `xrdcp` this file and figure things out, but then `SkimDirectory.txt` is a path relative within the remote machine; it could be `/eos/uscms/store/...` on LPC or `/cms/ahart/disappearingTracks/...` on Rutgers...and you in general don't know the physical path on a machine from the xrootd redirector. You'd need to know that the LPC strips `/eos/uscms`, Rutgers changed `/cms` to `/store/user`, and etc for special cases.

...Or you could be lazy and use the fact that the datasetInfo already has a complete history of the skim inputs. If the input skim's datasetInfo has secondary input files, you need to keep that the same, and if there were none then you just want the listOfFiles for the input skim.

This works when running over things stored at the LPC because that natively uses xrootd, but this won't work for OSU or Rutgers' T3 because those paths will still be local physical paths.