### PR TITLE
Extended siblings

### DIFF
--- a/DBTools/python/osusub_cfg.py
+++ b/DBTools/python/osusub_cfg.py
@@ -101,7 +101,7 @@ def getSiblings (fileName, dataset):
     # put the files of the target dataset in another set
     dataset = dbs3api_phys03.listFiles (dataset = dataset)
     for f in dataset:
-      miniaodSuperset.add (f["logical_file_name"])
+      miniaodSubset.add (f["logical_file_name"])
 
   # return the intersection of the two sets
   return list (miniaodSubset.intersection (miniaod))

--- a/DBTools/python/osusub_cfg.py
+++ b/DBTools/python/osusub_cfg.py
@@ -45,32 +45,63 @@ def getSiblings (fileName, dataset):
     i = fileName.find ("/store/")
     fileName = fileName[i:]
 
-  # first get the parents
-  parents = dbs3api_phys03.listFileParents (logical_file_name = fileName)
-
-  # for each of the parents, get the grandparents
-  grandparents = []
-  for parent in parents:
-    for parent_file_name in parent["parent_logical_file_name"]:
-      grandparents.extend (dbs3api_global.listFileParents (logical_file_name = parent_file_name))
-
-  # then for each of the grandparents, get their children
-  children = []
-  for grandparent in grandparents:
-    for grandparent_file_name in grandparent["parent_logical_file_name"]:
-      children.extend (dbs3api_global.listFileChildren (logical_file_name = grandparent_file_name))
-
-  # put the children in a set
   miniaod = set ([])
-  for child in children:
-    for child_file_name in child["child_logical_file_name"]:
-      miniaod.add (child_file_name)
+  miniaodSubset = set ([])
+  # if dataset is not a USER dataset, then assume the file comes from a USER dataset
+  if "/USER" not in dataset:
+    # first get the parents
+    parents = dbs3api_phys03.listFileParents (logical_file_name = fileName)
 
-  # put the files of the target dataset in another set
-  dataset = dbs3api_global.listFiles (dataset = dataset)
-  miniaodSuperset = set ([])
-  for f in dataset:
-    miniaodSuperset.add (f["logical_file_name"])
+    # for each of the parents, get the grandparents
+    grandparents = []
+    for parent in parents:
+      for parent_file_name in parent["parent_logical_file_name"]:
+        grandparents.extend (dbs3api_global.listFileParents (logical_file_name = parent_file_name))
+
+    # then for each of the grandparents, get their children
+    children = []
+    for grandparent in grandparents:
+      for grandparent_file_name in grandparent["parent_logical_file_name"]:
+        children.extend (dbs3api_global.listFileChildren (logical_file_name = grandparent_file_name))
+
+    # put the children in a set
+    for child in children:
+      for child_file_name in child["child_logical_file_name"]:
+        miniaod.add (child_file_name)
+
+    # put the files of the target dataset in another set
+    dataset = dbs3api_global.listFiles (dataset = dataset)
+    for f in dataset:
+      miniaodSubset.add (f["logical_file_name"])
+
+  # if dataset is a USER dataset, then assume the file comes from a MINIAOD dataset
+  else:
+    # first get the parents
+    parents = dbs3api_global.listFileParents (logical_file_name = fileName)
+
+    # then for each of the grandparents, get their children
+    children = []
+    for parent in parents:
+      for parent_file_name in parent["parent_logical_file_name"]:
+        children.extend (dbs3api_global.listFileChildren (logical_file_name = parent_file_name))
+
+    # then for each of the grandparents, get their children
+    grandchildren = []
+    for child in children:
+      for child_file_name in child["child_logical_file_name"]:
+        if "/AOD/" not in child_file_name:
+          continue
+        grandchildren.extend (dbs3api_phys03.listFileChildren (logical_file_name = child_file_name))
+
+    # put the children in a set
+    for grandchild in grandchildren:
+      for grandchild_file_name in grandchild["child_logical_file_name"]:
+        miniaod.add (grandchild_file_name)
+
+    # put the files of the target dataset in another set
+    dataset = dbs3api_phys03.listFiles (dataset = dataset)
+    for f in dataset:
+      miniaodSuperset.add (f["logical_file_name"])
 
   # return the intersection of the two sets
