### PR TITLE
Produce electron VIDs when tracks are used

### DIFF
--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -939,7 +939,7 @@ def set_input(process, input_string):
         return
 
 def customizeMINIAODElectronVID(process, collections, usedCollections):
-    if not hasattr (collections, "electrons") or "electrons" not in usedCollections:
+    if not hasattr (collections, "electrons") or ("electrons" not in usedCollections and "tracks" not in usedCollections):
         return process
 
     from PhysicsTools.SelectorUtils.tools.vid_id_tools import DataFormat,switchOnVIDElectronIdProducer,setupAllVIDIdsInModule,setupVIDElectronSelection


### PR DESCRIPTION
@btcardwell I was slightly wrong in #149, the track producer runs a copy of the electron VID producer and needs to be considered.

This PR adds VID producers if either electrons or tracks are used.