### PR TITLE
Add2018ele trigger match

### DIFF
--- a/Collections/interface/Electron.h
+++ b/Collections/interface/Electron.h
@@ -35,7 +35,7 @@ namespace osu
         const int missingMiddleHitsFromTrackerLayersWithoutMeasurements () const;
         const int missingOuterHitsFromTrackerLayersWithoutMeasurements () const;
 
-        const bool passesTightID_noIsolation () const;
+        const bool passesTightID_noIsolation_LegacySpring15 () const;
 
         const bool passesVID_vetoID () const;
         const bool passesVID_looseID () const;
@@ -44,6 +44,7 @@ namespace osu
 
         const bool match_HLT_Ele25_eta2p1_WPTight_Gsf_v () const;
         const bool match_HLT_Ele22_eta2p1_WPLoose_Gsf_v () const;
+        const bool match_HLT_Ele32_WPTight_Gsf_v () const;
         const bool match_HLT_Ele35_WPTight_Gsf_v () const;
 
         void set_rho (float value) { rho_  = value; }
@@ -54,13 +55,14 @@ namespace osu
         void set_electronPVIndex (int value) { electronPVIndex_  = value; };
         void set_genD0 (double value) { genD0_  = value; };
         void set_d0SmearingVal (double value) { d0SmearingVal_  = value; };
-        void set_passesTightID_noIsolation (const reco::BeamSpot &, const TYPE(primaryvertexs) &, const edm::Handle<vector<reco::Conversion> > &);
+        void set_passesTightID_noIsolation_LegacySpring15 (const reco::BeamSpot &, const TYPE(primaryvertexs) &, const edm::Handle<vector<reco::Conversion> > &);
         void set_passesVID_vetoID (const bool);
         void set_passesVID_looseID (const bool);
         void set_passesVID_mediumID (const bool);
         void set_passesVID_tightID (const bool);
         void set_match_HLT_Ele25_eta2p1_WPTight_Gsf_v (const bool);
         void set_match_HLT_Ele22_eta2p1_WPLoose_Gsf_v (const bool);
+        void set_match_HLT_Ele32_WPTight_Gsf_v (const bool);
         void set_match_HLT_Ele35_WPTight_Gsf_v (const bool);
 
         const double metMinusOnePt () const;
@@ -103,7 +105,7 @@ namespace osu
         double sumPUPtCorr_;
         double genD0_;
         double d0SmearingVal_;
-        bool passesTightID_noIsolation_;
+        bool passesTightID_noIsolation_LegacySpring15_;
 
         bool passesVID_vetoID_;
         bool passesVID_looseID_;
@@ -112,6 +114,7 @@ namespace osu
 
         bool match_HLT_Ele25_eta2p1_WPTight_Gsf_v_;
         bool match_HLT_Ele22_eta2p1_WPLoose_Gsf_v_;
+        bool match_HLT_Ele32_WPTight_Gsf_v_;
         bool match_HLT_Ele35_WPTight_Gsf_v_;
 
         double metMinusOnePt_;

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -113,7 +113,7 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
         electron.set_rho((float)(*rho));
 
       if(beamspot.isValid() && conversions.isValid() && vertices.isValid() && !vertices->empty ())
-        electron.set_passesTightID_noIsolation (*beamspot, vertices->at (0), conversions);
+        electron.set_passesTightID_noIsolation_LegacySpring15 (*beamspot, vertices->at (0), conversions);
 
       if(vidVetoIdMap.isValid())
         electron.set_passesVID_vetoID ( (*vidVetoIdMap)[(*collection).refAt(iEle)] );