-  return list (miniaodSuperset.intersection (miniaod))
+  return list (miniaodSubset.intersection (miniaod))

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -732,11 +732,12 @@ def MakeSpecificConfig(Dataset, Directory, SkimDirectory, Label, SkimChannelName
     # If the dataset has a sibling defined, add the corresponding files to the secondary file names
     if ("sibling_datasets" in locals() or "sibling_datasets" in globals()) and Label in sibling_datasets:
         ConfigFile.write("\nsiblings = []\n")
-        ConfigFile.write("try:\n")
-        ConfigFile.write("  for fileName in osusub.runList:\n")
-        ConfigFile.write("    siblings.extend (osusub.getSiblings (fileName, \"" + sibling_datasets[Label] + "\"))\n")
-        ConfigFile.write("except:\n")
-        ConfigFile.write("  print \"No valid grid proxy. Not adding sibling files.\"\n")
+        ConfigFile.write("if osusub.batchMode:\n")
+        ConfigFile.write("  try:\n")
+        ConfigFile.write("    for fileName in osusub.runList:\n")
+        ConfigFile.write("      siblings.extend (osusub.getSiblings (fileName, \"" + sibling_datasets[Label] + "\"))\n")
+        ConfigFile.write("  except:\n")
+        ConfigFile.write("    print \"No valid grid proxy. Not adding sibling files.\"\n")
         ConfigFile.write("pset.process.source.secondaryFileNames.extend(siblings)\n\n")
 
     ConfigFile.write('process = pset.process\n')

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -772,10 +772,6 @@ def AcquireAwesomeAAA(Dataset, datasetInfoName, AAAFileList, datasetRead, crossS
     for f in inputFiles:
         if arguments.Redirector != "":
             f = 'root://' + RedirectorDic[arguments.Redirector] + '/' + f
-        elif lxbatch:
-            f = "root://xrootd.ba.infn.it/" + f
-        else:
-            f = "root://cms-xrd-global.cern.ch/" + f
         text += '"' + f + '",\n'
     text += ']\n'
     text += ('listOfSecondaryFiles = []\n' if not append else 'listOfSecondaryFiles += []\n')
@@ -848,10 +844,6 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
             for f in inputFiles:
                 if arguments.Redirector != "":
                     f = 'root://' + RedirectorDic[arguments.Redirector] + '/' + f
-                elif lxbatch:
-                    f = "root://xrootd.ba.infn.it/" + f
-                else:
-                    f = "root://cmsxrootd.fnal.gov/" + f
                 text += '"' + f + '",\n'
             text += ']\n'
         text += 'listOfSecondaryFiles = []\n'
@@ -890,10 +882,6 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
             for f in inputFiles:
                 if arguments.Redirector != "":
                     f = 'root://' + RedirectorDic[arguments.Redirector] + '/' + f
-                elif lxbatch:
-                    f = "root://xrootd.ba.infn.it/" + f
-                else:
-                    f = "root://cmsxrootd.fnal.gov/" + f
                 text += '"' + f + '",\n'
             text += ']\n'
         text += 'listOfSecondaryFiles = []\n'

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -509,9 +509,10 @@ def MakeCondorSubmitScript(Dataset,NumberOfJobs,Directory,Label, SkimChannelName
         SubmitScript.write ("PYTHONPATH=$PYTHONPATH:./" + os.environ["CMSSW_VERSION"] + "/python:.\n\n")
 
     if rutgers:
-        SubmitScript.write ("rm -f " + proxy + "\n")
-        SubmitScript.write ("mv -f " + os.path.basename (proxy) + " " + os.path.dirname (proxy) + "/\n")
-        SubmitScript.write ("chmod 600 " + proxy + "\n\n")
+        SubmitScript.write ("rm -f /tmp/" + os.path.basename (proxy) + "\n")
+        SubmitScript.write ("mv -f " + os.path.basename (proxy) + " /tmp/\n")
+        SubmitScript.write ("chmod 600 /tmp/" + os.path.basename (proxy) + "\n")
+        SubmitScript.write ("X509_USER_PROXY=/tmp/" + os.path.basename (proxy) + "\n\n")
 
     SubmitScript.write ("(>&2 echo \"Arguments passed to this script are: $@\")\n")
     SubmitScript.write (cmsRunExecutable + " $@\n")


### PR DESCRIPTION
The main change in this PR is in osusub_cfg.py, where the `getSiblings` function has been extended. Before, it would get a list of siblings from the prod/global DBS instance, assuming the given file was in prod/phys03. Now, the reverse case is handled, where the list of siblings comes from the prod/phys03 instance, assuming the given file is in prod/global. The case is determined by whether the target dataset ends in "/USER".

A few other minor changes have been made to osusub.py:
- When in "Rutgers mode", the proxy file is copied to /tmp/ on the worker nodes, instead of to the same directory that it lives in on the interactive nodes. This is needed on the LPC because the home directories, where the proxy file now lives on the interactive nodes, is not mounted on the worker nodes.
- In the config_cfg.py file that is generated by osusub.py, the list of siblings is only gotten when running in batch mode. This prevents contacting DBS when this file is imported during the submission process.
- No redirector is prepended to each file name if the user does not use the --redirector option.