### PR TITLE
Add AMSB reweighting rules from 10cm

### DIFF
--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -9673,6 +9673,8 @@ for dataset0 in nJobs:
     pdgIdsForISRReweighting[dataset] = [1000022, 1000024]
 
   destinationCTaus = [ctau0 * 0.1 * i for i in range(2, 11)]
+  if ctau0 == 10:
+    destinationCTaus.extend([round(ctau0 * 0.01 * i, 2) for i in range(2, 11)])
   rulesForLifetimeReweighting[dataset0] = [lifetimeReweightingRule([1000024], [ctau0], [d], (d == ctau0)) for d in destinationCTaus]
 
   pdgIdsForISRReweighting[dataset0] = [1000022, 1000024]

--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -9674,7 +9674,7 @@ for dataset0 in nJobs:
 
   destinationCTaus = [ctau0 * 0.1 * i for i in range(2, 11)]
   if ctau0 == 10:
-    destinationCTaus.extend([round(ctau0 * 0.01 * i, 2) for i in range(2, 11)])
+    destinationCTaus.extend([round(ctau0 * 0.01 * i, 2) for i in range(1, 11)])
   rulesForLifetimeReweighting[dataset0] = [lifetimeReweightingRule([1000024], [ctau0], [d], (d == ctau0)) for d in destinationCTaus]
 
   pdgIdsForISRReweighting[dataset0] = [1000022, 1000024]


### PR DESCRIPTION
Extends the rules for 10cm AMSB samples. The only thing this changes is that additional eventvariables are created when running LifetimeWeightProducer over these samples, reweighting 10cm all the way down to 0.1cm.

Tested by manually calculating the weight for 10cm --> 0.2 (and 0.9) cm using the chargino lifetimes:
```
Total weight from eventvariables: 0.0306425 (2cm), 2.55763e-31 (0p2cm)
Total weight from math:           0.0306425 (2cm), 2.55763e-31 (0p2cm)
```

So the eventvariables are produced and they have the right values.