### PR TITLE
Gen matching update

### DIFF
--- a/Configuration/python/histogramDefinitions.py
+++ b/Configuration/python/histogramDefinitions.py
@@ -177,74 +177,74 @@ MuonHistograms = cms.PSet(
 
         #gen
         cms.PSet (
-            name = cms.string("muonBestMatchPdgId"),
+            name = cms.string("muonGenMatchPdgId"),
             title = cms.string(";|PDG ID| of generator particle matched to muon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
             inputVariables = cms.vstring("abs (genMatchedParticle.noFlagsPdgId)"),
             ),
         cms.PSet (
-            name = cms.string("muonBestMatchDeltaR"),
+            name = cms.string("muonGenMatchDeltaR"),
             title = cms.string(";#DeltaR between muon and generator particle matched to muon"),
             binsX = cms.untracked.vdouble(300,0,6),
             inputVariables = cms.vstring("genMatchedParticle.noFlagsDR"),
             ),
         cms.PSet (
-            name = cms.string("muonGenPt"),
+            name = cms.string("muonGenMatchPt"),
             title = cms.string("Gen Muon Transverse Momentum;Gen muon p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(100, 0, 500),
             inputVariables = cms.vstring("genMatchedParticle.noFlags.pt"),
         ),
         cms.PSet (
-            name = cms.string("muonGenPt_ext"),
+            name = cms.string("muonGenMatchPt_ext"),
             title = cms.string("Gen Muon Transverse Momentum;Gen muon p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(300, 0, 3000),
             inputVariables = cms.vstring("genMatchedParticle.noFlags.pt"),
         ),
         cms.PSet (
-            name = cms.string("muonGenEta"),
+            name = cms.string("muonGenMatchEta"),
             title = cms.string("Gen Muon Eta;Gen muon #eta"),
             binsX = cms.untracked.vdouble(80, -4, 4),
             inputVariables = cms.vstring("genMatchedParticle.noFlags.eta"),
         ),
         cms.PSet (
-            name = cms.string("muonGenPhi"),
+            name = cms.string("muonGenMatchPhi"),
             title = cms.string("Gen Muon Phi;Gen muon #phi"),
             binsX = cms.untracked.vdouble(64, -3.2, 3.2),
             inputVariables = cms.vstring("genMatchedParticle.noFlags.phi"),
         ),
 
         cms.PSet (
-            name = cms.string("muonBestMatchOfSameTypePdgId"),
+            name = cms.string("muonGenMatchOfSameTypePdgId"),
             title = cms.string(";|PDG ID| of generator particle matched to muon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
             inputVariables = cms.vstring("abs (genMatchedParticleOfSameType.noFlagsPdgId)"),
             ),
         cms.PSet (
-            name = cms.string("muonBestMatchOfSameTypeDeltaR"),
+            name = cms.string("muonGenMatchOfSameTypeDeltaR"),
             title = cms.string(";#DeltaR between muon and generator particle matched to muon"),
             binsX = cms.untracked.vdouble(300,0,6),
             inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlagsDR"),
             ),
         cms.PSet (
-            name = cms.string("muonGenOfSameTypePt"),
+            name = cms.string("muonGenMatchOfSameTypePt"),
             title = cms.string("Gen Muon Transverse Momentum;Gen muon p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(100, 0, 500),
             inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.pt"),
         ),
         cms.PSet (
-            name = cms.string("muonGenOfSameTypePt_ext"),
+            name = cms.string("muonGenMatchOfSameTypePt_ext"),
             title = cms.string("Gen Muon Transverse Momentum;Gen muon p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(300, 0, 3000),
             inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.pt"),
         ),
         cms.PSet (
-            name = cms.string("muonGenOfSameTypeEta"),
+            name = cms.string("muonGenMatchOfSameTypeEta"),
             title = cms.string("Gen Muon Eta;Gen muon #eta"),
             binsX = cms.untracked.vdouble(80, -4, 4),
             inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.eta"),
         ),
         cms.PSet (
-            name = cms.string("muonGenOfSameTypePhi"),
+            name = cms.string("muonGenMatchOfSameTypePhi"),
             title = cms.string("Gen Muon Phi;Gen muon #phi"),
             binsX = cms.untracked.vdouble(64, -3.2, 3.2),
             inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.phi"),
@@ -255,7 +255,7 @@ MuonHistograms = cms.PSet(
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_7_6_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
     MuonHistograms.histograms.append(
         cms.PSet (
-            name = cms.string("muonGenMotherPdgId"),
+            name = cms.string("muonGenMatchMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen muon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
             inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.mother_.pdgId)"),
@@ -264,7 +264,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_7_6_") or os.environ["CMSSW_VE
 elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     MuonHistograms.histograms.append(
         cms.PSet (
-            name = cms.string("muonGenMotherPdgId"),
+            name = cms.string("muonGenMatchMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen muon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
             inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.motherRef.pdgId)"),
@@ -560,74 +560,74 @@ ElectronHistograms = cms.PSet(
 
         #gen
         cms.PSet (
-            name = cms.string("electronBestMatchPdgId"),
+            name = cms.string("electronGenMatchPdgId"),
             title = cms.string(";|PDG ID| of generator particle matched to electron"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
             inputVariables = cms.vstring("abs (genMatchedParticle.noFlagsPdgId)"),
             ),
         cms.PSet (
-            name = cms.string("electronBestMatchDeltaR"),
+            name = cms.string("electronGenMatchDeltaR"),
             title = cms.string(";#DeltaR between electron and generator particle matched to electron"),
             binsX = cms.untracked.vdouble(300,0,6),
             inputVariables = cms.vstring("genMatchedParticle.noFlagsDR"),
         ),
         cms.PSet (
-            name = cms.string("electronGenPt"),
+            name = cms.string("electronGenMatchPt"),
             title = cms.string("Gen Electron Transverse Momentum;Gen electron p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(100, 0, 500),
             inputVariables = cms.vstring("genMatchedParticle.noFlags.pt"),
         ),
         cms.PSet (
-            name = cms.string("electronGenPt_ext"),
+            name = cms.string("electronGenMatchPt_ext"),
             title = cms.string("Gen Electron Transverse Momentum;Gen electron p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(300, 0, 3000),
             inputVariables = cms.vstring("genMatchedParticle.noFlags.pt"),
         ),
         cms.PSet (
-            name = cms.string("electronGenEta"),
+            name = cms.string("electronGenMatchEta"),
             title = cms.string("Gen Electron Eta;Gen electron #eta"),
             binsX = cms.untracked.vdouble(80, -4, 4),
             inputVariables = cms.vstring("genMatchedParticle.noFlags.eta"),
         ),
         cms.PSet (
-            name = cms.string("electronGenPhi"),
+            name = cms.string("electronGenMatchPhi"),
             title = cms.string("Gen Electron Phi;Gen electron #phi"),
             binsX = cms.untracked.vdouble(64, -3.2, 3.2),
             inputVariables = cms.vstring("genMatchedParticle.noFlags.phi"),
         ),
 
         cms.PSet (
-            name = cms.string("electronBestMatchOfSameTypePdgId"),
+            name = cms.string("electronGenMatchOfSameTypePdgId"),
             title = cms.string(";|PDG ID| of generator particle matched to electron"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
             inputVariables = cms.vstring("abs (genMatchedParticleOfSameType.noFlagsPdgId)"),
             ),
         cms.PSet (
-            name = cms.string("electronBestMatchOfSameTypeDeltaR"),
+            name = cms.string("electronGenMatchOfSameTypeDeltaR"),
             title = cms.string(";#DeltaR between electron and generator particle matched to electron"),
             binsX = cms.untracked.vdouble(300,0,6),
             inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlagsDR"),
         ),
         cms.PSet (
-            name = cms.string("electronGenOfSameTypePt"),
+            name = cms.string("electronGenMatchOfSameTypePt"),
             title = cms.string("Gen Electron Transverse Momentum;Gen electron p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(100, 0, 500),
             inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.pt"),
         ),
         cms.PSet (
-            name = cms.string("electronGenOfSameTypePt_ext"),
+            name = cms.string("electronGenMatchOfSameTypePt_ext"),
             title = cms.string("Gen Electron Transverse Momentum;Gen electron p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(300, 0, 3000),
             inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.pt"),
         ),
         cms.PSet (
-            name = cms.string("electronGenOfSameTypeEta"),
+            name = cms.string("electronGenMatchOfSameTypeEta"),
             title = cms.string("Gen Electron Eta;Gen electron #eta"),
             binsX = cms.untracked.vdouble(80, -4, 4),
             inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.eta"),
         ),
         cms.PSet (
-            name = cms.string("electronGenOfSameTypePhi"),
+            name = cms.string("electronGenMatchOfSameTypePhi"),
             title = cms.string("Gen Electron Phi;Gen electron #phi"),
             binsX = cms.untracked.vdouble(64, -3.2, 3.2),
             inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.phi"),
@@ -638,7 +638,7 @@ ElectronHistograms = cms.PSet(
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_7_6_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
     ElectronHistograms.histograms.append(
         cms.PSet (
-            name = cms.string("electronGenMotherPdgId"),
+            name = cms.string("electronGenMatchMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen electron"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
             inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.mother_.pdgId)"),
@@ -647,7 +647,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_7_6_") or os.environ["CMSSW_VE
 elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     ElectronHistograms.histograms.append(
         cms.PSet (
-            name = cms.string("electronGenMotherPdgId"),
+            name = cms.string("electronGenMatchMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen electron"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
             inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.motherRef.pdgId)"),
@@ -1490,25 +1490,25 @@ PhotonHistograms = cms.PSet(
             inputVariables = cms.vstring("phi","eta"),
         ),
         cms.PSet (
-            name = cms.string("photonBestMatchPdgId"),
+            name = cms.string("photonGenMatchPdgId"),
             title = cms.string(";|PDG ID| of generator particle matched to photon"),
             binsX = cms.untracked.vdouble(600, 0, 600),
             inputVariables = cms.vstring("abs (genMatchedParticle.noFlagsPdgId)"),
             ),
         cms.PSet (
-            name = cms.string("photonGenPt"),
+            name = cms.string("photonGenMatchPt"),
             title = cms.string("Gen Photon Transverse Momentum;Gen photon p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(100, 0, 500),
             inputVariables = cms.vstring("genMatchedParticle.noFlags.pt"),
         ),
         cms.PSet (
-            name = cms.string("photonGenEta"),
+            name = cms.string("photonGenMatchEta"),
             title = cms.string("Gen Photon Eta;Gen photon #eta"),
             binsX = cms.untracked.vdouble(80, -4, 4),
             inputVariables = cms.vstring("genMatchedParticle.noFlags.eta"),
         ),
         cms.PSet (
-            name = cms.string("photonGenPhi"),
+            name = cms.string("photonGenMatchPhi"),
             title = cms.string("Gen Photon Phi;Gen photon #phi"),
             binsX = cms.untracked.vdouble(64, -3.2, 3.2),
             inputVariables = cms.vstring("genMatchedParticle.noFlags.phi"),
@@ -1518,7 +1518,7 @@ PhotonHistograms = cms.PSet(
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_7_6_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_"):
     PhotonHistograms.histograms.append(
         cms.PSet (
-            name = cms.string("photonGenMotherPdgId"),
+            name = cms.string("photonGenMatchMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen photon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
             inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.mother_.pdgId)"),
@@ -1527,7 +1527,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_7_6_") or os.environ["CMSSW_VE
 elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
     PhotonHistograms.histograms.append(
         cms.PSet (
-            name = cms.string("photonGenMotherPdgId"),
+            name = cms.string("photonGenMatchMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen photon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
             inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.motherRef.pdgId)"),

--- a/Configuration/python/histogramDefinitions.py
+++ b/Configuration/python/histogramDefinitions.py
@@ -180,74 +180,74 @@ MuonHistograms = cms.PSet(
             name = cms.string("muonBestMatchPdgId"),
             title = cms.string(";|PDG ID| of generator particle matched to muon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
-            inputVariables = cms.vstring("abs (genMatchedParticle.bestMatchPdgId)"),
+            inputVariables = cms.vstring("abs (genMatchedParticle.noFlagsPdgId)"),
             ),
         cms.PSet (
             name = cms.string("muonBestMatchDeltaR"),
             title = cms.string(";#DeltaR between muon and generator particle matched to muon"),
             binsX = cms.untracked.vdouble(300,0,6),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatchDR"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlagsDR"),
             ),
         cms.PSet (
             name = cms.string("muonGenPt"),
             title = cms.string("Gen Muon Transverse Momentum;Gen muon p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(100, 0, 500),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatch.pt"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlags.pt"),
         ),
         cms.PSet (
             name = cms.string("muonGenPt_ext"),
             title = cms.string("Gen Muon Transverse Momentum;Gen muon p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(300, 0, 3000),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatch.pt"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlags.pt"),
         ),
         cms.PSet (
             name = cms.string("muonGenEta"),
             title = cms.string("Gen Muon Eta;Gen muon #eta"),
             binsX = cms.untracked.vdouble(80, -4, 4),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatch.eta"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlags.eta"),
         ),
         cms.PSet (
             name = cms.string("muonGenPhi"),
             title = cms.string("Gen Muon Phi;Gen muon #phi"),
             binsX = cms.untracked.vdouble(64, -3.2, 3.2),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatch.phi"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlags.phi"),
         ),
 
         cms.PSet (
             name = cms.string("muonBestMatchOfSameTypePdgId"),
             title = cms.string(";|PDG ID| of generator particle matched to muon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
-            inputVariables = cms.vstring("abs (genMatchedParticleOfSameType.bestMatchPdgId)"),
+            inputVariables = cms.vstring("abs (genMatchedParticleOfSameType.noFlagsPdgId)"),
             ),
         cms.PSet (
             name = cms.string("muonBestMatchOfSameTypeDeltaR"),
             title = cms.string(";#DeltaR between muon and generator particle matched to muon"),
             binsX = cms.untracked.vdouble(300,0,6),
-            inputVariables = cms.vstring("genMatchedParticleOfSameType.bestMatchDR"),
+            inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlagsDR"),
             ),
         cms.PSet (
             name = cms.string("muonGenOfSameTypePt"),
             title = cms.string("Gen Muon Transverse Momentum;Gen muon p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(100, 0, 500),
-            inputVariables = cms.vstring("genMatchedParticleOfSameType.bestMatch.pt"),
+            inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.pt"),
         ),
         cms.PSet (
             name = cms.string("muonGenOfSameTypePt_ext"),
             title = cms.string("Gen Muon Transverse Momentum;Gen muon p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(300, 0, 3000),
-            inputVariables = cms.vstring("genMatchedParticleOfSameType.bestMatch.pt"),
+            inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.pt"),
         ),
         cms.PSet (
             name = cms.string("muonGenOfSameTypeEta"),
             title = cms.string("Gen Muon Eta;Gen muon #eta"),
             binsX = cms.untracked.vdouble(80, -4, 4),
-            inputVariables = cms.vstring("genMatchedParticleOfSameType.bestMatch.eta"),
+            inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.eta"),
         ),
         cms.PSet (
             name = cms.string("muonGenOfSameTypePhi"),
             title = cms.string("Gen Muon Phi;Gen muon #phi"),
             binsX = cms.untracked.vdouble(64, -3.2, 3.2),
-            inputVariables = cms.vstring("genMatchedParticleOfSameType.bestMatch.phi"),
+            inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.phi"),
         ),
     )
 )
@@ -258,7 +258,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_7_6_") or os.environ["CMSSW_VE
             name = cms.string("muonGenMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen muon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
-            inputVariables = cms.vstring("abs(genMatchedParticle.bestMatch.mother_.pdgId)"),
+            inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.mother_.pdgId)"),
         ),
         )
 elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
@@ -267,7 +267,7 @@ elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_
             name = cms.string("muonGenMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen muon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
-            inputVariables = cms.vstring("abs(genMatchedParticle.bestMatch.motherRef.pdgId)"),
+            inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.motherRef.pdgId)"),
         ),
         )
 
@@ -563,74 +563,74 @@ ElectronHistograms = cms.PSet(
             name = cms.string("electronBestMatchPdgId"),
             title = cms.string(";|PDG ID| of generator particle matched to electron"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
-            inputVariables = cms.vstring("abs (genMatchedParticle.bestMatchPdgId)"),
+            inputVariables = cms.vstring("abs (genMatchedParticle.noFlagsPdgId)"),
             ),
         cms.PSet (
             name = cms.string("electronBestMatchDeltaR"),
             title = cms.string(";#DeltaR between electron and generator particle matched to electron"),
             binsX = cms.untracked.vdouble(300,0,6),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatchDR"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlagsDR"),
         ),
         cms.PSet (
             name = cms.string("electronGenPt"),
             title = cms.string("Gen Electron Transverse Momentum;Gen electron p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(100, 0, 500),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatch.pt"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlags.pt"),
         ),
         cms.PSet (
             name = cms.string("electronGenPt_ext"),
             title = cms.string("Gen Electron Transverse Momentum;Gen electron p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(300, 0, 3000),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatch.pt"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlags.pt"),
         ),
         cms.PSet (
             name = cms.string("electronGenEta"),
             title = cms.string("Gen Electron Eta;Gen electron #eta"),
             binsX = cms.untracked.vdouble(80, -4, 4),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatch.eta"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlags.eta"),
         ),
         cms.PSet (
             name = cms.string("electronGenPhi"),
             title = cms.string("Gen Electron Phi;Gen electron #phi"),
             binsX = cms.untracked.vdouble(64, -3.2, 3.2),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatch.phi"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlags.phi"),
         ),
 
         cms.PSet (
             name = cms.string("electronBestMatchOfSameTypePdgId"),
             title = cms.string(";|PDG ID| of generator particle matched to electron"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
-            inputVariables = cms.vstring("abs (genMatchedParticleOfSameType.bestMatchPdgId)"),
+            inputVariables = cms.vstring("abs (genMatchedParticleOfSameType.noFlagsPdgId)"),
             ),
         cms.PSet (
             name = cms.string("electronBestMatchOfSameTypeDeltaR"),
             title = cms.string(";#DeltaR between electron and generator particle matched to electron"),
             binsX = cms.untracked.vdouble(300,0,6),
-            inputVariables = cms.vstring("genMatchedParticleOfSameType.bestMatchDR"),
+            inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlagsDR"),
         ),
         cms.PSet (
             name = cms.string("electronGenOfSameTypePt"),
             title = cms.string("Gen Electron Transverse Momentum;Gen electron p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(100, 0, 500),
-            inputVariables = cms.vstring("genMatchedParticleOfSameType.bestMatch.pt"),
+            inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.pt"),
         ),
         cms.PSet (
             name = cms.string("electronGenOfSameTypePt_ext"),
             title = cms.string("Gen Electron Transverse Momentum;Gen electron p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(300, 0, 3000),
-            inputVariables = cms.vstring("genMatchedParticleOfSameType.bestMatch.pt"),
+            inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.pt"),
         ),
         cms.PSet (
             name = cms.string("electronGenOfSameTypeEta"),
             title = cms.string("Gen Electron Eta;Gen electron #eta"),
             binsX = cms.untracked.vdouble(80, -4, 4),
-            inputVariables = cms.vstring("genMatchedParticleOfSameType.bestMatch.eta"),
+            inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.eta"),
         ),
         cms.PSet (
             name = cms.string("electronGenOfSameTypePhi"),
             title = cms.string("Gen Electron Phi;Gen electron #phi"),
             binsX = cms.untracked.vdouble(64, -3.2, 3.2),
-            inputVariables = cms.vstring("genMatchedParticleOfSameType.bestMatch.phi"),
+            inputVariables = cms.vstring("genMatchedParticleOfSameType.noFlags.phi"),
         ),
     )
 )
@@ -641,7 +641,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_7_6_") or os.environ["CMSSW_VE
             name = cms.string("electronGenMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen electron"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
-            inputVariables = cms.vstring("abs(genMatchedParticle.bestMatch.mother_.pdgId)"),
+            inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.mother_.pdgId)"),
         ),
         )
 elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
@@ -650,7 +650,7 @@ elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_
             name = cms.string("electronGenMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen electron"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
-            inputVariables = cms.vstring("abs(genMatchedParticle.bestMatch.motherRef.pdgId)"),
+            inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.motherRef.pdgId)"),
         ),
         )
 
@@ -1493,25 +1493,25 @@ PhotonHistograms = cms.PSet(
             name = cms.string("photonBestMatchPdgId"),
             title = cms.string(";|PDG ID| of generator particle matched to photon"),
             binsX = cms.untracked.vdouble(600, 0, 600),
-            inputVariables = cms.vstring("abs (genMatchedParticle.bestMatchPdgId)"),
+            inputVariables = cms.vstring("abs (genMatchedParticle.noFlagsPdgId)"),
             ),
         cms.PSet (
             name = cms.string("photonGenPt"),
             title = cms.string("Gen Photon Transverse Momentum;Gen photon p_{T} [GeV]"),
             binsX = cms.untracked.vdouble(100, 0, 500),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatch.pt"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlags.pt"),
         ),
         cms.PSet (
             name = cms.string("photonGenEta"),
             title = cms.string("Gen Photon Eta;Gen photon #eta"),
             binsX = cms.untracked.vdouble(80, -4, 4),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatch.eta"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlags.eta"),
         ),
         cms.PSet (
             name = cms.string("photonGenPhi"),
             title = cms.string("Gen Photon Phi;Gen photon #phi"),
             binsX = cms.untracked.vdouble(64, -3.2, 3.2),
-            inputVariables = cms.vstring("genMatchedParticle.bestMatch.phi"),
+            inputVariables = cms.vstring("genMatchedParticle.noFlags.phi"),
         ),
     )
 )
@@ -1521,7 +1521,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_7_6_") or os.environ["CMSSW_VE
             name = cms.string("photonGenMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen photon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
-            inputVariables = cms.vstring("abs(genMatchedParticle.bestMatch.mother_.pdgId)"),
+            inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.mother_.pdgId)"),
         ),
         )
 elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
@@ -1530,7 +1530,7 @@ elif os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_
             name = cms.string("photonGenMotherPdgId"),
             title = cms.string(";|PDG ID| of mother of gen photon"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
-            inputVariables = cms.vstring("abs(genMatchedParticle.bestMatch.motherRef.pdgId)"),
+            inputVariables = cms.vstring("abs(genMatchedParticle.noFlags.motherRef.pdgId)"),
         ),
         )
 
@@ -1647,10 +1647,10 @@ TrackHistograms = cms.PSet(
             inputVariables = cms.vstring("charge"),
         ),
         cms.PSet (
-            name = cms.string("bestMatchPdgId"),
+            name = cms.string("noFlagsPdgId"),
             title = cms.string(";|PDG ID| of generator particle matched to track"),
             binsX = cms.untracked.vdouble(getPdgBins(["unmatched", "quarks", "leptons", "bosons"])),
-            inputVariables = cms.vstring("abs (genMatchedParticle.bestMatchPdgId)"),
+            inputVariables = cms.vstring("abs (genMatchedParticle.noFlagsPdgId)"),
             ),
         cms.PSet (
             name = cms.string("genMatchedPromptFinalStateIsMatched"),


### PR DESCRIPTION
This PR:
- adds the category of matching called "noFlags". That is, no gen flags from 
https://github.com/cms-sw/cmssw/blob/master/DataFormats/PatCandidates/interface/PackedGenParticle.h#L459-L465
This is ok, however, because GenMatchable by default looks at the packedGenParticles collection (all status 1 particles). This should be the default configuration used by displaced leptons.

- renames bestMatch to something more descriptive, namely, "promptOrTauDecay"

- change the main histograms to point to the noFlags version


This PR has been tested and accurately matches events and makes histograms as expected.