### PR TITLE
unique mothers

### DIFF
--- a/Collections/interface/HardInteractionMcparticle.h
+++ b/Collections/interface/HardInteractionMcparticle.h
@@ -14,14 +14,11 @@ namespace osu
         HardInteractionMcparticle (const TYPE(hardInteractionMcparticles) &);
         ~HardInteractionMcparticle ();
 
-	const int motherPdgId () const;
-	const int motherStatus () const;
+	const int uniqueMotherPdgId () const;
 
-	void set_motherPdgId (double value) { motherPdgId_  = value; };
-	void set_motherStatus (double value) { motherStatus_  = value; };
+	void set_uniqueMotherPdgId (double value) { uniqueMotherPdgId_  = value; };
 
-	int motherPdgId_;
-	int motherStatus_;
+	int uniqueMotherPdgId_;
 
     };
 }

--- a/Collections/plugins/HardInteractionMcparticleProducer.cc
+++ b/Collections/plugins/HardInteractionMcparticleProducer.cc
@@ -30,13 +30,25 @@ HardInteractionMcparticleProducer::produce (edm::Event &event, const edm::EventS
     pl_->emplace_back (object);
     osu::HardInteractionMcparticle &hiMcpart = pl_->back();
 
-    if(hiMcpart.numberOfMothers()<1) continue;
-    hiMcpart.set_motherPdgId(hiMcpart.mother()->pdgId());
-    hiMcpart.set_motherStatus(hiMcpart.mother()->status());
+    if(!uniqueMother(hiMcpart)) continue;
+    hiMcpart.set_uniqueMotherPdgId(uniqueMother(hiMcpart)->pdgId());
   }
 
   event.put (std::move (pl_), collection_.instance ());
   pl_.reset ();
+}
+
+const reco::Candidate *
+HardInteractionMcparticleProducer::uniqueMother(const TYPE(hardInteractionMcparticles) &p) const {
+  const reco::Candidate *mo = &p;
+  std::unordered_set<const reco::Candidate *> dupCheck;
+  while (mo && mo->pdgId() == p.pdgId()) {
+    dupCheck.insert(mo);
+    mo = mo->mother();
+    if (dupCheck.count(mo))
+      return nullptr;
+  }
+  return mo;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Collections/plugins/HardInteractionMcparticleProducer.h
+++ b/Collections/plugins/HardInteractionMcparticleProducer.h
@@ -8,6 +8,8 @@
 
 #include "OSUT3Analysis/Collections/interface/HardInteractionMcparticle.h"
 
+#include <unordered_set>
+
 class HardInteractionMcparticleProducer : public edm::EDProducer
 {
   public:
@@ -27,6 +29,8 @@ class HardInteractionMcparticleProducer : public edm::EDProducer
 
     // Payload for this EDFilter.
     unique_ptr<vector<osu::HardInteractionMcparticle> > pl_;
+
+    const reco::Candidate * uniqueMother (const TYPE(hardInteractionMcparticles) &) const;
 };
 
 #endif

--- a/Collections/src/HardInteractionMcparticle.cc
+++ b/Collections/src/HardInteractionMcparticle.cc
@@ -8,21 +8,14 @@ osu::HardInteractionMcparticle::HardInteractionMcparticle ()
 
 osu::HardInteractionMcparticle::HardInteractionMcparticle (const TYPE(hardInteractionMcparticles) &hardInteractionMcparticle) :
   TYPE(hardInteractionMcparticles) (hardInteractionMcparticle),
-  motherPdgId_                     (INVALID_VALUE),
-  motherStatus_                    (INVALID_VALUE)
+  uniqueMotherPdgId_                     (INVALID_VALUE)
 {
 }
 
 const int
-osu::HardInteractionMcparticle::motherPdgId () const
+osu::HardInteractionMcparticle::uniqueMotherPdgId () const
 {
-  return motherPdgId_;
-}
-
-const int
-osu::HardInteractionMcparticle::motherStatus () const
-{
-  return motherStatus_;
+  return uniqueMotherPdgId_;
 }
 
 osu::HardInteractionMcparticle::~HardInteractionMcparticle ()


### PR DESCRIPTION
This PR
- finds the unique mother of gen particles
- removes unneeded motherStatus function

tested interactively to find gen ee, emu, and mumu combinations in Displaced SUSY signal. From my side, should be ready to merge.