### PR TITLE
Add numTrueInteractions to eventvariables

### DIFF
--- a/AnaTools/plugins/PUScalingFactorProducer.cc
+++ b/AnaTools/plugins/PUScalingFactorProducer.cc
@@ -134,6 +134,7 @@ PUScalingFactorProducer::AddVariables (const edm::Event &event) {
       (*eventvariables)["puScalingFactor"]     = puWeight_->GetBinContent(puWeight_->FindBin(numTruePV));
       (*eventvariables)["puScalingFactorUp"]   = puWeightUp_ ? puWeightUp_->GetBinContent(puWeightUp_->FindBin(numTruePV)) : 1;
       (*eventvariables)["puScalingFactorDown"] = puWeightDown_ ? puWeightDown_->GetBinContent(puWeightDown_->FindBin(numTruePV)) : 1;
+      (*eventvariables)["numTruePV"] = numTruePV;
     }
   else
     {
@@ -149,11 +150,13 @@ PUScalingFactorProducer::AddVariables (const edm::Event &event) {
              (*eventvariables)["puScalingFactor"]     = 1;
              (*eventvariables)["puScalingFactorUp"]   = 1;
              (*eventvariables)["puScalingFactorDown"] = 1;
+             (*eventvariables)["numTruePV"] = INVALID_VALUE;
     }
 #else
     (*eventvariables)["puScalingFactor"]     = 1;
     (*eventvariables)["puScalingFactorUp"]   = 1;
     (*eventvariables)["puScalingFactorDown"] = 1;
+   (*eventvariables)["numTruePV"] = INVALID_VALUE;
 # endif
     isFirstEvent_ = false;
 }

--- a/AnaTools/plugins/PUScalingFactorProducer.cc
+++ b/AnaTools/plugins/PUScalingFactorProducer.cc
@@ -134,7 +134,7 @@ PUScalingFactorProducer::AddVariables (const edm::Event &event) {
       (*eventvariables)["puScalingFactor"]     = puWeight_->GetBinContent(puWeight_->FindBin(numTruePV));
       (*eventvariables)["puScalingFactorUp"]   = puWeightUp_ ? puWeightUp_->GetBinContent(puWeightUp_->FindBin(numTruePV)) : 1;
       (*eventvariables)["puScalingFactorDown"] = puWeightDown_ ? puWeightDown_->GetBinContent(puWeightDown_->FindBin(numTruePV)) : 1;
-      (*eventvariables)["numTruePV"] = numTruePV;
+      (*eventvariables)["numTrueInteractions"] = numTruePV;
     }
   else
     {
@@ -150,13 +150,13 @@ PUScalingFactorProducer::AddVariables (const edm::Event &event) {
              (*eventvariables)["puScalingFactor"]     = 1;
              (*eventvariables)["puScalingFactorUp"]   = 1;
              (*eventvariables)["puScalingFactorDown"] = 1;
-             (*eventvariables)["numTruePV"] = INVALID_VALUE;
+             (*eventvariables)["numTrueInteractions"] = INVALID_VALUE;
     }
 #else
     (*eventvariables)["puScalingFactor"]     = 1;
     (*eventvariables)["puScalingFactorUp"]   = 1;
     (*eventvariables)["puScalingFactorDown"] = 1;
-   (*eventvariables)["numTruePV"] = INVALID_VALUE;
+   (*eventvariables)["numTrueInteractions"] = INVALID_VALUE;
 # endif
     isFirstEvent_ = false;
 }


### PR DESCRIPTION
Makes `numTrueInteractions` (BX0->getTrueNumInteractions()) available in eventvariables. Set to a large negative number if the event isn't MC or if not using MINIAOD.