### PR TITLE
Update jer methods

### DIFF
--- a/AnaTools/interface/CommonUtils.h
+++ b/AnaTools/interface/CommonUtils.h
@@ -272,11 +272,15 @@ anatools::getObjectHash(const T& object){
 template<class T> bool
 anatools::jetPassesTightLepVeto (const T &jet)
 {
-  // Taken from recommendations from the JetMET group for 13 TeV:
+#if CMSSW_VERSION_CODE >= CMSSW_VERSION(9,4,0)
+  // https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2017
+  return (((jet.neutralHadronEnergyFraction()<0.90 && jet.neutralEmEnergyFraction()<0.90 && (jet.chargedMultiplicity() + jet.neutralMultiplicity())>1 && jet.muonEnergyFraction()<0.8) && ((fabs(jet.eta())<=2.4 && jet.chargedHadronEnergyFraction()>0 && jet.chargedMultiplicity()>0 && jet.chargedEmEnergyFraction()<0.80) || fabs(jet.eta())>2.4) && fabs(jet.eta())<=3.0)
+    || (jet.neutralEmEnergyFraction()<0.90 && jet.neutralMultiplicity()>10 && fabs(jet.eta())>3.0));
+#else
   // https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID#Recommendations_for_13_TeV_data
-  //
   return (((jet.neutralHadronEnergyFraction()<0.90 && jet.neutralEmEnergyFraction()<0.90 && (jet.chargedMultiplicity() + jet.neutralMultiplicity())>1 && jet.muonEnergyFraction()<0.8) && ((fabs(jet.eta())<=2.4 && jet.chargedHadronEnergyFraction()>0 && jet.chargedMultiplicity()>0 && jet.chargedEmEnergyFraction()<0.90) || fabs(jet.eta())>2.4) && fabs(jet.eta())<=3.0)
     || (jet.neutralEmEnergyFraction()<0.90 && jet.neutralMultiplicity()>10 && fabs(jet.eta())>3.0));
+#endif
 }
 
 template<class T> bool

--- a/Collections/plugins/OSUGenericJetProducer.cc
+++ b/Collections/plugins/OSUGenericJetProducer.cc
@@ -294,10 +294,8 @@ OSUGenericJetProducer<T>::produce (edm::Event &event, const edm::EventSetup &set
 
           if(jet.jerSF() > 1.0) {
             if(jetResNewPrescription_) {
-              // https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_25/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L244
-              double sigma = jet.jer() * sqrt(jet.jerSF() * jet.jerSF() - 1.);
-              // smearFactor = 1. + Gaus(0, sigma);
-              double smearedPt = jet.pt() * (1.0 + rng->Gaus(0.0, sigma));
+              double smearedPt = rng->Gaus(0.0, jet.jer()) * sqrt(max(jet.jerSF() * jet.jerSF() - 1.0, 0.0));
+              smearedPt = jet.pt() * (1.0 + smearedPt);
               jet.set_smearedPt(    smearedPt);
               jet.set_smearedPtUp(  smearedPt * jet.jerSFUp() / jet.jerSF());
               jet.set_smearedPtDown(smearedPt * jet.jerSFDown() / jet.jerSF());
@@ -312,9 +310,9 @@ OSUGenericJetProducer<T>::produce (edm::Event &event, const edm::EventSetup &set
             }
           }
           else {
-            jet.set_smearedPt(INVALID_VALUE);
-            jet.set_smearedPtUp(INVALID_VALUE);
-            jet.set_smearedPtDown(INVALID_VALUE);
+            jet.set_smearedPt(    jet.pt());
+            jet.set_smearedPtUp(  jet.pt());
+            jet.set_smearedPtDown(jet.pt());
           }
 
         } // if no matched genJet

--- a/Collections/plugins/OSUGenericJetProducer.cc
+++ b/Collections/plugins/OSUGenericJetProducer.cc
@@ -19,6 +19,7 @@ OSUGenericJetProducer<T>::OSUGenericJetProducer (const edm::ParameterSet &cfg) :
   jetResolutionPayload_ (cfg.getParameter<string> ("jetResolutionPayload")),
   jetResSFPayload_      (cfg.getParameter<string> ("jetResSFPayload")),
   jetResFromGlobalTag_  (cfg.getParameter<bool> ("jetResFromGlobalTag")),
+  jetResNewPrescription_ (cfg.getParameter<bool> ("jetResNewPrescription")),
   cfg_         (cfg)
 {
   collection_ = collections_.getParameter<edm::InputTag> ("jets");
@@ -266,24 +267,49 @@ OSUGenericJetProducer<T>::produce (edm::Event &event, const edm::EventSetup &set
           double dR = deltaR (genjet, jet);
           double dPt = jet.pt() - genjet.pt();
 
-          if(dR < 0.2 && fabs(dPt) < 3.0 * jet.jer()) {
-            jet.set_smearedPt(max(0.0, genjet.pt() + jet.jerSF() * dPt));
-            jet.set_smearedPtUp(max(0.0, genjet.pt() + jet.jerSFUp() * dPt));
-            jet.set_smearedPtDown(max(0.0, genjet.pt() + jet.jerSFDown() * dPt));
-
-            isMatchedToGenJet = true;
-            break;
+          if(jetResNewPrescription_) {
+            // https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_25/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L237
+            if(dR < 0.2 && fabs(dPt) < 3.0 * jet.pt() * jet.jer()) {
+              // smearFactor = 1 + (jet.jerSF() - 1.) * dPt / jet.pt();
+              jet.set_smearedPt(    max(0.0, jet.pt() + (jet.jerSF()     - 1.) * dPt));
+              jet.set_smearedPtUp(  max(0.0, jet.pt() + (jet.jerSFUp()   - 1.) * dPt));
+              jet.set_smearedPtDown(max(0.0, jet.pt() + (jet.jerSFDown() - 1.) * dPt));
+              isMatchedToGenJet = true;
+              break;
+            }
           }
-        }
+          else {
+            if(dR < 0.2 && fabs(dPt) < 3.0 * jet.jer()) {
+              jet.set_smearedPt(    max(0.0, genjet.pt() + jet.jerSF()     * dPt));
+              jet.set_smearedPtUp(  max(0.0, genjet.pt() + jet.jerSFUp()   * dPt));
+              jet.set_smearedPtDown(max(0.0, genjet.pt() + jet.jerSFDown() * dPt));
+              isMatchedToGenJet = true;
+              break;
+            }
+          }
+            
+        } // for genjets
+
         if(!isMatchedToGenJet) {
 
           if(jet.jerSF() > 1.0) {
-            double smearedPt = rng->Gaus(jet.pt(),
-                                         sqrt(jet.jerSF() * jet.jerSF() - 1) * jet.jer());
+            if(jetResNewPrescription_) {
+              // https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_25/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L244
+              double sigma = jet.jer() * sqrt(jet.jerSF() * jet.jerSF() - 1.);
+              // smearFactor = 1. + Gaus(0, sigma);
+              double smearedPt = jet.pt() * (1.0 + rng->Gaus(0.0, sigma));
+              jet.set_smearedPt(    smearedPt);
+              jet.set_smearedPtUp(  smearedPt * jet.jerSFUp() / jet.jerSF());
+              jet.set_smearedPtDown(smearedPt * jet.jerSFDown() / jet.jerSF());
+            }
+            else {
+              double smearedPt = rng->Gaus(jet.pt(),
+                                           sqrt(jet.jerSF() * jet.jerSF() - 1) * jet.jer());
 
-            jet.set_smearedPt(smearedPt);
-            jet.set_smearedPtUp(smearedPt * jet.jerSFUp() / jet.jerSF());
-            jet.set_smearedPtDown(smearedPt * jet.jerSFDown() / jet.jerSF());
+              jet.set_smearedPt(smearedPt);
+              jet.set_smearedPtUp(smearedPt * jet.jerSFUp() / jet.jerSF());
+              jet.set_smearedPtDown(smearedPt * jet.jerSFDown() / jet.jerSF());
+            }
           }
           else {
             jet.set_smearedPt(INVALID_VALUE);
@@ -291,6 +317,17 @@ OSUGenericJetProducer<T>::produce (edm::Event &event, const edm::EventSetup &set
             jet.set_smearedPtDown(INVALID_VALUE);
           }
 
+        } // if no matched genJet
+
+        // https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_25/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L255
+        if(jetResNewPrescription_ && jet.energy() * jet.smearedPt() / jet.pt() < 1.e-2) {
+          // Negative or too small smearFactor. We would change direction of the jet
+          // and this is not what we want.
+          // Recompute the smearing factor in order to have jet.energy() == MIN_JET_ENERGY (1.e-2)
+          double newSmearFactor = 1.e-2 / jet.energy();
+          jet.set_smearedPt(    newSmearFactor * jet.pt());
+          jet.set_smearedPtUp(  newSmearFactor * jet.pt() * jet.jerSFUp()   / jet.jerSF());
+          jet.set_smearedPtDown(newSmearFactor * jet.pt() * jet.jerSFDown() / jet.jerSF());
         }
 
       } // if(hasGenjets)

--- a/Collections/plugins/OSUGenericJetProducer.h
+++ b/Collections/plugins/OSUGenericJetProducer.h
@@ -38,6 +38,7 @@ class OSUGenericJetProducer : public edm::EDProducer
   string jetResolutionPayload_;
   string jetResSFPayload_;
   bool jetResFromGlobalTag_;
+  bool jetResNewPrescription_;
 
   edm::EDGetTokenT<vector<TYPE(jets)> > token_;
   edm::EDGetTokenT<vector<osu::Mcparticle> > mcparticleToken_;

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -132,10 +132,12 @@ collectionProducer.jets = cms.EDProducer ("OSUJetProducer",
     jetResolutionPayload = cms.string(os.environ['CMSSW_BASE'] + "/src/OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_PtResolution_AK4PFchs.txt"),
     jetResSFPayload = cms.string(os.environ['CMSSW_BASE'] + "/src/OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_SF_AK4PFchs.txt"),
     jetResFromGlobalTag = cms.bool(False),
+    jetResNewPrescription = cms.bool(False),
 )
 
-if 'CMSSW_8' in os.environ['CMSSW_VERSION']:
+if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     collectionProducer.jets.jetResFromGlobalTag = cms.bool(True)
+    collectionProducer.jets.jetResNewPrescription = cms.bool(True)
 
 copyConfiguration (collectionProducer.jets, collectionProducer.genMatchables)
 


### PR DESCRIPTION
https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution#Smearing_procedures

The prescription from JME has changed, and these are implemented here. There is a flag available to toggle the old behavior, but the default is to use the previous method in 2015 and new method in 2016-8.

Also the flag to use JER from the global tag was only set to true for 2016, so 2017 users were using 2015 text file payloads for JER. The GT is now used in 2016-8.