@@ -131,6 +131,7 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
         {
           electron.set_match_HLT_Ele25_eta2p1_WPTight_Gsf_v (anatools::isMatchedToTriggerObject (event, *triggers, object, *trigobjs, "hltEgammaCandidates::HLT", "hltEle25erWPTightGsfTrackIsoFilter"));
           electron.set_match_HLT_Ele22_eta2p1_WPLoose_Gsf_v (anatools::isMatchedToTriggerObject (event, *triggers, object, *trigobjs, "hltEgammaCandidates::HLT", "hltSingleEle22WPLooseGsfTrackIsoFilter"));
+          electron.set_match_HLT_Ele32_WPTight_Gsf_v        (anatools::isMatchedToTriggerObject (event, *triggers, object, *trigobjs, "hltEgammaCandidates::HLT", "hltEle32WPTightGsfTrackIsoFilter"));
           electron.set_match_HLT_Ele35_WPTight_Gsf_v        (anatools::isMatchedToTriggerObject (event, *triggers, object, *trigobjs, "hltEgammaCandidates::HLT", "hltEle35noerWPTightGsfTrackIsoFilter"));
         }
 

--- a/Collections/src/Electron.cc
+++ b/Collections/src/Electron.cc
@@ -295,26 +295,26 @@ osu::Electron::set_passesTightID_noIsolation_LegacySpring15 (const reco::BeamSpo
 
   // not 94X -- actually corresponds to https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2Archive#Spring15_selection_25ns
   if (fabs (this->superCluster ()->eta ()) <= 1.479) {
-      passesTightID_noIsolation_ = (this->full5x5_sigmaIetaIeta ()                                                        <   0.0101  &&
-                                    fabs (this->deltaEtaSuperClusterTrackAtVtx ())                                        <   0.00926 &&
-                                    fabs (this->deltaPhiSuperClusterTrackAtVtx ())                                        <   0.0336  &&
-                                    this->hadronicOverEm ()                                                               <   0.0597  &&
-                                    fabs (1.0 / this->ecalEnergy () - this->eSuperClusterOverP () / this->ecalEnergy ())  <   0.012   &&
-                                    fabs (this->gsfTrack ()->dxy (vertex.position ()))                                    <   0.0111  &&
-                                    fabs (this->gsfTrack ()->dz (vertex.position ()))                                     <   0.0466  &&
-                                    this->gsfTrack ()->hitPattern ().numberOfHits (reco::HitPattern::MISSING_INNER_HITS)  <=  2       &&
-                                    !ConversionTools::hasMatchedConversion (*this, conversions, beamspot.position ()));
+      passesTightID_noIsolation_LegacySpring15_ = (this->full5x5_sigmaIetaIeta ()                                                        <   0.0101  &&
+                                                   fabs (this->deltaEtaSuperClusterTrackAtVtx ())                                        <   0.00926 &&
+                                                   fabs (this->deltaPhiSuperClusterTrackAtVtx ())                                        <   0.0336  &&
+                                                   this->hadronicOverEm ()                                                               <   0.0597  &&
+                                                   fabs (1.0 / this->ecalEnergy () - this->eSuperClusterOverP () / this->ecalEnergy ())  <   0.012   &&
+                                                   fabs (this->gsfTrack ()->dxy (vertex.position ()))                                    <   0.0111  &&
+                                                   fabs (this->gsfTrack ()->dz (vertex.position ()))                                     <   0.0466  &&
+                                                   this->gsfTrack ()->hitPattern ().numberOfHits (reco::HitPattern::MISSING_INNER_HITS)  <=  2       &&
+                                                   !ConversionTools::hasMatchedConversion (*this, conversions, beamspot.position ()));
   }
   else if (fabs (this->superCluster ()->eta ()) < 2.5) {
-      passesTightID_noIsolation_ = (this->full5x5_sigmaIetaIeta ()                                                        <   0.0279  &&
-                                    fabs (this->deltaEtaSuperClusterTrackAtVtx ())                                        <   0.00724 &&
-                                    fabs (this->deltaPhiSuperClusterTrackAtVtx ())                                        <   0.0918  &&
-                                    this->hadronicOverEm ()                                                               <   0.0615  &&
-                                    fabs (1.0 / this->ecalEnergy () - this->eSuperClusterOverP () / this->ecalEnergy ())  <   0.00999 &&
-                                    fabs (this->gsfTrack ()->dxy (vertex.position ()))                                    <   0.0351  &&
-                                    fabs (this->gsfTrack ()->dz (vertex.position ()))                                     <   0.417   &&
-                                    this->gsfTrack ()->hitPattern ().numberOfHits (reco::HitPattern::MISSING_INNER_HITS)  <=  1       &&
-                                    !ConversionTools::hasMatchedConversion (*this, conversions, beamspot.position ()));
+      passesTightID_noIsolation_LegacySpring15_ = (this->full5x5_sigmaIetaIeta ()                                                        <   0.0279  &&
+                                                   fabs (this->deltaEtaSuperClusterTrackAtVtx ())                                        <   0.00724 &&
+                                                   fabs (this->deltaPhiSuperClusterTrackAtVtx ())                                        <   0.0918  &&
+                                                   this->hadronicOverEm ()                                                               <   0.0615  &&
+                                                   fabs (1.0 / this->ecalEnergy () - this->eSuperClusterOverP () / this->ecalEnergy ())  <   0.00999 &&
+                                                   fabs (this->gsfTrack ()->dxy (vertex.position ()))                                    <   0.0351  &&
+                                                   fabs (this->gsfTrack ()->dz (vertex.position ()))                                     <   0.417   &&
+                                                   this->gsfTrack ()->hitPattern ().numberOfHits (reco::HitPattern::MISSING_INNER_HITS)  <=  1       &&
+                                                   !ConversionTools::hasMatchedConversion (*this, conversions, beamspot.position ()));
   }
 }
 

