### PR TITLE
Provide list of mother IDs to reject in isrPt calculation

### DIFF
--- a/AnaTools/plugins/ISRWeightProducer.h
+++ b/AnaTools/plugins/ISRWeightProducer.h
@@ -20,6 +20,7 @@ private:
   edm::EDGetTokenT<vector<TYPE(hardInteractionMcparticles)> > mcparticlesToken_;
 
   vector<int> pdgIds_;
+  vector<int> motherIdsToReject_;
   string weightFile_;
   vector<string> weightHist_;
 


### PR DESCRIPTION
Existing code has 2 bugs, basically a confusion of what "original particle" means when what you really want is the hard interaction:
1) isOriginalParticle would continue climbing up a decay chain until it found a particle with a differently id'd mother, and then call everything in the chain "original"
2) "original" just meant its mother had a different id; for DisappTrks AMSB you will have charginos decay to neutralinos, and this would call both original and you'd add too much to the isrPt.

This PR adds an extra parameter to specify particles to reject in the isrPt calculation, based on what their mother's ID is.

You can leave it empty but you will need to provide this parameter if you use this producer:
```process.ISRWeightProducer.motherIdsToReject = cms.vint32()```

Before this PR, some debug output:
```
event 1:
found original particle: id = -1000024, pt = 307.181, mother = 1
found original particle: id = 1000022, pt = 307.181, mother = 1
found original particle: id = 1000022, pt = 116.197, mother = -1000024

event 2:
found original particle: id = 1000024, pt = 377.899, mother = 1
found original particle: id = -1000024, pt = 377.899, mother = 1
found original particle: id = 1000022, pt = 380.853, mother = 1000024
found original particle: id = 1000022, pt = 375.822, mother = -1000024
```

After this change, using `process.ISRWeightProducer.motherIdsToReject = cms.vint32(1000022, 1000024)`:
```
event 1:
found original particle: id = -1000024, pt = 307.181, mother = 1
found original particle: id = 1000022, pt = 307.181, mother = 1

event 2:
found original particle: id = 1000024, pt = 377.899, mother = 1
found original particle: id = -1000024, pt = 377.899, mother = 1
```

Which is what we really wanted.