### PR TITLE
Add siblings as secondary files according to sibling_datasets dictionary.

### DIFF
--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -66,6 +66,7 @@ parser.add_option("--resubmit", dest="Resubmit", action="store_true", default = 
 parser.add_option("--redirector", dest="Redirector", default = "", help="Setup the redirector for xrootd service to use")
 parser.add_option("--extend", dest="Extend", action="store_true", default = False, help="Use unique random seeds for this job")  # See https://cmshead.mps.ohio-state.edu:8080/OSUT3Analysis/65
 parser.add_option("--inputDirectory", dest="inputDirectory", default = "", help="Specify the directory containing input files. Wildcards allowed.")
+parser.add_option("--forceRutgersMode", dest="forceRutgersMode", default = False, help="Force Rutgers mode for getSiblings to work properly.")
 
 (arguments, args) = parser.parse_args()
 
@@ -177,7 +178,7 @@ def getLatestJsonFile():
         if re.search('17$', arguments.JSONType):
             rerecoDir = 'ReReco'
         if re.search('18$', arguments.JSONType):
-            rerecoDir = 'Rereco'
+            rerecoDir = 'ReReco'
 
         if arguments.JSONType[:2] == 'P_':
             tmpDir = tempfile.mkdtemp ()
@@ -1176,7 +1177,7 @@ hostname = socket.getfqdn()
 remoteAccessT3 = ('interactive' not in hostname)
 lxbatch = ('cern.ch' in hostname)
 lpcCAF = ('fnal.gov' in hostname)
-rutgers = ('rutgers.edu' in hostname)
+rutgers = ('rutgers.edu' in hostname or arguments.forceRutgersMode)
 
 ################################################################################
 #             First of all to set up the working directory                     #

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -66,7 +66,7 @@ parser.add_option("--resubmit", dest="Resubmit", action="store_true", default = 
 parser.add_option("--redirector", dest="Redirector", default = "", help="Setup the redirector for xrootd service to use")
 parser.add_option("--extend", dest="Extend", action="store_true", default = False, help="Use unique random seeds for this job")  # See https://cmshead.mps.ohio-state.edu:8080/OSUT3Analysis/65
 parser.add_option("--inputDirectory", dest="inputDirectory", default = "", help="Specify the directory containing input files. Wildcards allowed.")
-parser.add_option("--forceRutgersMode", dest="forceRutgersMode", default = False, help="Force Rutgers mode for getSiblings to work properly.")
+parser.add_option("--forceRutgersMode", action="store_true", dest="forceRutgersMode", default = False, help="Force Rutgers mode for getSiblings to work properly.")
 
 (arguments, args) = parser.parse_args()
 

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -177,7 +177,7 @@ def getLatestJsonFile():
         if re.search('17$', arguments.JSONType):
             rerecoDir = 'ReReco'
         if re.search('18$', arguments.JSONType):
-            rerecoDir = 'ReReco'
+            rerecoDir = 'Rereco'
 
         if arguments.JSONType[:2] == 'P_':
             tmpDir = tempfile.mkdtemp ()


### PR DESCRIPTION
The intended use case here is that you have ntuples produced from a higher data tier, e.g., AOD, that contain a special collection not found in MINIAOD, e.g., tracks. And you want to run over these ntuples, using the standard MINIAOD collections for all of the other object types.

With the current changes, you can define a dictionary in your local config file called `sibling_datasets`, e.g.:
```python
sibling_datasets = {
    "MET_2018A" : "/MET/Run2018A-17Sep2018-v1/MINIAOD",
    "MET_2018B" : "/MET/Run2018B-17Sep2018-v1/MINIAOD",
    …
}
```
Then the config files that `osusub.py` generates will add the necessary files from the values of this dictionary to the secondary files in `process.source`.

If this dictionary is not defined, then the behavior is unchanged.