### PR TITLE
passBadCalibFilterUpdate

### DIFF
--- a/Collections/interface/Met.h
+++ b/Collections/interface/Met.h
@@ -58,9 +58,11 @@ namespace osu
 
         void setBadChargedCandidateFilter (const bool);
         void setBadPFMuonFilter (const bool);
+        void setPassecalBadCalibFilterUpdate (const bool);
 
         const bool badChargedCandidateFilter () const { return badChargedCandidateFilter_; }
         const bool badPFMuonFilter () const { return badPFMuonFilter_; }
+        const bool passecalBadCalibFilterUpdate () const { return passecalBadCalibFilterUpdate_; }
 
       private:
         double noMuPt_;
@@ -91,6 +93,7 @@ namespace osu
 
         bool badChargedCandidateFilter_;
         bool badPFMuonFilter_;
+        bool passecalBadCalibFilterUpdate_;
     };
 }
 

--- a/Collections/plugins/OSUMetProducer.cc
+++ b/Collections/plugins/OSUMetProducer.cc
@@ -18,6 +18,7 @@ OSUMetProducer::OSUMetProducer (const edm::ParameterSet &cfg) :
 
   BadChCandFilterToken_ = consumes<bool>(cfg.getParameter<edm::InputTag>("BadChargedCandidateFilter"));
   BadPFMuonFilterToken_ = consumes<bool>(cfg.getParameter<edm::InputTag>("BadPFMuonFilter"));
+  ecalBadCalibFilterUpdateToken_ = consumes<bool>(cfg.getParameter<edm::InputTag>("ecalBadCalibReducedMINIAODFilter"));
 }
 
 OSUMetProducer::~OSUMetProducer ()
@@ -37,6 +38,9 @@ OSUMetProducer::produce (edm::Event &event, const edm::EventSetup &setup)
   edm::Handle<bool> ifilterbadPFMuon;
   event.getByToken(BadPFMuonFilterToken_, ifilterbadPFMuon);
 
+  edm::Handle<bool> passecalBadCalibFilterUpdate ;
+  event.getByToken(ecalBadCalibFilterUpdateToken_, passecalBadCalibFilterUpdate);
+
   edm::Handle<vector<pat::PackedCandidate> > pfCandidates;
   event.getByToken (pfCandidatesToken_, pfCandidates);
 
@@ -52,6 +56,10 @@ OSUMetProducer::produce (edm::Event &event, const edm::EventSetup &setup)
         pl_->back ().setBadPFMuonFilter (*ifilterbadPFMuon);
       else if (firstEvent_)
         edm::LogWarning ("OSUMetProducer") << "Not applying \"Bad PF Muon Filter\"!";
+      if (passecalBadCalibFilterUpdate.isValid ())
+        pl_->back ().setPassecalBadCalibFilterUpdate (*passecalBadCalibFilterUpdate);
+      else if (firstEvent_)
+        edm::LogWarning ("OSUMetProducer") << "Not applying \"pass ecal Bad Calib Filter Update\"!";
     }
 
   event.put (std::move (pl_), collection_.instance ());

--- a/Collections/plugins/OSUMetProducer.h
+++ b/Collections/plugins/OSUMetProducer.h
@@ -28,6 +28,7 @@ class OSUMetProducer : public edm::EDProducer
     edm::EDGetTokenT<vector<pat::PackedCandidate> > pfCandidatesToken_;
     edm::EDGetTokenT<bool> BadChCandFilterToken_;
     edm::EDGetTokenT<bool> BadPFMuonFilterToken_;
+    edm::EDGetTokenT<bool> ecalBadCalibFilterUpdateToken_ ;
     ////////////////////////////////////////////////////////////////////////////
 
     // Payload for this EDFilter.

--- a/Collections/src/Met.cc
+++ b/Collections/src/Met.cc
@@ -27,7 +27,8 @@ osu::Met::Met (const TYPE(mets) &met) :
   noMuPt_UnclusteredEnDown_ (INVALID_VALUE),
   noMuPt_PhotonEnDown_      (INVALID_VALUE),
   badChargedCandidateFilter_ (true),
-  badPFMuonFilter_           (true)
+  badPFMuonFilter_           (true),
+  passecalBadCalibFilterUpdate_ (true)
 {
 }
 
@@ -50,7 +51,8 @@ osu::Met::Met (const TYPE(mets) &met, const edm::Handle<vector<pat::PackedCandid
   noMuPt_UnclusteredEnDown_ (INVALID_VALUE),
   noMuPt_PhotonEnDown_      (INVALID_VALUE),
   badChargedCandidateFilter_ (true),
-  badPFMuonFilter_           (true)
+  badPFMuonFilter_           (true),
+  passecalBadCalibFilterUpdate_ (true)
 {
   if (pfCandidates.isValid ()) {
       TVector2 metNoMu (met.px(), met.py());
@@ -151,4 +153,9 @@ osu::Met::setBadPFMuonFilter (const bool flag)
   badPFMuonFilter_ = flag;
 }
 
+void
+osu::Met::setPassecalBadCalibFilterUpdate (const bool flag)
+{
+  passecalBadCalibFilterUpdate_ = flag;
+}
 #endif


### PR DESCRIPTION
passBadCalibFilterUpdate is recommended in 
https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#2018_data
Changes are adopted in METfilter mainly for 2018 datasets.
Please check the change..