### PR TITLE
Weight histograms using "optional_dict_ntupleEff".

### DIFF
--- a/Configuration/python/mergeUtilities.py
+++ b/Configuration/python/mergeUtilities.py
@@ -488,8 +488,9 @@ def mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir="", optional_dict_ntu
     if crossSection > 0 and IntLumi > 0:
         if runOverSkim and float(datasetInfo.originalNumberOfEvents)*float(TotalNumber):
             Weight = IntLumi*crossSection*nTupleEff*float(datasetInfo.skimNumberOfEvents)/(float(datasetInfo.originalNumberOfEvents)*float(TotalNumber))
-            # The factor TotalNumber / skimNumberOfEvents corresponds to the fraction of skim events that were actually processed,
-            # i.e., it accounts for the fact that perhaps not all of the jobs finished successfully.
+            # TotalNumber: number of events actually processed
+            # skimNumberOfEvents / originalNumberOfEvents: efficiency for events to have made it into the skim that we are running over
+            # nTupleEff: efficiency for events to have made it into the ntuples that we originally made skims from
         elif float(TotalNumber):
             Weight = IntLumi*crossSection*nTupleEff/float(TotalNumber)
     InputWeightString = MakeWeightsString(Weight, GoodRootFiles)

--- a/Configuration/scripts/mergeOut.py
+++ b/Configuration/scripts/mergeOut.py
@@ -75,12 +75,15 @@ if arguments.IntLumi is not "":
 split_datasets     = list(set(split_datasets))
 composite_datasets = list(set(composite_datasets))
 
+if "optional_dict_ntupleEff" not in locals () and "optional_dict_ntupleEff" not in globals ():
+    optional_dict_ntupleEff = {}
+
 currentCondorSubArgumentsSet = {}
 if arguments.verbose:
     print "List of datasets: ", split_datasets
 if not arguments.compositeOnly and not arguments.UseCondor:
     for dataSet in split_datasets:
-        mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir, verbose = arguments.verbose, skipMerging = arguments.skipMerging)
+        mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir, optional_dict_ntupleEff, verbose = arguments.verbose, skipMerging = arguments.skipMerging)
 
 if arguments.UseCondor:
     # Make necessary files for condor and submit condor jobs.
@@ -88,7 +91,7 @@ if arguments.UseCondor:
     currentCondorSubArgumentsSet = copy.deepcopy(CondorSubArgumentsSet)
     GetCompleteOrderedArgumentsSet(InputCondorArguments, currentCondorSubArgumentsSet)
     MakeSubmissionScriptForMerging(CondorDir, currentCondorSubArgumentsSet, split_datasets)
-    MakeMergingConfigForCondor(CondorDir, OutputDir, split_datasets, IntLumi)
+    MakeMergingConfigForCondor(CondorDir, OutputDir, split_datasets, IntLumi, optional_dict_ntupleEff)
     os.chdir(CondorDir)
     if arguments.NotToExecute:
         print 'Configuration files created in ' + str(CondorDir) + ' directory but no jobs submitted.\n'


### PR DESCRIPTION
The user can include an optional dictionary called "optional_dict_ntupleEff" in their local config file, with dataset names as keys and floating point numbers as values. The values are used to weight the corresponding datasets during merging.

The intended use case of this dictionary is to provide skim efficiencies for skims that are produced outside the usual skim framework, e.g., during ntuple making.

There is no change in merging behavior if no "optional_dict_ntupleEff" is provided.