### PR TITLE
Match to isolated tracks

### DIFF
--- a/Collections/interface/DisappearingTrack.h
+++ b/Collections/interface/DisappearingTrack.h
@@ -65,12 +65,21 @@ namespace osu {
                         const map<DetId, vector<double> > * const, 
                         const map<DetId, vector<int> > * const, 
                         const bool,
+#if DATA_FORMAT_IS_2017
+                        const edm::Handle<vector<CandidateTrack> > &,
+                        const edm::Handle<vector<pat::IsolatedTrack> > &);
+#else
                         const edm::Handle<vector<CandidateTrack> > &);
+#endif
 
       ~DisappearingTrack ();
 
       const edm::Ref<vector<CandidateTrack> > matchedCandidateTrack () const { return matchedCandidateTrack_; };
       const double dRToMatchedCandidateTrack () const { return (IS_INVALID(dRToMatchedCandidateTrack_)) ? MAX_DR : dRToMatchedCandidateTrack_; };
+#if DATA_FORMAT_IS_2017
+      const edm::Ref<vector<pat::IsolatedTrack> > matchedIsolatedTrack () const { return matchedIsolatedTrack_; };
+      const double dRToMatchedIsolatedTrack () const { return (IS_INVALID(dRToMatchedIsolatedTrack_)) ? MAX_DR : dRToMatchedIsolatedTrack_; };
+#endif
 
       void set_minDeltaRToElectrons(const edm::Handle<edm::View<TYPE(electrons)> > &,
                                     const edm::Handle<vector<TYPE(primaryvertexs)> > &,
@@ -126,6 +135,9 @@ namespace osu {
 
     private:
       const edm::Ref<vector<CandidateTrack> > &findMatchedCandidateTrack (const edm::Handle<vector<CandidateTrack> > &, edm::Ref<vector<CandidateTrack> > &, double &) const;
+#if DATA_FORMAT_IS_2017
+      const edm::Ref<vector<pat::IsolatedTrack> > &findMatchedIsolatedTrack (const edm::Handle<vector<pat::IsolatedTrack> > &, edm::Ref<vector<pat::IsolatedTrack> > &, double &) const;
+#endif
 
       void set_primaryPFIsolations(const edm::Handle<vector<pat::PackedCandidate> > &);
       void set_additionalPFIsolations(const edm::Handle<vector<pat::PackedCandidate> > &, const edm::Handle<vector<pat::PackedCandidate> > &);
@@ -133,6 +145,12 @@ namespace osu {
       edm::Ref<vector<CandidateTrack> > matchedCandidateTrack_;
       double dRToMatchedCandidateTrack_;
       double maxDeltaR_candidateTrackMatching_;
+
+#if DATA_FORMAT_IS_2017
+      edm::Ref<vector<pat::IsolatedTrack> > matchedIsolatedTrack_;      
+      double dRToMatchedIsolatedTrack_;
+      double maxDeltaR_isolatedTrackMatching_;
+#endif
 
       float deltaRToClosestElectron_;
       float deltaRToClosestVetoElectron_;
@@ -197,7 +215,12 @@ namespace osu {
                                  const map<DetId, vector<double> > * const, 
                                  const map<DetId, vector<int> > * const, 
                                  const bool,
+#if DATA_FORMAT_FROM_MINIAOD && DATA_FORMAT_IS_2017
+                                 const edm::Handle<vector<CandidateTrack> > &,
+                                 const edm::Handle<vector<pat::IsolatedTrack> > &);
+#else
                                  const edm::Handle<vector<CandidateTrack> > &);
+#endif
 
       ~SecondaryDisappearingTrack();
   };

--- a/Collections/interface/DisappearingTrack.h
+++ b/Collections/interface/DisappearingTrack.h
@@ -65,7 +65,7 @@ namespace osu {
                         const map<DetId, vector<double> > * const, 
                         const map<DetId, vector<int> > * const, 
                         const bool,
-#if DATA_FORMAT_IS_2017
+#if DATA_FORMAT_FROM_MINIAOD && DATA_FORMAT_IS_2017
                         const edm::Handle<vector<CandidateTrack> > &,
                         const edm::Handle<vector<pat::IsolatedTrack> > &);
 #else
@@ -76,7 +76,7 @@ namespace osu {
 
       const edm::Ref<vector<CandidateTrack> > matchedCandidateTrack () const { return matchedCandidateTrack_; };
       const double dRToMatchedCandidateTrack () const { return (IS_INVALID(dRToMatchedCandidateTrack_)) ? MAX_DR : dRToMatchedCandidateTrack_; };
-#if DATA_FORMAT_IS_2017
+#if DATA_FORMAT_FROM_MINIAOD && DATA_FORMAT_IS_2017
       const edm::Ref<vector<pat::IsolatedTrack> > matchedIsolatedTrack () const { return matchedIsolatedTrack_; };
       const double dRToMatchedIsolatedTrack () const { return (IS_INVALID(dRToMatchedIsolatedTrack_)) ? MAX_DR : dRToMatchedIsolatedTrack_; };
 #endif
@@ -135,7 +135,7 @@ namespace osu {
 
     private:
       const edm::Ref<vector<CandidateTrack> > &findMatchedCandidateTrack (const edm::Handle<vector<CandidateTrack> > &, edm::Ref<vector<CandidateTrack> > &, double &) const;
-#if DATA_FORMAT_IS_2017
+#if DATA_FORMAT_FROM_MINIAOD && DATA_FORMAT_IS_2017
       const edm::Ref<vector<pat::IsolatedTrack> > &findMatchedIsolatedTrack (const edm::Handle<vector<pat::IsolatedTrack> > &, edm::Ref<vector<pat::IsolatedTrack> > &, double &) const;
 #endif
 
@@ -146,7 +146,7 @@ namespace osu {
       double dRToMatchedCandidateTrack_;
       double maxDeltaR_candidateTrackMatching_;
 
-#if DATA_FORMAT_IS_2017
+#if DATA_FORMAT_FROM_MINIAOD && DATA_FORMAT_IS_2017
       edm::Ref<vector<pat::IsolatedTrack> > matchedIsolatedTrack_;      
       double dRToMatchedIsolatedTrack_;
       double maxDeltaR_isolatedTrackMatching_;

--- a/Collections/plugins/OSUGenericTrackProducer.cc
+++ b/Collections/plugins/OSUGenericTrackProducer.cc
@@ -215,7 +215,12 @@ OSUGenericTrackProducer<T>::produce (edm::Event &event, const edm::EventSetup &s
                          &EcalAllDeadChannelsValMap_,
                          &EcalAllDeadChannelsBitMap_,
                          !event.isRealData (),
+#if DATA_FORMAT_IS_2017
+                         candidateTracks,
+                         isolatedTracks);
+#else
                          candidateTracks);
+#endif
 #elif DATA_FORMAT_FROM_MINIAOD
       pl_->emplace_back (object, 
                          particles, 

--- a/Collections/plugins/OSUGenericTrackProducer.cc
+++ b/Collections/plugins/OSUGenericTrackProducer.cc
@@ -187,7 +187,7 @@ OSUGenericTrackProducer<T>::produce (edm::Event &event, const edm::EventSetup &s
   edm::Handle<vector<pat::PackedCandidate> > lostTracks;
   event.getByToken (lostTracksToken_, lostTracks);
 
-#if DATA_FORMAT_IS_2017
+#if DATA_FORMAT_FROM_MINIAOD && DATA_FORMAT_IS_2017
   edm::Handle<vector<pat::IsolatedTrack> > isolatedTracks;
   event.getByToken (isolatedTracksToken_, isolatedTracks);
 #endif
@@ -215,7 +215,7 @@ OSUGenericTrackProducer<T>::produce (edm::Event &event, const edm::EventSetup &s
                          &EcalAllDeadChannelsValMap_,
                          &EcalAllDeadChannelsBitMap_,
                          !event.isRealData (),
-#if DATA_FORMAT_IS_2017
+#if DATA_FORMAT_FROM_MINIAOD && DATA_FORMAT_IS_2017
                          candidateTracks,
                          isolatedTracks);
 #else
@@ -300,7 +300,7 @@ OSUGenericTrackProducer<T>::produce (edm::Event &event, const edm::EventSetup &s
         track.set_minDeltaRToMuons(muons, vertices);
         track.set_minDeltaRToTaus(taus);
 
-#if DATA_FORMAT_IS_2017
+#if DATA_FORMAT_FROM_MINIAOD && DATA_FORMAT_IS_2017
         track.set_isoTrackIsolation(isolatedTracks);
 #endif
 

--- a/Collections/src/DisappearingTrack.cc
+++ b/Collections/src/DisappearingTrack.cc
@@ -220,7 +220,7 @@ osu::DisappearingTrack::DisappearingTrack (const TYPE(tracks) &track,
                    const map<DetId, vector<double> > * const EcalAllDeadChannelsValMap,
                    const map<DetId, vector<int> > * const EcalAllDeadChannelsBitMap,
                    const bool dropHits,
-#if DATA_FORMAT_IS_2017
+#if DATA_FORMAT_FROM_MINIAOD && DATA_FORMAT_IS_2017
                    const edm::Handle<vector<CandidateTrack> > &candidateTracks,
                    const edm::Handle<vector<pat::IsolatedTrack> > &isolatedTracks) :
 #else
@@ -274,7 +274,7 @@ osu::DisappearingTrack::DisappearingTrack (const TYPE(tracks) &track,
   }
   else dRToMatchedCandidateTrack_ = INVALID_VALUE;
 
-#if DATA_FORMAT_IS_2017
+#if DATA_FORMAT_FROM_MINIAOD && DATA_FORMAT_IS_2017
   // if the tracks collection itself is IsolatedTracks, don't bother with matching this to itself
   if(cfg.getParameter<edm::ParameterSet>("collections").getParameter<edm::InputTag>("tracks").label() != "isolatedTracks") {
     maxDeltaR_isolatedTrackMatching_ = cfg.getParameter<double> ("maxDeltaRForIsolatedTrackMatching");
@@ -308,7 +308,7 @@ osu::DisappearingTrack::findMatchedCandidateTrack (const edm::Handle<vector<Cand
   return matchedCandidateTrack;
 }
 
-#if DATA_FORMAT_IS_2017
+#if DATA_FORMAT_FROM_MINIAOD && DATA_FORMAT_IS_2017
 const edm::Ref<vector<pat::IsolatedTrack> > &
 osu::DisappearingTrack::findMatchedIsolatedTrack (const edm::Handle<vector<pat::IsolatedTrack> > &isolatedTracks, edm::Ref<vector<pat::IsolatedTrack> > &matchedIsolatedTrack, double &dRToMatchedIsolatedTrack) const
 {

--- a/Collections/src/DisappearingTrack.cc
+++ b/Collections/src/DisappearingTrack.cc
@@ -272,13 +272,15 @@ osu::DisappearingTrack::DisappearingTrack (const TYPE(tracks) &track,
     maxDeltaR_candidateTrackMatching_ = cfg.getParameter<double> ("maxDeltaRForCandidateTrackMatching");
     if(candidateTracks.isValid()) findMatchedCandidateTrack(candidateTracks, matchedCandidateTrack_, dRToMatchedCandidateTrack_);
   }
+  else dRToMatchedCandidateTrack_ = INVALID_VALUE;
 
 #if DATA_FORMAT_IS_2017
   // if the tracks collection itself is IsolatedTracks, don't bother with matching this to itself
   if(cfg.getParameter<edm::ParameterSet>("collections").getParameter<edm::InputTag>("tracks").label() != "isolatedTracks") {
     maxDeltaR_isolatedTrackMatching_ = cfg.getParameter<double> ("maxDeltaRForIsolatedTrackMatching");
-    if(isolatedTracks.isValid()) findMatchedIsolatedTrack(isolatedTracks, matchedIsolatedTrack_, dRToMatchedCandidateTrack_);
+    if(isolatedTracks.isValid()) findMatchedIsolatedTrack(isolatedTracks, matchedIsolatedTrack_, dRToMatchedIsolatedTrack_);
   }
+  else dRToMatchedIsolatedTrack_ = INVALID_VALUE;
 #endif
 
 }
@@ -313,7 +315,8 @@ osu::DisappearingTrack::findMatchedIsolatedTrack (const edm::Handle<vector<pat::
   dRToMatchedIsolatedTrack = INVALID_VALUE;
   for(vector<pat::IsolatedTrack>::const_iterator isoTrack = isolatedTracks->begin(); isoTrack != isolatedTracks->end(); isoTrack++) {
     double dR = deltaR(*isoTrack, *this);
-    if(maxDeltaR_isolatedTrackMatching_ >= 0.0 && dR > maxDeltaR_isolatedTrackMatching_) {
+    if(maxDeltaR_isolatedTrackMatching_ >= 0.0 && dR > maxDeltaR_isolatedTrackMatching_) continue;
+    if(dR < dRToMatchedIsolatedTrack || dRToMatchedIsolatedTrack < 0.0) {
       dRToMatchedIsolatedTrack = dR;
       matchedIsolatedTrack = edm::Ref<vector<pat::IsolatedTrack> >(isolatedTracks, isoTrack - isolatedTracks->begin());
     }

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -260,7 +260,8 @@ collectionProducer.tracks = cms.EDProducer ("OSUTrackProducer",
 
     # these are only relavent for the disappearing tracks analysis
     candidateTracks = cms.InputTag ("candidateTrackProducer", ""),
-    maxDeltaRForCandidateTrackMatching = cms.double (0.2), # if cutting on dRToMatchedIsolatedTrack, must set this to be greater than the cut threshold
+    maxDeltaRForCandidateTrackMatching = cms.double (0.2), # if cutting on dRToMatchedCandidateTrack, must set this to be greater than the cut threshold
+    maxDeltaRForIsolatedTrackMatching = cms.double (0.2), # if cutting on dRToMatchedIsolatedTrack, must set this to be greater than the cut threshold
 
     # The following three parameters are used to correct the missing outer hits
     # distribution in MC for the disappearing tracks analysis.


### PR DESCRIPTION
Adds a match to the nearest pat::IsolatedTrack (within dR <= 0.2) if the data format has them. None of this affects anyone who does not `#define DISAPP_TRKS`.

Example in AMSB:
<img width="972" alt="Screen Shot 2019-07-12 at 8 47 02 AM" src="https://user-images.githubusercontent.com/4975421/61129086-a6f01880-a481-11e9-99bc-eaecd494f8e9.png">
