### PR TITLE
Handle -H /eos on LPC

### DIFF
--- a/Configuration/python/mergeUtilities.py
+++ b/Configuration/python/mergeUtilities.py
@@ -151,7 +151,7 @@ def MakeFilesForSkimDirectoryEOS(Member, Directory, DirectoryOut, TotalNumber, S
         print 'Failed to copy OriginalNumberOfEvents.txt:', e
     outfile = os.path.join(tmpDir, 'SkimNumberOfEvents.txt')
     fout = open(outfile, 'w')
-    fout.write(str(SkimNumber) + '\n')
+    fout.write(str(SkimNumber[Member]) + '\n')
     fout.close()
     try:
         subprocess.check_output(['xrdcp', '-f', outfile, xrootdDestination])

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -662,7 +662,7 @@ def MakeSpecificConfig(Dataset, Directory, SkimDirectory, Label, SkimChannelName
                     WriteTextToFile(Directory + '\n', Directory + '/' + channelName + '/SkimDirectory.txt', lpcCAF)
 
                     # Create an extra copy in the skim directory, in case a user later wants to run over this skim remotely via xrootd
-                    if lpcCAF and os.path.dirname(filePath).startswith('/eos/uscms'):
+                    if lpcCAF and os.path.realpath(Directory + '/' + channelName + '/').startswith('/eos/uscms'):
                         subprocess.call('xrdcp ' + Directory + '/datasetInfo_' + dataset + '_cfg.py root://cmseos.fnal.gov/' + os.path.realpath(Directory + '/' + channelName + '/'), shell = True)
                     else:
                         subprocess.call('cp ' + Directory + '/datasetInfo_' + dataset + '_cfg.py ' + Directory + '/' + channelName + '/', shell = True)

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -639,7 +639,6 @@ def MakeSpecificConfig(Dataset, Directory, SkimDirectory, Label, SkimChannelName
         ConfigFile.write('myLumis = LumiList.LumiList(filename = \'' + str(jsonFile) + '\').getCMSSWString().split(\',\')\n')
     ConfigFile.write('\n')
     if not Generic:
-        # fuck
         if len(SkimChannelNames) == 0:
             SkimChannelNames = SkimChannelFinder('userConfig_' + Label + '_cfg', Directory, temPset)
             for channelName in SkimChannelNames:
@@ -956,11 +955,9 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
                 print "No input skim files found for dataset " + Label + ".  Will skip it and continue"
                 datasetRead['numberOfFiles'] = numInputFiles
                 return datasetRead
-            # fuck
             SkimDirectory = Condor + str(arguments.SkimDirectory) + '/' + str(Label) + '/'
             secondaryCollectionModifications = SecondaryCollectionInstance(SkimDirectory, arguments.SkimChannel)
             #Copy the datasetInfo file from the skim directory.
-            # fuck
             shutil.copy (SkimDirectory + 'datasetInfo_' + Label + '_cfg.py', datasetInfoName)
             #Modidy the datasetInfo file copied so that it can be used by the jobs running over skims. Also update the crossSection here.
             SkimModifier(Label, Directory, crossSection)
@@ -1366,7 +1363,6 @@ if not arguments.Resubmit:
             elif arguments.crossSection != "":
                 crossSection = arguments.crossSection
 
-            # fuck
             DatasetRead = MakeFileList(DatasetName,arguments.FileType,WorkDir,dataset, UseAAA, crossSection)
             NumberOfFiles = int(DatasetRead['numberOfFiles'])
 

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -639,6 +639,7 @@ def MakeSpecificConfig(Dataset, Directory, SkimDirectory, Label, SkimChannelName
         ConfigFile.write('myLumis = LumiList.LumiList(filename = \'' + str(jsonFile) + '\').getCMSSWString().split(\',\')\n')
     ConfigFile.write('\n')
     if not Generic:
+        # fuck
         if len(SkimChannelNames) == 0:
             SkimChannelNames = SkimChannelFinder('userConfig_' + Label + '_cfg', Directory, temPset)
             for channelName in SkimChannelNames:
@@ -650,6 +651,12 @@ def MakeSpecificConfig(Dataset, Directory, SkimDirectory, Label, SkimChannelName
                         if not os.path.exists(Directory + '/' + channelName):
                             os.symlink (SkimDirectory + '/' + channelName, Directory + '/' + channelName)
                     WriteTextToFile(Directory + '\n', Directory + '/' + channelName + '/SkimDirectory.txt', lpcCAF)
+
+                    # Create an extra copy in the skim directory, in case a user later wants to run over this skim remotely via xrootd
+                    if lpcCAF and os.path.realpath(Directory + '/' + channelName + '/').startswith('/eos/uscms'):
+                        subprocess.call('xrdcp ' + Directory + '/datasetInfo_' + dataset + '_cfg.py root://cmseos.fnal.gov/' + os.path.realpath(Directory + '/' + channelName + '/'), shell = True)
+                    else:
+                        subprocess.call('cp ' + Directory + '/datasetInfo_' + dataset + '_cfg.py ' + Directory + '/' + channelName + '/', shell = True)
         else:
             for channelName in SkimChannelNames:
                 if not channelName == '':
@@ -949,9 +956,11 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
                 print "No input skim files found for dataset " + Label + ".  Will skip it and continue"
                 datasetRead['numberOfFiles'] = numInputFiles
                 return datasetRead
+            # fuck
             SkimDirectory = Condor + str(arguments.SkimDirectory) + '/' + str(Label) + '/'
             secondaryCollectionModifications = SecondaryCollectionInstance(SkimDirectory, arguments.SkimChannel)
             #Copy the datasetInfo file from the skim directory.
+            # fuck
             shutil.copy (SkimDirectory + 'datasetInfo_' + Label + '_cfg.py', datasetInfoName)
             #Modidy the datasetInfo file copied so that it can be used by the jobs running over skims. Also update the crossSection here.
             SkimModifier(Label, Directory, crossSection)
@@ -1357,6 +1366,7 @@ if not arguments.Resubmit:
             elif arguments.crossSection != "":
                 crossSection = arguments.crossSection
 
+            # fuck
             DatasetRead = MakeFileList(DatasetName,arguments.FileType,WorkDir,dataset, UseAAA, crossSection)
             NumberOfFiles = int(DatasetRead['numberOfFiles'])
 


### PR DESCRIPTION
Replaces a few direct file operations with xrootd commands when needed. The framework could handle the transfer of skim files to LPC EOS before, but it still relied on regular disk access to create the skim directories and a few small files.

Honestly it's close to being able to handle `-H root://somewhere.totally.else/` if we really wanted that option, which makes me concerned that we're just recreating crab at this point.

But this change makes `-H /eos/uscms/...` work again on LPC after the refactor.