### PR TITLE
Add muon rho

### DIFF
--- a/Collections/interface/Muon.h
+++ b/Collections/interface/Muon.h
@@ -19,6 +19,7 @@ namespace osu
         Muon (const TYPE(muons) &, const edm::Handle<vector<osu::Mcparticle> > &, const edm::ParameterSet &, const osu::Met &);
         ~Muon ();
 
+        const float rho() const;
         const double pfdBetaIsoCorr () const;
         const double sumChargedHadronPtCorr () const;
         const double sumPUPtCorr () const;
@@ -27,6 +28,7 @@ namespace osu
         const double d0SmearingVal () const;
         const bool isTightMuonWRTVtx() const { return isTightMuonWRTVtx_; }
         const bool isSoftMuonWRTVtx() const { return isSoftMuonWRTVtx_; }
+        void set_rho (float value) { rho_  = value; }
         void set_isTightMuonWRTVtx(const bool isTightMuon);
         void set_isSoftMuonWRTVtx(const bool isSoftMuon);
         void set_pfdBetaIsoCorr (double value) { pfdBetaIsoCorr_  = value; };
@@ -67,6 +69,7 @@ namespace osu
         const bool match_HLT_IsoMu27_v   () const { return get_hltMatch("HLT_IsoMu27_v"); };
 
       private:
+        float rho_;
         bool isTightMuonWRTVtx_;
         bool isSoftMuonWRTVtx_;
         double pfdBetaIsoCorr_;

--- a/Collections/plugins/OSUMuonProducer.cc
+++ b/Collections/plugins/OSUMuonProducer.cc
@@ -11,6 +11,7 @@ OSUMuonProducer::OSUMuonProducer (const edm::ParameterSet &cfg) :
   collections_     (cfg.getParameter<edm::ParameterSet> ("collections")),
   cfg_             (cfg),
   pfCandidate_     (cfg.getParameter<edm::InputTag>     ("pfCandidate")),
