### PR TITLE
LPC condor refactor

### DIFF
--- a/Configuration/python/Color.py
+++ b/Configuration/python/Color.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+# define some constants with meaningful names for the ANSI color codes
+# https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+
+A_BLACK           =  "\033[30m"
+A_RED             =  "\033[31m"
+A_GREEN           =  "\033[32m"
+A_YELLOW          =  "\033[33m"
+A_BLUE            =  "\033[34m"
+A_MAGENTA         =  "\033[35m"
+A_CYAN            =  "\033[36m"
+A_WHITE           =  "\033[37m"
+
+A_BRIGHT_BLACK    =  "\033[1;30m"
+A_BRIGHT_RED      =  "\033[1;31m"
+A_BRIGHT_GREEN    =  "\033[1;32m"
+A_BRIGHT_YELLOW   =  "\033[1;33m"
+A_BRIGHT_BLUE     =  "\033[1;34m"
+A_BRIGHT_MAGENTA  =  "\033[1;35m"
+A_BRIGHT_CYAN     =  "\033[1;36m"
+A_BRIGHT_WHITE    =  "\033[1;37m"
+
+A_RESET           =  "\033[0m"

--- a/Configuration/python/ProgressIndicator.py
+++ b/Configuration/python/ProgressIndicator.py
@@ -1,29 +1,7 @@
 #!/usr/bin/env python
 
 import sys, time
-
-# define some macros with meaningful names for the ANSI color codes
-# https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
-
-A_BLACK           =  "\033[30m"
-A_RED             =  "\033[31m"
-A_GREEN           =  "\033[32m"
-A_YELLOW          =  "\033[33m"
-A_BLUE            =  "\033[34m"
-A_MAGENTA         =  "\033[35m"
-A_CYAN            =  "\033[36m"
-A_WHITE           =  "\033[37m"
-
-A_BRIGHT_BLACK    =  "\033[1;30m"
-A_BRIGHT_RED      =  "\033[1;31m"
-A_BRIGHT_GREEN    =  "\033[1;32m"
-A_BRIGHT_YELLOW   =  "\033[1;33m"
-A_BRIGHT_BLUE     =  "\033[1;34m"
-A_BRIGHT_MAGENTA  =  "\033[1;35m"
-A_BRIGHT_CYAN     =  "\033[1;36m"
-A_BRIGHT_WHITE    =  "\033[1;37m"
-
-A_RESET           =  "\033[0m"
+import OSUT3Analysis.Configuration.Color
 
 # define some macros with meaningful names for the ANSI control sequences
 # https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_sequences

