### PR TITLE
invMass operation modified for track with zero-mass assumption

### DIFF
--- a/AnaTools/src/ValueLookupTree.cc
+++ b/AnaTools/src/ValueLookupTree.cc
@@ -800,7 +800,12 @@ ValueLookupTree::evaluateOperator (const string &op, const vector<Leaf> &operand
 
           for (const auto &operand : operands)
             {
-              energy += valueLookup (boost::get<string> (operand) + "s", objs, "energy");
+	      if( boost::get<string> (operand) == "track" ){
+                energy += valueLookup (boost::get<string> (operand) + "s", objs, "p");
+              }
+              else{
+                energy += valueLookup (boost::get<string> (operand) + "s", objs, "energy");
+              }
               px += valueLookup (boost::get<string> (operand) + "s", objs, "px", false);
               py += valueLookup (boost::get<string> (operand) + "s", objs, "py", false);
               pz += valueLookup (boost::get<string> (operand) + "s", objs, "pz", false);

--- a/AnaTools/src/ValueLookupTree.cc
+++ b/AnaTools/src/ValueLookupTree.cc
@@ -800,6 +800,8 @@ ValueLookupTree::evaluateOperator (const string &op, const vector<Leaf> &operand
 
           for (const auto &operand : operands)
             {
+	      // As the track collection does not have measured energy associated to it,
+	      // we assume tracks are massless while calculating invariant mass.
 	      if( boost::get<string> (operand) == "track" ){
                 energy += valueLookup (boost::get<string> (operand) + "s", objs, "p");
               }


### PR DESCRIPTION
In "invMass" operation, if inputCollection is track, track.p is called as track.energy.