--- a/Collections/src/Electron.cc
+++ b/Collections/src/Electron.cc
@@ -27,6 +27,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron) :
   passesVID_tightID_                    (false),
   match_HLT_Ele25_eta2p1_WPTight_Gsf_v_ (false),
   match_HLT_Ele22_eta2p1_WPLoose_Gsf_v_ (false),
+  match_HLT_Ele32_WPTight_Gsf_v_        (false),
   match_HLT_Ele35_WPTight_Gsf_v_        (false),
   metMinusOnePt_                        (INVALID_VALUE),
   metMinusOnePx_                        (INVALID_VALUE),
@@ -63,6 +64,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   passesVID_tightID_                    (false),
   match_HLT_Ele25_eta2p1_WPTight_Gsf_v_ (false),
   match_HLT_Ele22_eta2p1_WPLoose_Gsf_v_ (false),
+  match_HLT_Ele32_WPTight_Gsf_v_        (false),
   match_HLT_Ele35_WPTight_Gsf_v_        (false),
   metMinusOnePt_                        (INVALID_VALUE),
   metMinusOnePx_                        (INVALID_VALUE),
@@ -99,6 +101,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   passesVID_tightID_                    (false),
   match_HLT_Ele25_eta2p1_WPTight_Gsf_v_ (false),
   match_HLT_Ele22_eta2p1_WPLoose_Gsf_v_ (false),
+  match_HLT_Ele32_WPTight_Gsf_v_        (false),
   match_HLT_Ele35_WPTight_Gsf_v_        (false),
   metMinusOnePt_                        (INVALID_VALUE),
   metMinusOnePx_                        (INVALID_VALUE),
@@ -135,6 +138,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   passesVID_tightID_                    (false),
   match_HLT_Ele25_eta2p1_WPTight_Gsf_v_ (false),
   match_HLT_Ele22_eta2p1_WPLoose_Gsf_v_ (false),
+  match_HLT_Ele32_WPTight_Gsf_v_        (false),
   match_HLT_Ele35_WPTight_Gsf_v_        (false),
   metMinusOnePt_                        (INVALID_VALUE),
   metMinusOnePx_                        (INVALID_VALUE),
@@ -279,42 +283,16 @@ osu::Electron::d0SmearingVal () const
 }
 
 const bool
-osu::Electron::passesTightID_noIsolation () const
+osu::Electron::passesTightID_noIsolation_LegacySpring15 () const
 {
-  return passesTightID_noIsolation_;
+  return passesTightID_noIsolation_LegacySpring15_;
 }
 
 void
