### PR TITLE
Fix checkJobs for different log names

### DIFF
--- a/AnaTools/scripts/checkJobs
+++ b/AnaTools/scripts/checkJobs
@@ -77,7 +77,7 @@ def printJobs(logs, desc):
   jobRanges = {}
   for log in logs:
     dataset = log.split('/')[-2]
-    jobNumber = int(log.split('/')[-1][7:-4]) # condor_N.log
+    jobNumber = int(os.path.basename(log).split('_')[-1][:-4]) # condor_N.log or condor_dataset_N.log
     if not dataset in jobRanges:
       jobRanges[dataset] = [jobNumber];
     else:


### PR DESCRIPTION
A future commit will create condor log files like
`condor_SingleEle_2017B_7.log`
and checkJobs currently expects only e.g. `condor_7.log`. This prevents a script crash and checks these new logs.