### PR TITLE
update electron VID to V2

### DIFF
--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -93,6 +93,19 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4"):
     collectionProducer.electrons.vidMediumIdMap  = cms.InputTag   ("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-medium")
     collectionProducer.electrons.vidTightIdMap   = cms.InputTag   ("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V1-tight")
     collectionProducer.electrons.effAreasPayload = cms.FileInPath ("RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_92X.txt")
+    if int(os.environ["CMSSW_VERSION"].split("_")[3]) >=9:
+        collectionProducer.electrons.vidVetoIdMap    = cms.InputTag   ("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-veto")
+        collectionProducer.electrons.vidLooseIdMap   = cms.InputTag   ("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-loose")
+        collectionProducer.electrons.vidMediumIdMap  = cms.InputTag   ("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-medium")
+        collectionProducer.electrons.vidTightIdMap   = cms.InputTag   ("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-tight")
+        collectionProducer.electrons.effAreasPayload = cms.FileInPath ("RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_94X.txt")
+
+if os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2"):
+    collectionProducer.electrons.vidVetoIdMap    = cms.InputTag   ("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-veto")
+    collectionProducer.electrons.vidLooseIdMap   = cms.InputTag   ("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-loose")
+    collectionProducer.electrons.vidMediumIdMap  = cms.InputTag   ("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-medium")
+    collectionProducer.electrons.vidTightIdMap   = cms.InputTag   ("egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-tight")
+    collectionProducer.electrons.effAreasPayload = cms.FileInPath ("RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_94X.txt")
 
 copyConfiguration (collectionProducer.electrons, collectionProducer.genMatchables)
 
@@ -272,7 +285,7 @@ if osusub.batchMode and types[osusub.datasetLabel] == "data":
         collectionProducer.tracks.fiducialMaps.electrons[0].era = cms.string (osusub.datasetLabel[osusub.datasetLabel.find('_201'):])
         collectionProducer.tracks.fiducialMaps.muons[0].era = cms.string (osusub.datasetLabel[osusub.datasetLabel.find('_201'):])
 
-# For 94X which uses electron VIDs, define the vertexing requirements for veto electrons        
+# For 94X which uses electron VIDs, define the vertexing requirements for veto electrons
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
     # Cut values are ordered by ID, as: veto, loose, medium, tight
     # https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Working_points_for_92X_and_later

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -277,7 +277,7 @@ def add_channels (process,
     elif rootFile.startswith ("skim_"):
         makeEmptySkim = True
 
-    # If the input file is either skim_*.root or emptySkim_*.root, 
+    # If the input file is either skim_*.root or emptySkim_*.root,
     # we need now to read the input tags and replace as necessary
     if makeEmptySkim:
         # If we deliberately ignore this by user flag, just print a message
@@ -920,11 +920,16 @@ def customizeMINIAODElectronVID(process, collections, usedCollections):
 
     my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff']
 
-    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
+    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
         my_id_modules.extend(['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff'])
 
     if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
         my_id_modules.extend(['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_cff'])
+        if int(os.environ["CMSSW_VERSION"].split("_")[3]) >=9:
+            my_id_modules.extend(['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff'])
+
+    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
+        my_id_modules.extend(['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff'])
 
     # Setup all the desired modules to be run
     for idmod in my_id_modules:
@@ -932,7 +937,7 @@ def customizeMINIAODElectronVID(process, collections, usedCollections):
     process.egmGsfElectronIDSequence_step = cms.Path(process.egmGsfElectronIDSequence)
     process.schedule.insert(0, process.egmGsfElectronIDSequence_step)
 
-    # In the case where tracks are being used in a skim where electron cuts are applied, 
+    # In the case where tracks are being used in a skim where electron cuts are applied,
     # there's now two different electron collections of interest. We need to duplicate
     # the VID producer for the original collection
     if 'tracks' in usedCollections and collections.electrons.getProcessName().startswith('OSUAnalysis'):


### PR DESCRIPTION
This PR adds the Fall17 electron VID V2, which is recommended to be used for CMSSW_9_4_9 and greater, with 2017 and 2018 data.

https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2