+  rho_             (cfg.getParameter<edm::InputTag>     ("rho")),
   d0SmearingWidth_ (cfg.getParameter<double>            ("d0SmearingWidth")),
   hltMatchingInfo_ (cfg.getParameter<vector<edm::ParameterSet> > ("hltMatchingInfo"))
 {
@@ -24,6 +25,7 @@ OSUMuonProducer::OSUMuonProducer (const edm::ParameterSet &cfg) :
   mcparticleToken_ = consumes<vector<osu::Mcparticle> > (collections_.getParameter<edm::InputTag> ("mcparticles"));
   prunedParticleToken_ = consumes<vector<reco::GenParticle> > (collections_.getParameter<edm::InputTag> ("hardInteractionMcparticles"));
   pfCandidateToken_ = consumes<vector<pat::PackedCandidate>>(pfCandidate_);
+  rhoToken_ = consumes<double> (rho_);
   beamspotToken_ = consumes<TYPE(beamspots)> (collections_.getParameter<edm::InputTag> ("beamspots"));
   primaryvertexToken_ = consumes<vector<TYPE(primaryvertexs)> > (collections_.getParameter<edm::InputTag> ("primaryvertexs"));
   metToken_ = consumes<vector<osu::Met> > (collections_.getParameter<edm::InputTag> ("mets"));
@@ -46,6 +48,9 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 
   Handle<vector<pat::PackedCandidate> > cands;
   event.getByToken(pfCandidateToken_, cands);
+
+  Handle<double> rho;
+  event.getByToken (rhoToken_, rho);
 
   Handle<vector<TYPE(primaryvertexs)> > vertices;
   event.getByToken (primaryvertexToken_, vertices);
@@ -73,6 +78,9 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
     {
       pl_->emplace_back (object, particles, cfg_, met->at (0));
       osu::Muon &muon = pl_->back ();
+
+      if(rho.isValid())
+        muon.set_rho((float)(*rho));
 
       if (!vertices->empty ())
         {

--- a/Collections/plugins/OSUMuonProducer.h
+++ b/Collections/plugins/OSUMuonProducer.h
@@ -30,11 +30,13 @@ class OSUMuonProducer : public edm::EDProducer
     edm::EDGetTokenT<vector<pat::PackedCandidate> > pfCandidateToken_;
     edm::EDGetTokenT<vector<TYPE(primaryvertexs)> > primaryvertexToken_;
     edm::EDGetTokenT<vector<osu::Met> > metToken_;
+    edm::EDGetTokenT<double> rhoToken_;
     edm::EDGetTokenT<edm::TriggerResults> triggersToken_;
     edm::EDGetTokenT<vector<pat::TriggerObjectStandAlone> > trigobjsToken_;
 
     edm::ParameterSet  cfg_;
     edm::InputTag      pfCandidate_;
+    edm::InputTag      rho_;
     double             d0SmearingWidth_;
     vector<edm::ParameterSet> hltMatchingInfo_;
 

--- a/Collections/src/Muon.cc
+++ b/Collections/src/Muon.cc
@@ -11,6 +11,7 @@ osu::Muon::Muon ()
 
 osu::Muon::Muon (const TYPE(muons) &muon) :
   GenMatchable             (muon),
+  rho_                     (INVALID_VALUE),
   isTightMuonWRTVtx_       (false),
   isSoftMuonWRTVtx_        (false),
   pfdBetaIsoCorr_          (INVALID_VALUE),
@@ -32,6 +33,7 @@ osu::Muon::Muon (const TYPE(muons) &muon) :
 
 osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcparticle> > &particles) :
   GenMatchable             (muon, particles),
+  rho_                     (INVALID_VALUE),
   isTightMuonWRTVtx_       (false),
   isSoftMuonWRTVtx_        (false),
   pfdBetaIsoCorr_          (INVALID_VALUE),
@@ -53,6 +55,7 @@ osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcpartic
 
 osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcparticle> > &particles, const edm::ParameterSet &cfg) :
   GenMatchable             (muon, particles, cfg),
+  rho_                     (INVALID_VALUE),
   isTightMuonWRTVtx_       (false),
   isSoftMuonWRTVtx_        (false),
   pfdBetaIsoCorr_          (INVALID_VALUE),
@@ -74,6 +77,7 @@ osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcpartic
 
 osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcparticle> > &particles, const edm::ParameterSet &cfg, const osu::Met &met) :
   GenMatchable             (muon, particles, cfg),
+  rho_                     (INVALID_VALUE),
   isTightMuonWRTVtx_       (false),
   isSoftMuonWRTVtx_        (false),
   pfdBetaIsoCorr_          (INVALID_VALUE),
@@ -116,6 +120,12 @@ void osu::Muon::set_isTightMuonWRTVtx (const bool isTightMuon)
 void osu::Muon::set_isSoftMuonWRTVtx (const bool isSoftMuon)
 {
   isSoftMuonWRTVtx_ = isSoftMuon;
+}
+
+const float
+osu::Muon::rho () const
+{
+  return this->rho_;
 }
 
 const double

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -167,6 +167,7 @@ collectionProducer.mets = cms.EDProducer ("OSUMetProducer",
 
 collectionProducer.muons = cms.EDProducer ("OSUMuonProducer",
     pfCandidate =  cms.InputTag  ('packedPFCandidates','',''),
+    rho         =  cms.InputTag  ('fixedGridRhoFastjetAll','',''),
     d0SmearingWidth = cms.double (-1.0),
     hltMatchingInfo = cms.VPSet (
         cms.PSet(name = cms.string("HLT_IsoMu20_v"),   collection = cms.string("hltL3MuonCandidates::HLT"),     filter = cms.string("hltL3crIsoL1sMu16L1f0L2f10QL3f20QL3trkIsoFiltered0p09")),


### PR DESCRIPTION
Add rho variable (fixedGridRhoFastjetAll) to muon object for new muon isolation definition in Displaced Leptons. All other needed changes can be implemented in our analysis repo. I have tested this PR and believe it to be ready to merge.