### PR TITLE
Fix xrdfs issue for large directories

### DIFF
--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -425,13 +425,13 @@ def GetListOfRemoteRootFiles(Path):
     thisRedirector = Path.split('//')[0] + '//' + Path.split('//')[1] + '/'
     thisRemotePath = '/' + Path.split('//')[2]
     try:
-        tmpFileList = subprocess.check_output('xrdfs ' + thisRedirector + ' ls -l -u ' + thisRemotePath, shell = True).split('\n')
+        tmpFileList = subprocess.check_output('xrdfs ' + thisRedirector + ' ls -u ' + thisRemotePath, shell = True).split('\n')
     except subprocess.CalledProcessError:
         return None
     for filePath in tmpFileList:
-        if len(filePath.split()) == 5:
-            if filePath.split()[4].endswith('.root'):
-                fileList.append(filePath.split()[4])
+        if len(filePath.split()) == 1:
+            if filePath.endswith('.root'):
+                fileList.append(filePath)
     return fileList
 
 #It generates the condor.sub file for each dataset.


### PR DESCRIPTION
After recently making new initial skims of EGamma_2018D (see [0]), I found that I was unable to run over them. osusub would hang and eventually fail, and after some digging I found that the `xrdfs ls -l -u` command used to create the list of skim file paths was hanging indefinitely.

`xrdfs ls -l -u` works fine for every other directory I have tried, and other xrdfs commands (including `xrdfs ls -u`) work fine for this directory as well. The only unique quality I can find about this directory is its size (~7k files taking up 1.2TB), which Marguerite suggested might be an issue (via lpc-how-to).

In any case, removing the `-l` option solves my problem, and I can't see any way in which it would create new problems for others. I have tested the new code by running over directory [0] to create directory [1], and everything appears to work as expected.

[0] `/store/user/cardwell/EEInitialSkim_2018Analysis_09August2019`
[1] `/store/user/cardwell/EEPreselection_2018Analysis_13Aug2019`