### PR TITLE
add hardInteractionMcparticleD0WRTBeamspot definition

### DIFF
--- a/Configuration/python/cutUtilities.py
+++ b/Configuration/python/cutUtilities.py
@@ -66,6 +66,7 @@ muonD0WRTPV       = "((muon.vx - eventvariable.leadingPV_x) * muon.py - (muon.vy
 
 muonSmearedD0WRTBeamspot = "(muon.d0SmearingVal + ((muon.vx - beamspot.x0) * muon.py - (muon.vy - beamspot.y0) * muon.px) / muon.pt)"
 
+hardInteractionMcparticleD0WRTBeamspot = "((hardInteractionMcparticle.vx - beamspot.x0) * hardInteractionMcparticle.py - (hardInteractionMcparticle.vy - beamspot.y0) * hardInteractionMcparticle.px) / hardInteractionMcparticle.pt"
 
 # Calculation from https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/DataFormats/TrackReco/interface/TrackBase.h#L674
 electronDZWRTBeamspot = "(electron.vz - beamspot.z0) \


### PR DESCRIPTION
Adds a useful definition for gen-level plots

Validated by producing the plot attached (hist defined in DisplacedSUSY package)

<img width="683" alt="Screen Shot 2020-05-22 at 5 03 48 PM" src="https://user-images.githubusercontent.com/5177191/82681667-6559fd80-9c4e-11ea-9f37-c1bceaee30b7.png">
