### PR TITLE
fix for 3D plots

### DIFF
--- a/AnaTools/plugins/Plotter.cc
+++ b/AnaTools/plugins/Plotter.cc
@@ -503,7 +503,7 @@ void Plotter::fill3DHistogram(const HistoDef &definition){
             continue;
           if (!IS_INVALID(definition.indexY) && leafY - definition.valueLookupTrees.at(1)->evaluate().begin() != definition.indexY)
             continue;
-          if (!IS_INVALID(definition.indexZ) && leafZ - definition.valueLookupTrees.at(1)->evaluate().begin() != definition.indexZ)
+          if (!IS_INVALID(definition.indexZ) && leafZ - definition.valueLookupTrees.at(2)->evaluate().begin() != definition.indexZ)
             continue;
 
           fill3DHistogram(definition, valueX, valueY, valueZ, weight);


### PR DESCRIPTION
We need to change a 1 to a 2, so that 3D plots with different indices get filled.

See https://milliqanelog.asc.ohio-state.edu:8080/OSUT3Analysis/140 and
https://milliqanelog.asc.ohio-state.edu:8080/OSUT3Analysis/141