--- a/DBTools/python/condorSubArgumentsSet.py
+++ b/DBTools/python/condorSubArgumentsSet.py
@@ -1,14 +1,33 @@
-CondorSubArgumentsSet = {
-    1   :  {'Executable'             :  ''},
-    2   :  {'Universe'               :  'vanilla'},
-    3   :  {'Getenv'                 :  'True'},
-    4   :  {'request_memory '        : '2048MB'},
-    5   :  {'Arguments'              :  ''},
-    6   :  {'Output'                 :  'condor_$(Process).out'},
-    7   :  {'Error'                  :  'condor_$(Process).err'},
-    8   :  {'Log'                    :  'condor_$(Process).log\n'},
-    9   :  {'Transfer_Input_files'   :  ''},
-    10  :  {'Transfer_Output_files'  :  ''},
-    11  :  {'+IsLocalJob'            :  'true'},
-    12  :  {'Rank'                   :  'TARGET.IsLocalSlot\n'},
-}
+#!/usr/bin/env python
+
+import socket
+
+hostname = socket.getfqdn()
+lpcCAF = ('fnal.gov' in hostname)
+
+CondorSubArgumentsSet = {}
+if lpcCAF:
+    CondorSubArgumentsSet = {
+        1   :  {'Executable'             :  ''},
+        2   :  {'Universe'               :  'vanilla'},
+        3   :  {'request_memory '        : '2048MB'},
+        4   :  {'Arguments'              :  ''},
+        5   :  {'Output'                 :  'condor_$(Process).out'},
+        6   :  {'Error'                  :  'condor_$(Process).err'},
+        7   :  {'Log'                    :  'condor_$(Process).log\n'},
+        8   :  {'Transfer_Input_files'   :  ''},
+        9   :  {'Transfer_Output_files'  :  ''},
+    }
+else:
+    CondorSubArgumentsSet = {
+        1   :  {'Executable'             :  ''},
+        2   :  {'Universe'               :  'vanilla'},
+        3   :  {'Getenv'                 :  'True'},
+        4   :  {'request_memory '        : '2048MB'},
+        5   :  {'Arguments'              :  ''},
+        6   :  {'Output'                 :  'condor_$(Process).out'},
+        7   :  {'Error'                  :  'condor_$(Process).err'},
+        8   :  {'Log'                    :  'condor_$(Process).log\n'},
+        9   :  {'Transfer_Input_files'   :  ''},
+        10  :  {'Transfer_Output_files'  :  ''},
+    }

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -402,17 +402,17 @@ def MakeCondorSubmitScript(Dataset,NumberOfJobs,Directory,Label, SkimChannelName
                 FilesToTransfer += ',datasetInfo_' + Label + '_cfg.py'
             if UseGridProxy:
                 if rutgers:
-                    shutil.copy ("/tmp/" + proxy, Directory + "/" + proxy)
-                    os.chmod (Directory + "/" + proxy, 0644)
-                    FilesToTransfer += ',' + proxy
+                    shutil.copy (proxy, Directory + "/" + os.path.basename (proxy))
+                    os.chmod (Directory + "/" + os.path.basename (proxy), 0644)
+                    FilesToTransfer += ',' + os.path.basename (proxy)
                 else:
-                    FilesToTransfer += ',/tmp/' + proxy
+                    FilesToTransfer += ',' + proxy
             if jsonFile != '':
                 FilesToTransfer += ',' + jsonFile
             SubmitFile.write('should_transfer_files   = YES\n')
             SubmitFile.write('Transfer_Input_files = ' + FilesToTransfer + '\n')
             if UseGridProxy and not rutgers:
-                SubmitFile.write('x509userproxy = /tmp/' + proxy + '\n')
+                SubmitFile.write('x509userproxy = ' + proxy + '\n')
         elif currentCondorSubArgumentsSet[argument].has_key('Transfer_Output_files') and currentCondorSubArgumentsSet[argument]['Transfer_Output_files'] == "":
             SubmitFile.write ('Transfer_Output_files = ')
             if os.path.realpath (Directory).startswith (("/data/users/", "/mnt/hadoop/se/store/", "/eos/uscms/store/", "/cms/")):
@@ -458,9 +458,9 @@ def MakeCondorSubmitScript(Dataset,NumberOfJobs,Directory,Label, SkimChannelName
         SubmitScript.write ("PYTHONPATH=$PYTHONPATH:./" + os.environ["CMSSW_VERSION"] + "/python:.\n\n")
 
     if rutgers:
-        SubmitScript.write ("rm -f /tmp/" + proxy + "\n")
-        SubmitScript.write ("mv -f " + proxy + " /tmp/\n")
-        SubmitScript.write ("chmod 600 /tmp/" + proxy + "\n\n")
+        SubmitScript.write ("rm -f " + proxy + "\n")
+        SubmitScript.write ("mv -f " + os.path.basename (proxy) + " " + os.path.dirname (proxy) + "/\n")
+        SubmitScript.write ("chmod 600 " + proxy + "\n\n")
 
     SubmitScript.write ("(>&2 echo \"Arguments passed to this script are: $@\")\n")
     SubmitScript.write (cmsRunExecutable + " $@\n")
@@ -1181,6 +1181,12 @@ if not arguments.localConfig:
 ###############################################################################
 #    Get the host name to determine whether you are using lxplus or OSU T3.   #
 ###############################################################################
+hostname = socket.getfqdn()
+remoteAccessT3 = ('interactive' not in hostname)
+lxbatch = ('cern.ch' in hostname)
+lpcCAF = ('fnal.gov' in hostname)
+rutgers = ('rutgers.edu' in hostname)
+
 UseAAA = False
 UseGridProxy = False
 Generic = False
@@ -1189,15 +1195,10 @@ if arguments.Generic:
 if arguments.UseAAA:
     UseAAA = True
 UseGridProxy = UseAAA or arguments.UseGridProxy
-if os.path.realpath (CondorDir).startswith ("/eos/uscms/store/") or os.path.realpath (HadoopDir).startswith ("/eos/uscms/store/"):
+if lpcCAF or os.path.realpath (CondorDir).startswith ("/eos/uscms/store/") or os.path.realpath (HadoopDir).startswith ("/eos/uscms/store/"):
     UseGridProxy = True
 userId = os.getuid()
-proxy = 'x509up_u' + str(userId)
-hostname = socket.getfqdn()
-remoteAccessT3 = ('interactive' not in hostname)
-lxbatch = ('cern.ch' in hostname)
-lpcCAF = ('fnal.gov' in hostname)
-rutgers = ('rutgers.edu' in hostname)
+proxy = '/tmp/x509up_u' + str(userId) if "X509_USER_PROXY" not in os.environ else os.environ["X509_USER_PROXY"]
 
 if arguments.Redirector != "":
     if not RedirectorDic.has_key(arguments.Redirector):
@@ -1207,10 +1208,8 @@ if arguments.Redirector != "":
 if lpcCAF and not arguments.skimToHadoop:
     print
     print "Warning! You are working on the LPC, but have not provided a \"Hadoop\" directory for your skim with \"-H\"."
-    print "         LPC's condor nodes have no access to regular directories, so you will never be able to run over"
-    print "         the resulting skim files using condor, nor will you be able to access them with xrootd remotely."
-    print "         Consider using -H with eos!"
-    print
+    print "         Your skim files will be written directly to your condor directory, which may threaten the quota"
+    print "         on your home directory. Consider using -H with eos!"
 
 ###############################################################################
 #                End of Setup stage, will begin to submit jobs                #
@@ -1338,12 +1337,12 @@ if not arguments.Resubmit:
                     os.syetem('./lxbatchSub.sh')
                 else:
                     os.symlink ("../" + os.environ["CMSSW_VERSION"] + ".tar.gz", os.environ["CMSSW_VERSION"] + ".tar.gz")
-                    cmd = "condor_submit condor.sub"
-                    if os.path.isfile (proxy):
-                        os.chmod (proxy, 0644)
+                    cmd = "LD_LIBRARY_PATH= condor_submit condor.sub"
+                    if os.path.isfile (os.path.basename (proxy)):
+                        os.chmod (os.path.basename (proxy), 0644)
                     subprocess.call(cmd, shell = True)
-                    if os.path.isfile (proxy):
-                        os.chmod (proxy, 0600)
+                    if os.path.isfile (os.path.basename (proxy)):
+                        os.chmod (os.path.basename (proxy), 0600)
                 os.chdir(SubmissionDir)
             else:
                 print 'Configuration files created for ' + str(dataset) + ' dataset but no jobs submitted.\n'
@@ -1386,12 +1385,12 @@ if not arguments.Resubmit:
                 os.syetem('./lxbatchSub.sh')
             else:
                 os.symlink ("../" + os.environ["CMSSW_VERSION"] + ".tar.gz", os.environ["CMSSW_VERSION"] + ".tar.gz")
-                cmd = "condor_submit condor.sub"
-                if os.path.isfile (proxy):
-                    os.chmod (proxy, 0644)
+                cmd = "LD_LIBRARY_PATH= condor_submit condor.sub"
+                if os.path.isfile (os.path.basename (proxy)):
+                    os.chmod (os.path.basename (proxy), 0644)
                 subprocess.call(cmd, shell = True)
-                if os.path.isfile (proxy):
-                    os.chmod (proxy, 0600)
+                if os.path.isfile (os.path.basename (proxy)):
+                    os.chmod (os.path.basename (proxy), 0600)
             os.chdir(SubmissionDir)
         else:
             print 'Configuration files created for ' + str(Config) + '  but no jobs submitted.\n'
@@ -1400,10 +1399,10 @@ else:
         SubmissionDir = os.getcwd()
         for dataset in split_datasets:
             WorkDir = CondorDir + '/' + str(dataset)
-            if os.path.isfile (WorkDir + "/" + proxy) and os.path.isfile ("/tmp/" + proxy):
-                os.unlink (WorkDir + "/" + proxy)
-                shutil.copy ("/tmp/" + proxy, WorkDir + "/" + proxy)
-                os.chmod (WorkDir + "/" + proxy, 0644)
+            if os.path.isfile (WorkDir + "/" + os.path.basename (proxy)) and os.path.isfile (proxy):
+                os.unlink (WorkDir + "/" + os.path.basename (proxy))
+                shutil.copy (proxy, WorkDir + "/" + os.path.basename (proxy))
+                os.chmod (WorkDir + "/" + os.path.basename (proxy), 0644)
             if os.path.exists(WorkDir + '/condor_resubmit.sh'):
                 os.chdir(WorkDir)
                 subprocess.call ('./condor_resubmit.sh', shell = True)
@@ -1422,10 +1421,10 @@ else:
                                break
                         subprocess.call('sed -i \'s/' + str(originalRedirector) + '/' + str(RedirectorDic[arguments.Redirector]) + '/g\' '  +  str(datasetInfoFileName), shell = True)
                 print '################ Resubmit failed jobs for ' + str(dataset) + ' dataset #############'
-                cmd = "condor_submit condor_resubmit.sub"
-                if os.path.isfile (proxy):
-                    os.chmod (proxy, 0644)
+                cmd = "LD_LIBRARY_PATH= condor_submit condor_resubmit.sub"
+                if os.path.isfile (os.path.basename (proxy)):
+                    os.chmod (os.path.basename (proxy), 0644)
                 subprocess.call(cmd, shell = True)
-                if os.path.isfile (proxy):
-                    os.chmod (proxy, 0600)
+                if os.path.isfile (os.path.basename (proxy)):
+                    os.chmod (os.path.basename (proxy), 0600)
                 os.chdir(SubmissionDir)

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -4,6 +4,7 @@ import getpass
 import os
 import re
 import socket
+import platform
 import time
 from time import gmtime, strftime
 import copy
@@ -15,6 +16,7 @@ import tarfile
 from math import *
 from array import *
 from optparse import OptionParser
+from OSUT3Analysis.Configuration.Color import *
 from OSUT3Analysis.Configuration.configurationOptions import *
 from OSUT3Analysis.Configuration.processingUtilities import *
 from OSUT3Analysis.Configuration.formattingUtilities import *
@@ -214,7 +216,7 @@ def getLatestJsonFile():
 
             if len(jsonFileFiltered) == 0:
                 print "#######################################################"
-                print "Warning!!!!!!!!!!!Could not find wanted JSON file"
+                print A_BRIGHT_RED + "Warning!!!!!!!!!!!Could not find wanted JSON file" + A_RESET
                 print "#######################################################"
 
             for json in jsonFileFiltered:
@@ -290,7 +292,7 @@ def getLatestJsonFile():
 
             if len(jsonFileFiltered) == 0:
                 print "#######################################################"
-                print "Warning!!!!!!!!!!!Could not find wanted JSON file"
+                print A_BRIGHT_RED + "Warning!!!!!!!!!!!Could not find wanted JSON file" + A_RESET
                 print "#######################################################"
 
             ultimateJson = jsonFileFiltered[-1]
@@ -1174,7 +1176,7 @@ if not arguments.localConfig:
         print "No cmsRun executable is given, aborting."
         sys.exit(1)
     if arguments.Dataset == "":
-        print "Warning, you are running batch jobs witout using input sources."
+        print A_BRIGHT_RED + "Warning, you are running batch jobs witout using input sources." + A_RESET
     else:
         split_datasets.append(arguments.Dataset)
 
@@ -1186,6 +1188,12 @@ remoteAccessT3 = ('interactive' not in hostname)
 lxbatch = ('cern.ch' in hostname)
 lpcCAF = ('fnal.gov' in hostname)
 rutgers = ('rutgers.edu' in hostname)
+
+if lpcCAF and "el6" in platform.release ():
+  print
+  print A_BRIGHT_RED + "Warning! You are working in SL6 on the LPC. Job submission is currently"
+  print                "         problematic in SLF6, and you are encouraged to switch to SL7." + A_RESET
+  print
 
 UseAAA = False
 UseGridProxy = False
@@ -1202,14 +1210,16 @@ proxy = '/tmp/x509up_u' + str(userId) if "X509_USER_PROXY" not in os.environ els
 
 if arguments.Redirector != "":
     if not RedirectorDic.has_key(arguments.Redirector):
-        print "Warning! Invalid redirector provided!! Quit!!"
+        print A_BRIGHT_RED + "Warning! Invalid redirector provided!! Quit!!" + A_RESET
         sys.exit(1)
 
 if lpcCAF and not arguments.skimToHadoop:
     print
-    print "Warning! You are working on the LPC, but have not provided a \"Hadoop\" directory for your skim with \"-H\"."
-    print "         Your skim files will be written directly to your condor directory, which may threaten the quota"
-    print "         on your home directory. Consider using -H with eos!"
+    print A_BRIGHT_RED + "Warning! You are working on the LPC, but have not provided a \"Hadoop\" directory"
+    print                "         for your skim with \"-H\". Your skim files will be written directly to"
+    print                "         your condor directory, which may threaten the quota on your home"
+    print                "         directory. Consider using -H with eos!" + A_RESET
+    print
 
 ###############################################################################
 #                End of Setup stage, will begin to submit jobs                #


### PR DESCRIPTION
A few changes to deal with the LPC's condor refactor:
- Always use a grid proxy when submitting jobs at the LPC
- Allow the grid proxy to be in locations other than /tmp/, as determined by X509_USER_PROXY
- Remove `Getenv = True` from `condor.sub` when submitting jobs at the LPC
- Added a warning about submitting from SL6 at the LPC

Jobs seem to run just fine when submitted from an SL7 release on an SL7 node. But right now, success varies wildly when submitting from SL6. This is likely an issue that the LPC admins will have to address.

But for us, it's easy enough to switch to SL7, so I just added a warning when submitting jobs from SL6, informing the user that they should switch.