### PR TITLE
Save decay length, beta, and gamma along with cTau for plotting

### DIFF
--- a/AnaTools/plugins/LifetimeWeightProducer.h
+++ b/AnaTools/plugins/LifetimeWeightProducer.h
@@ -2,6 +2,7 @@
 #define LIFETIME_WEIGHT_PRODUCER
 
 #include <assert.h>
+#include "TVector3.h"
 
 #include "OSUT3Analysis/AnaTools/interface/EventVariableProducer.h"
 
@@ -26,6 +27,7 @@ class LifetimeWeightProducer : public EventVariableProducer {
 
         bool isOriginalParticle(const TYPE(hardInteractionMcparticles) &, const int) const;
         double getCTau(const TYPE(hardInteractionMcparticles) &) const;
+        TVector3 getEndVertex(const TYPE(hardInteractionMcparticles) &) const;
         void getFinalPosition(const reco::Candidate &, const int, bool, math::XYZPoint &) const;
 
         void AddVariables(const edm::Event &);


### PR DESCRIPTION
Adds eventvariables like `decayLength_1000024_0` for the decay length, beta, and gamma of particles used in the lifetime reweighting, to go along with whatever `cTau_1000024_1` (etc) variables you're already seeing.

In a DisappTrks repo version of `getEndVertex`, we require the daughter ID to be the neutralino, but this is of course too specific for the framework. The vertices of all daughters should really be the same so I've used that as a shortcut.