### PR TITLE
Initialize the lifetime weights to one for every event

### DIFF
--- a/AnaTools/plugins/LifetimeWeightProducer.cc
+++ b/AnaTools/plugins/LifetimeWeightProducer.cc
@@ -50,6 +50,8 @@ void
 LifetimeWeightProducer::AddVariables(const edm::Event &event) {
 
 #ifndef STOPPPED_PTLS
+  for(unsigned int iRule = 0; iRule < weights_.size(); iRule++) weights_[iRule] = 1.0;
+
   edm::Handle<vector<TYPE(hardInteractionMcparticles)> > mcparticles;
   if(!event.getByToken(mcparticlesToken_, mcparticles)) {
     // Save the weights


### PR DESCRIPTION
Was continuously multiplying the weights across events...whoops.