### PR TITLE
Add uniqueMotherPdgId to Mcparticle

### DIFF
--- a/Collections/interface/Mcparticle.h
+++ b/Collections/interface/Mcparticle.h
@@ -13,7 +13,15 @@ namespace osu
         Mcparticle ();
         Mcparticle (const TYPE(mcparticles) &);
         ~Mcparticle ();
+
+	const int uniqueMotherPdgId () const;
+
+	void set_uniqueMotherPdgId (double value) { uniqueMotherPdgId_  = value; };
+
+	int uniqueMotherPdgId_;
+
     };
+
 }
 
 #else

--- a/Collections/plugins/HardInteractionMcparticleProducer.cc
+++ b/Collections/plugins/HardInteractionMcparticleProducer.cc
@@ -30,8 +30,8 @@ HardInteractionMcparticleProducer::produce (edm::Event &event, const edm::EventS
     pl_->emplace_back (object);
     osu::HardInteractionMcparticle &hiMcpart = pl_->back();
 
-    if(!uniqueMother(hiMcpart)) continue;
-    hiMcpart.set_uniqueMotherPdgId(uniqueMother(hiMcpart)->pdgId());
+    const reco::Candidate *uniqueMo = uniqueMother(hiMcpart);
+    if (uniqueMo) hiMcpart.set_uniqueMotherPdgId(uniqueMo->pdgId());
   }
 
   event.put (std::move (pl_), collection_.instance ());

--- a/Collections/plugins/McparticleProducer.cc
+++ b/Collections/plugins/McparticleProducer.cc
@@ -26,11 +26,29 @@ McparticleProducer::produce (edm::Event &event, const edm::EventSetup &setup)
     return;
 
   pl_ = unique_ptr<vector<osu::Mcparticle> > (new vector<osu::Mcparticle> ());
-  for (const auto &object : *collection)
+  for (const auto &object : *collection) {
     pl_->emplace_back (object);
+    osu::Mcparticle &mcpart = pl_->back();
+
+    if(!uniqueMother(mcpart)) continue;
+    mcpart.set_uniqueMotherPdgId(uniqueMother(mcpart)->pdgId());
+  }
 
   event.put (std::move (pl_), collection_.instance ());
   pl_.reset ();
+}
+
+const reco::Candidate *
+McparticleProducer::uniqueMother(const TYPE(mcparticles) &p) const {
+  const reco::Candidate *mo = &p;
+  std::unordered_set<const reco::Candidate *> dupCheck;
+  while (mo && mo->pdgId() == p.pdgId()) {
+    dupCheck.insert(mo);
+    mo = mo->mother();
+    if (dupCheck.count(mo))
+      return nullptr;
+  }
+  return mo;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Collections/plugins/McparticleProducer.cc
+++ b/Collections/plugins/McparticleProducer.cc
@@ -30,8 +30,8 @@ McparticleProducer::produce (edm::Event &event, const edm::EventSetup &setup)
     pl_->emplace_back (object);
     osu::Mcparticle &mcpart = pl_->back();
 
-    if(!uniqueMother(mcpart)) continue;
-    mcpart.set_uniqueMotherPdgId(uniqueMother(mcpart)->pdgId());
+    const reco::Candidate *uniqueMo = uniqueMother(mcpart);
+    if (uniqueMo) mcpart.set_uniqueMotherPdgId(uniqueMo->pdgId());
   }
 
   event.put (std::move (pl_), collection_.instance ());

--- a/Collections/plugins/McparticleProducer.h
+++ b/Collections/plugins/McparticleProducer.h
@@ -27,6 +27,8 @@ class McparticleProducer : public edm::EDProducer
 
     // Payload for this EDFilter.
     unique_ptr<vector<osu::Mcparticle> > pl_;
+
+    const reco::Candidate * uniqueMother (const TYPE(mcparticles) &) const;
 };
 
 #endif

--- a/Collections/src/Mcparticle.cc
+++ b/Collections/src/Mcparticle.cc
@@ -7,8 +7,15 @@ osu::Mcparticle::Mcparticle ()
 }
 
 osu::Mcparticle::Mcparticle (const TYPE(mcparticles) &mcparticle) :
-  TYPE(mcparticles) (mcparticle)
+  TYPE(mcparticles)  (mcparticle),
+  uniqueMotherPdgId_ (INVALID_VALUE)
 {
+}
+
+const int
+osu::Mcparticle::uniqueMotherPdgId () const
+{
+  return uniqueMotherPdgId_;
 }
 
 osu::Mcparticle::~Mcparticle ()


### PR DESCRIPTION
Add uniqueMotherPdgId to Mcparticle following the implementation in HardInteractionMcparticle. This works as expected when tested in 10_2_12.