### PR TITLE
Use xrootd paths as-is for secondary file list

### DIFF
--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -1025,7 +1025,10 @@ def SkimModifier(Label, Directory, crossSection, isRemote = False):
         os.chdir (tempdir)
         if lpcCAF:
             for s in getOriginalFiles (skimFiles, tempdir):
-                add += '"' + re.sub (r"/eos/uscms/store/", r"root://cmseos.fnal.gov//store/", os.path.realpath (s)) + '",\n'
+                if s.startswith ("root://"):
+                    add += '"' + s + '",\n'
+                else:
+                    add += '"' + re.sub (r"/eos/uscms/store/", r"root://cmseos.fnal.gov//store/", os.path.realpath (s)) + '",\n'
         else:
             for s in getOriginalFiles (skimFiles, tempdir):
                 add += '"file:' + os.path.realpath (s) + '",\n'
@@ -1058,6 +1061,8 @@ def getOriginalFile (f, tempdir, isFirstFile = True, skimDirs = []):
         if isFirstFile:
             return []
         else:
+            if f.startswith ("root://"):
+                return [f]
             return [os.path.realpath (f)]
 
     try:


### PR DESCRIPTION
Running over empty skims on the LPC was broken because `os.path.realpath` was being called on xrootd paths, which yields bad paths which fail the job. Example:

`root://cmseos.fnal.gov//store/user/lpclonglived/DisappTrks/skim/2017/electronTagSkim/SingleEle_2017B/ElectronTagSkim/skim_462.root`
gives something like
`/tmp/tmpQUlSst/root:/cmseos.fnal.gov/store/user/lpclonglived/DisappTrks/skim/2017/electronTagSkim/SingleEle_2017B/ElectronTagSkim/skim_462.root`
because `:` is interpreted as a separator for multiple files, and `//` is stripped to `/`.

So the solution is to take the file path itself if it starts with `root://` instead of calling `realpath`.

Testing: datasetInfo_*_cfg.py are no longer filled with garbage paths and jobs are running successfully @ LPC.