-osu::Electron::set_passesTightID_noIsolation (const reco::BeamSpot &beamspot, const TYPE(primaryvertexs) &vertex, const edm::Handle<vector<reco::Conversion> > &conversions)
+osu::Electron::set_passesTightID_noIsolation_LegacySpring15 (const reco::BeamSpot &beamspot, const TYPE(primaryvertexs) &vertex, const edm::Handle<vector<reco::Conversion> > &conversions)
 {
-  passesTightID_noIsolation_ = false;
+  passesTightID_noIsolation_LegacySpring15_ = false;
 
-#if CMSSW_VERSION_CODE >= CMSSW_VERSION(9,4,0)
-  // https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Offline_selection_criteria
-  if (fabs (this->superCluster ()->eta ()) <= 1.479) {
-      passesTightID_noIsolation_ = (this->full5x5_sigmaIetaIeta ()                                                           <   0.0104  &&
-                                    fabs (this->dEtaInSeed ())                                                               <   0.00353 &&
-                                    fabs (this->deltaPhiSuperClusterTrackAtVtx ())                                           <   0.0499  &&
-                                    pass_GsfEleHadronicOverEMEnergyScaledCut (0.026, 1.12, 0.0368)                                       &&
-                                    fabs (1.0 / this->ecalEnergy () - this->eSuperClusterOverP () / this->ecalEnergy ())     <   0.0278  &&
-                                    fabs (this->gsfTrack ()->dxy (vertex.position ()))                                       <   0.05    &&
-                                    fabs (this->gsfTrack ()->dz (vertex.position ()))                                        <   0.10    &&
-                                    this->gsfTrack ()->hitPattern ().numberOfLostHits (reco::HitPattern::MISSING_INNER_HITS) <=  1       &&
-                                    !ConversionTools::hasMatchedConversion (*this, conversions, beamspot.position ()));
-  }
-  else if (fabs (this->superCluster ()->eta ()) < 2.5) {
-      passesTightID_noIsolation_ = (this->full5x5_sigmaIetaIeta ()                                                           <   0.0305  &&
-                                    fabs (this->dEtaInSeed ())                                                               <   0.00567 &&
-                                    fabs (this->deltaPhiSuperClusterTrackAtVtx ())                                           <   0.0165  &&
-                                    pass_GsfEleHadronicOverEMEnergyScaledCut (0.026, 0.5, 0.201)                                         &&
-                                    fabs (1.0 / this->ecalEnergy () - this->eSuperClusterOverP () / this->ecalEnergy ())     <   0.0158  &&
-                                    fabs (this->gsfTrack ()->dxy (vertex.position ()))                                       <   0.10    &&
-                                    fabs (this->gsfTrack ()->dz (vertex.position ()))                                        <   0.20    &&
-                                    this->gsfTrack ()->hitPattern ().numberOfLostHits (reco::HitPattern::MISSING_INNER_HITS) <=  1       &&
-                                    !ConversionTools::hasMatchedConversion (*this, conversions, beamspot.position ()));
-    }
-
-#else 
   // not 94X -- actually corresponds to https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2Archive#Spring15_selection_25ns
   if (fabs (this->superCluster ()->eta ()) <= 1.479) {
       passesTightID_noIsolation_ = (this->full5x5_sigmaIetaIeta ()                                                        <   0.0101  &&
@@ -338,7 +316,6 @@ osu::Electron::set_passesTightID_noIsolation (const reco::BeamSpot &beamspot, co
                                     this->gsfTrack ()->hitPattern ().numberOfHits (reco::HitPattern::MISSING_INNER_HITS)  <=  1       &&
                                     !ConversionTools::hasMatchedConversion (*this, conversions, beamspot.position ()));
   }
-#endif // if/else 94X
 }
 
 void 
@@ -411,6 +388,19 @@ void
 osu::Electron::set_match_HLT_Ele22_eta2p1_WPLoose_Gsf_v (const bool flag)
 {
   match_HLT_Ele22_eta2p1_WPLoose_Gsf_v_ = flag;
+}
+
+
+const bool
+osu::Electron::match_HLT_Ele32_WPTight_Gsf_v () const
+{
+  return match_HLT_Ele32_WPTight_Gsf_v_;
+}
+
+void
+osu::Electron::set_match_HLT_Ele32_WPTight_Gsf_v (const bool flag)
+{
+  match_HLT_Ele32_WPTight_Gsf_v_ = flag;
 }
 
 const bool

--- a/Collections/src/Electron.cc
+++ b/Collections/src/Electron.cc
@@ -20,7 +20,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron) :
   sumPUPtCorr_                          (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
   d0SmearingVal_                        (INVALID_VALUE),
-  passesTightID_noIsolation_            (false),
+  passesTightID_noIsolation_LegacySpring15_ (false),
   passesVID_vetoID_                     (false),
   passesVID_looseID_                    (false),
   passesVID_mediumID_                   (false),
@@ -57,7 +57,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   sumPUPtCorr_                          (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
   d0SmearingVal_                        (INVALID_VALUE),
-  passesTightID_noIsolation_            (false),
+  passesTightID_noIsolation_LegacySpring15_ (false),
   passesVID_vetoID_                     (false),
   passesVID_looseID_                    (false),
   passesVID_mediumID_                   (false),
@@ -94,7 +94,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   sumPUPtCorr_                          (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
   d0SmearingVal_                        (INVALID_VALUE),
-  passesTightID_noIsolation_            (false),
+  passesTightID_noIsolation_LegacySpring15_ (false),
   passesVID_vetoID_                     (false),
   passesVID_looseID_                    (false),
   passesVID_mediumID_                   (false),
@@ -131,7 +131,7 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   sumPUPtCorr_                          (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
   d0SmearingVal_                        (INVALID_VALUE),
-  passesTightID_noIsolation_            (false),
+  passesTightID_noIsolation_LegacySpring15_ (false),
   passesVID_vetoID_                     (false),
   passesVID_looseID_                    (false),
   passesVID_mediumID_                   (false),
@@ -293,6 +293,7 @@ osu::Electron::set_passesTightID_noIsolation_LegacySpring15 (const reco::BeamSpo
 {
   passesTightID_noIsolation_LegacySpring15_ = false;
 
+#if CMSSW_VERSION_CODE < CMSSW_VERSION(9,0,0)
   // not 94X -- actually corresponds to https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2Archive#Spring15_selection_25ns
   if (fabs (this->superCluster ()->eta ()) <= 1.479) {
       passesTightID_noIsolation_LegacySpring15_ = (this->full5x5_sigmaIetaIeta ()                                                        <   0.0101  &&
@@ -316,6 +317,8 @@ osu::Electron::set_passesTightID_noIsolation_LegacySpring15 (const reco::BeamSpo
                                                    this->gsfTrack ()->hitPattern ().numberOfHits (reco::HitPattern::MISSING_INNER_HITS)  <=  1       &&
                                                    !ConversionTools::hasMatchedConversion (*this, conversions, beamspot.position ()));
   }
+#endif
+
 }
 
 void 

--- a/Collections/src/TrackBase.cc
+++ b/Collections/src/TrackBase.cc
@@ -206,8 +206,8 @@ osu::TrackBase::TrackBase (const TYPE(tracks) &track,
         deltaRToClosestPFElectron_ = dR;
 
       else if(pdgid == 13 &&
-              (dR < deltaRToClosestPFMuon_ || deltaRToClosestPFElectron_ < 0.0))
-        deltaRToClosestPFElectron_ = dR;
+              (dR < deltaRToClosestPFMuon_ || deltaRToClosestPFMuon_ < 0.0))
+        deltaRToClosestPFMuon_ = dR;
 
       else if(pdgid == 211 &&
               (dR < deltaRToClosestPFChHad_ || deltaRToClosestPFChHad_ < 0.0))

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -287,8 +287,8 @@ if osusub.batchMode and types[osusub.datasetLabel] == "data":
         collectionProducer.tracks.fiducialMaps.electrons[0].era = cms.string (osusub.datasetLabel[osusub.datasetLabel.find('_201'):])
         collectionProducer.tracks.fiducialMaps.muons[0].era = cms.string (osusub.datasetLabel[osusub.datasetLabel.find('_201'):])
 
-# For 94X which uses electron VIDs, define the vertexing requirements for veto electrons
-if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
+# For 94X/102X which use electron VIDs, define the vertexing requirements for veto electrons
+if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     # Cut values are ordered by ID, as: veto, loose, medium, tight
     # https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Working_points_for_92X_and_later
     collectionProducer.tracks.eleVtx_d0Cuts_barrel = cms.vdouble(0.05, 0.05, 0.05, 0.05)

--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -9349,7 +9349,7 @@ crossSections = {
     'stopToLD1000_100mm': 0.00615134,
 }
 
-if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
+if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
   crossSections['QCD_15to30']     = 1837410000
   crossSections['QCD_30to50']     = 140932000
   crossSections['QCD_50to80']     = 19204300

--- a/Configuration/python/histogramDefinitions.py
+++ b/Configuration/python/histogramDefinitions.py
@@ -190,7 +190,8 @@ MuonHistograms = cms.PSet(
         ),
     )
 )
-if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
+
+if os.environ["CMSSW_VERSION"].startswith ("CMSSW_7_6_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
     MuonHistograms.histograms.append(
         cms.PSet (
             name = cms.string("muonGenMotherPdgId"),
@@ -199,7 +200,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
             inputVariables = cms.vstring("abs(genMatchedParticle.bestMatch.mother_.pdgId)"),
         ),
         )
-elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
+elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     MuonHistograms.histograms.append(
         cms.PSet (
             name = cms.string("muonGenMotherPdgId"),
@@ -498,7 +499,7 @@ ElectronHistograms = cms.PSet(
     )
 )
 
-if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
+if os.environ["CMSSW_VERSION"].startswith ("CMSSW_7_6_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
     ElectronHistograms.histograms.append(
         cms.PSet (
             name = cms.string("electronGenMotherPdgId"),
@@ -507,7 +508,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
             inputVariables = cms.vstring("abs(genMatchedParticle.bestMatch.mother_.pdgId)"),
         ),
         )
-elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
+elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     ElectronHistograms.histograms.append(
         cms.PSet (
             name = cms.string("electronGenMotherPdgId"),

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -923,7 +923,12 @@ def customizeMINIAODElectronVID(process, collections, usedCollections):
     if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
         my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff']
 
-    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
+    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
+        my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_cff']
+        if int(os.environ["CMSSW_VERSION"].split("_")[3]) >=9:
+            my_id_modules.extend(['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff'])
+
+    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
         my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff']
 
     # Setup all the desired modules to be run

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -920,16 +920,11 @@ def customizeMINIAODElectronVID(process, collections, usedCollections):
 
     my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff']
 
-    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
-        my_id_modules.extend(['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff'])
+    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
+        my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff']
 
-    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_"):
-        my_id_modules.extend(['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V1_cff'])
-        if int(os.environ["CMSSW_VERSION"].split("_")[3]) >=9:
-            my_id_modules.extend(['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff'])
-
-    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
-        my_id_modules.extend(['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff'])
+    if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
+        my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Fall17_94X_V2_cff']
 
     # Setup all the desired modules to be run
     for idmod in my_id_modules:


### PR DESCRIPTION
A few things:

1) Renamed `passesTightID_noIsolatedion` to be very clear about what it is -- the only group using this should be Disappearing Tracks if they need to go back to 2015-6. Otherwise this ID is quite deprecated, and the VIDs provide real IDs.
2) Adds a trigger match method for Ele32 which is present in 2018 data.
3) Fixes a mistake in the track class for matching to PF muons
4) Clarifies a few CMSSW version checks

Overall I've decided that for Issue #87, for now, I won't switch to this new `electron.electronID()` method. While it would make a few things simpler, it's turned out to be a bit uncertain which CMSSW releases will have which versions available, and if this will be compatible for all analyses. I think we have something that works now and I don't want to start breaking it too much.

This PR needs a little more checking, I'll comment when I'm done.