### PR TITLE
Define QCD xsecs2017

### DIFF
--- a/AnaTools/interface/CommonUtils.h
+++ b/AnaTools/interface/CommonUtils.h
@@ -272,11 +272,15 @@ anatools::getObjectHash(const T& object){
 template<class T> bool
 anatools::jetPassesTightLepVeto (const T &jet)
 {
-  // Taken from recommendations from the JetMET group for 13 TeV:
+#if CMSSW_VERSION_CODE >= CMSSW_VERSION(9,4,0)
+  // https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2017
+  return (((jet.neutralHadronEnergyFraction()<0.90 && jet.neutralEmEnergyFraction()<0.90 && (jet.chargedMultiplicity() + jet.neutralMultiplicity())>1 && jet.muonEnergyFraction()<0.8) && ((fabs(jet.eta())<=2.4 && jet.chargedHadronEnergyFraction()>0 && jet.chargedMultiplicity()>0 && jet.chargedEmEnergyFraction()<0.80) || fabs(jet.eta())>2.4) && fabs(jet.eta())<=3.0)
+    || (jet.neutralEmEnergyFraction()<0.90 && jet.neutralMultiplicity()>10 && fabs(jet.eta())>3.0));
+#else
   // https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID#Recommendations_for_13_TeV_data
-  //
   return (((jet.neutralHadronEnergyFraction()<0.90 && jet.neutralEmEnergyFraction()<0.90 && (jet.chargedMultiplicity() + jet.neutralMultiplicity())>1 && jet.muonEnergyFraction()<0.8) && ((fabs(jet.eta())<=2.4 && jet.chargedHadronEnergyFraction()>0 && jet.chargedMultiplicity()>0 && jet.chargedEmEnergyFraction()<0.90) || fabs(jet.eta())>2.4) && fabs(jet.eta())<=3.0)
     || (jet.neutralEmEnergyFraction()<0.90 && jet.neutralMultiplicity()>10 && fabs(jet.eta())>3.0));
+#endif
 }
 
 template<class T> bool

--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -9232,7 +9232,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
   crossSections['QCD_50to80']     = 19204300
   crossSections['QCD_80to120']    = 2762530
   crossSections['QCD_120to170']   = 471100
-  crossSections['QCD_170to300']   = 19204300
+  crossSections['QCD_170to300']   = 117276 # pdmv has the CP5 93X xsec wrong, using /QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8/RunIISummer15GS-MCRUN2_71_V1_ext1-v1/GEN-SIM the other samples have the same xsecs
   crossSections['QCD_300to470']   = 7823
   crossSections['QCD_470to600']   = 648.2
   crossSections['QCD_600to800']   = 186.9

--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -9226,6 +9226,23 @@ crossSections = {
     'stopToLD1000_100mm': 0.00615134,
 }
 
+if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
+  crossSections['QCD_15to30']     = 1837410000
+  crossSections['QCD_30to50']     = 140932000
+  crossSections['QCD_50to80']     = 19204300
+  crossSections['QCD_80to120']    = 2762530
+  crossSections['QCD_120to170']   = 471100
+  crossSections['QCD_170to300']   = 19204300
+  crossSections['QCD_300to470']   = 7823
+  crossSections['QCD_470to600']   = 648.2
+  crossSections['QCD_600to800']   = 186.9
+  crossSections['QCD_800to1000']  = 32.293
+  crossSections['QCD_1000to1400'] = 9.4183
+  crossSections['QCD_1400to1800'] = 0.84265
+  crossSections['QCD_1800to2400'] = 0.114943
+  crossSections['QCD_2400to3200'] = 0.00682981
+  crossSections['QCD_3200toInf']  = 0.000165445
+
 InputCondorArguments = {}
 
 pdgIdsForLifetimeReweighting = {


### PR DESCRIPTION
These aren't stored on the T3 in the database for 2017, so must be defined here. Taken from pdmv:

https://cms-pdmv.cern.ch/mcm/requests?produce=%2FQCD_Pt_*_TuneCP5_13TeV_pythia8%2FRunIIFall17GS-93X_mc2017_realistic_v3-v1%2FGEN-SIM&page=0&shown=1048703