### PR TITLE
add EventSetup to EventVariableProducers

### DIFF
--- a/AnaTools/interface/EventVariableProducer.h
+++ b/AnaTools/interface/EventVariableProducer.h
@@ -32,7 +32,7 @@ class EventVariableProducer : public edm::EDFilter
 
       // Methods
 
-      virtual void AddVariables(const edm::Event &) = 0;
+      virtual void AddVariables(const edm::Event &, const edm::EventSetup &) = 0;
 
   };
 

--- a/AnaTools/plugins/ISRWeightProducer.cc
+++ b/AnaTools/plugins/ISRWeightProducer.cc
@@ -21,7 +21,7 @@ ISRWeightProducer::~ISRWeightProducer() {
 }
 
 void
-ISRWeightProducer::AddVariables (const edm::Event &event) {
+ISRWeightProducer::AddVariables (const edm::Event &event, const edm::EventSetup &setup) {
 
 #ifndef STOPPPED_PTLS
   if(event.isRealData() || weightFile_.empty () || weightHist_.empty ()) {
@@ -70,8 +70,8 @@ ISRWeightProducer::AddVariables (const edm::Event &event) {
 
   for(const auto &mcparticle : *mcparticles) {
 
-    // Pythia8 first creates particles in the frame of the interaction, and only boosts them 
-    // for ISR recoil in later steps. So only the last copy is desired. A particle that's both 
+    // Pythia8 first creates particles in the frame of the interaction, and only boosts them
+    // for ISR recoil in later steps. So only the last copy is desired. A particle that's both
     // a last and first copy means it is a decay product created after the boost is applied,
     // e.g. a neutralino from a chargino decay, and we've already added the mother chargino.
     if(requireLastNotFirstCopy_) {
@@ -80,13 +80,13 @@ ISRWeightProducer::AddVariables (const edm::Event &event) {
     }
 
     for(const auto &pdgId : pdgIds_) {
-      if(mcparticle.numberOfMothers() && 
-         !mcparticle.motherRef().isNull() && 
+      if(mcparticle.numberOfMothers() &&
+         !mcparticle.motherRef().isNull() &&
          find(motherIdsToReject_.begin(), motherIdsToReject_.end(), abs(mcparticle.motherRef()->pdgId())) != motherIdsToReject_.end()) {
         continue;
       }
 
-      if(abs(mcparticle.pdgId()) == abs(pdgId) && 
+      if(abs(mcparticle.pdgId()) == abs(pdgId) &&
          (requireLastNotFirstCopy_ || isOriginalParticle(mcparticle, mcparticle.pdgId()))) {
         px += mcparticle.px();
         py += mcparticle.py();

--- a/AnaTools/plugins/ISRWeightProducer.h
+++ b/AnaTools/plugins/ISRWeightProducer.h
@@ -29,7 +29,7 @@ private:
   vector<TH1D *> weights_;
 
   bool isOriginalParticle (const TYPE(hardInteractionMcparticles) &, const int) const;
-  void AddVariables(const edm::Event &);
+  void AddVariables(const edm::Event &, const edm::EventSetup &);
 };
 
 #endif

--- a/AnaTools/plugins/L1PrefiringWeightProducer.cc
+++ b/AnaTools/plugins/L1PrefiringWeightProducer.cc
@@ -21,7 +21,7 @@ L1PrefiringWeightProducer::~L1PrefiringWeightProducer() {
 }
 
 void
-L1PrefiringWeightProducer::AddVariables(const edm::Event &event) {
+L1PrefiringWeightProducer::AddVariables(const edm::Event &event, const edm::EventSetup &setup) {
   double w = 1.0, wUp = 1.0, wDown = 1.0;
   bool hasPrefiredJets = false;
 

--- a/AnaTools/plugins/L1PrefiringWeightProducer.h
+++ b/AnaTools/plugins/L1PrefiringWeightProducer.h
@@ -19,6 +19,6 @@ class L1PrefiringWeightProducer : public EventVariableProducer
 
         edm::EDGetTokenT<vector<TYPE(jets)> > tokenJets_;
 
-        void AddVariables(const edm::Event &);
+        void AddVariables(const edm::Event &, const edm::EventSetup &);
 };
 #endif

--- a/AnaTools/plugins/LifetimeWeightProducer.cc
+++ b/AnaTools/plugins/LifetimeWeightProducer.cc
@@ -22,12 +22,12 @@ LifetimeWeightProducer::LifetimeWeightProducer(const edm::ParameterSet &cfg) :
     srcCTau_.push_back      (reweightingRules_[iRule].getParameter<vector<double> > ("srcCTaus"));
     pdgIds_.push_back       (reweightingRules_[iRule].getParameter<vector<int> >    ("pdgIds"));
     isDefaultRule_.push_back(reweightingRules_[iRule].getParameter<bool>            ("isDefaultRule"));
-    assert(srcCTau_.back().size() == dstCTau_.back().size() && 
+    assert(srcCTau_.back().size() == dstCTau_.back().size() &&
            pdgIds_.back().size() == dstCTau_.back().size());
 
     suffix.str("");
     for(unsigned int iPdgId = 0; iPdgId < pdgIds_.back().size(); iPdgId++) {
-      suffix << "_" << pdgIds_.back()[iPdgId] << "_" 
+      suffix << "_" << pdgIds_.back()[iPdgId] << "_"
              << srcCTau_.back()[iPdgId] << "cmTo";
       if(dstCTau_.back()[iPdgId] < 1.0) {
         suffix << "0p" << dstCTau_.back()[iPdgId] * 10 << "cm";
@@ -36,7 +36,7 @@ LifetimeWeightProducer::LifetimeWeightProducer(const edm::ParameterSet &cfg) :
         suffix<< dstCTau_.back()[iPdgId] << "cm";
       }
     }
-    
+
     weights_.push_back(1.0);
     weightNames_.push_back("lifetimeWeight" + suffix.str());
   }
@@ -47,7 +47,7 @@ LifetimeWeightProducer::~LifetimeWeightProducer() {
 }
 
 void
-LifetimeWeightProducer::AddVariables(const edm::Event &event) {
+LifetimeWeightProducer::AddVariables(const edm::Event &event, const edm::EventSetup &setup) {
 
 #ifndef STOPPPED_PTLS
   for(unsigned int iRule = 0; iRule < weights_.size(); iRule++) weights_[iRule] = 1.0;
@@ -81,8 +81,8 @@ LifetimeWeightProducer::AddVariables(const edm::Event &event) {
     vector<vector<double> > gammaFactors(pdgIds_[iRule].size());
 
     for(const auto &mcparticle: *mcparticles) {
-      // Pythia8 first creates particles in the frame of the interaction, and only boosts them 
-      // for ISR recoil in later steps. So only the last copy is desired. A particle that's both 
+      // Pythia8 first creates particles in the frame of the interaction, and only boosts them
+      // for ISR recoil in later steps. So only the last copy is desired. A particle that's both
       // a last and first copy means it is a decay product created after the boost is applied,
       // e.g. a neutralino from a chargino decay, and we've already added the mother chargino.
       if(requireLastNotFirstCopy_) {
@@ -117,7 +117,7 @@ LifetimeWeightProducer::AddVariables(const edm::Event &event) {
         // overwritten for every rule but the ordering/index is always the same, so it will be fine
         suffix.str("");
         suffix << "_" << abs(pdgIds_[iRule][iPdgId]) << "_" << index++;
-        
+
         (*eventvariables)["cTau" + suffix.str()] = cTau;
         (*eventvariables)["decayLength" + suffix.str()] = decayLengths[iPdgId][i_cTau];
         (*eventvariables)["beta" + suffix.str()] = betaFactors[iPdgId][i_cTau];

--- a/AnaTools/plugins/LifetimeWeightProducer.h
+++ b/AnaTools/plugins/LifetimeWeightProducer.h
@@ -30,6 +30,6 @@ class LifetimeWeightProducer : public EventVariableProducer {
         TVector3 getEndVertex(const TYPE(hardInteractionMcparticles) &) const;
         void getFinalPosition(const reco::Candidate &, const int, bool, math::XYZPoint &) const;
 
-        void AddVariables(const edm::Event &);
+        void AddVariables(const edm::Event &, const edm::EventSetup &);
 };
 #endif

--- a/AnaTools/plugins/ObjectScalingFactorProducer.cc
+++ b/AnaTools/plugins/ObjectScalingFactorProducer.cc
@@ -55,7 +55,7 @@ ObjectScalingFactorProducer::ObjectScalingFactorProducer(const edm::ParameterSet
 ObjectScalingFactorProducer::~ObjectScalingFactorProducer() {}
 
 void
-ObjectScalingFactorProducer::AddVariables (const edm::Event &event) {
+ObjectScalingFactorProducer::AddVariables (const edm::Event &event, const edm::EventSetup &setup) {
 #if DATA_FORMAT_FROM_MINIAOD
   if (event.isRealData ()) {
     for (auto &sf : scaleFactors_) {

--- a/AnaTools/plugins/ObjectScalingFactorProducer.h
+++ b/AnaTools/plugins/ObjectScalingFactorProducer.h
@@ -30,7 +30,7 @@ class ObjectScalingFactorProducer : public EventVariableProducer
         bool doEleSF_;
         bool doMuSF_;
         bool doTrackSF_;
-        void AddVariables(const edm::Event &);
+        void AddVariables(const edm::Event &, const edm::EventSetup &);
               vector<ScaleFactor> scaleFactors_;
 
 };

--- a/AnaTools/plugins/PUScalingFactorProducer.cc
+++ b/AnaTools/plugins/PUScalingFactorProducer.cc
@@ -25,7 +25,7 @@ PUScalingFactorProducer::~PUScalingFactorProducer() {
 }
 
 void
-PUScalingFactorProducer::AddVariables (const edm::Event &event) {
+PUScalingFactorProducer::AddVariables (const edm::Event &event, const edm::EventSetup &setup) {
 #if DATA_FORMAT_FROM_MINIAOD
   if (!event.isRealData () && PU_ != "" && dataset_ != "" && target_ != "")
     {

--- a/AnaTools/plugins/PUScalingFactorProducer.h
+++ b/AnaTools/plugins/PUScalingFactorProducer.h
@@ -25,7 +25,7 @@ class PUScalingFactorProducer : public EventVariableProducer
         TH1D *puWeightUp_;
         TH1D *puWeightDown_;
         bool isFirstEvent_;
-        void AddVariables(const edm::Event &);
+        void AddVariables(const edm::Event &, const edm::EventSetup &);
 
         edm::EDGetTokenT<vector<TYPE(pileupinfos)> > pileUpInfosToken_;
 };

--- a/AnaTools/plugins/PrimaryVtxVarProducer.cc
+++ b/AnaTools/plugins/PrimaryVtxVarProducer.cc
@@ -11,7 +11,7 @@ PrimaryVtxVarProducer::PrimaryVtxVarProducer(const edm::ParameterSet &cfg) :
 PrimaryVtxVarProducer::~PrimaryVtxVarProducer() {}
 
 void
-PrimaryVtxVarProducer::AddVariables (const edm::Event &event) {
+PrimaryVtxVarProducer::AddVariables (const edm::Event &event, const edm::EventSetup &setup) {
 
   edm::Handle<vector<TYPE(primaryvertexs)> > primaryvertexs;
   if (!event.getByToken (token_, primaryvertexs)) {

--- a/AnaTools/plugins/PrimaryVtxVarProducer.h
+++ b/AnaTools/plugins/PrimaryVtxVarProducer.h
@@ -14,7 +14,7 @@ class PrimaryVtxVarProducer : public EventVariableProducer
         ~PrimaryVtxVarProducer ();
 
     private:
-        void AddVariables(const edm::Event &);
+        void AddVariables(const edm::Event &, const edm::EventSetup &);
         edm::EDGetTokenT<vector<TYPE(primaryvertexs)> > token_;
   };
 

--- a/AnaTools/src/EventVariableProducer.cc
+++ b/AnaTools/src/EventVariableProducer.cc
@@ -22,7 +22,7 @@ EventVariableProducer::filter (edm::Event &event, const edm::EventSetup &setup)
   eventvariables = unique_ptr<EventVariableProducerPayload> (new EventVariableProducerPayload);
 
   ////////////////////////////////////////////////////////////////////////
-  AddVariables(event);
+  AddVariables(event, setup);
 
   bool filterDecision = true;
   if (eventvariables->count ("EventVariableProducerFilterDecision"))

--- a/ExampleAnalysis/plugins/MyVariableProducer.cc
+++ b/ExampleAnalysis/plugins/MyVariableProducer.cc
@@ -21,7 +21,7 @@ MyVariableProducer::MyVariableProducer(const edm::ParameterSet &cfg) :
 MyVariableProducer::~MyVariableProducer() {}
 
 void
-MyVariableProducer::AddVariables (const edm::Event &event) {
+MyVariableProducer::AddVariables (const edm::Event &event, const edm::EventSetup &setup) {
 
   // Add all of the needed collections to objectsToGet_
   objectsToGet_.insert ("muon");

--- a/ExampleAnalysis/plugins/MyVariableProducer.h
+++ b/ExampleAnalysis/plugins/MyVariableProducer.h
@@ -39,7 +39,7 @@ class MyVariableProducer : public EventVariableProducer
     private:
 
         // Functions
-        void AddVariables(const edm::Event &);
+        void AddVariables(const edm::Event &, const edm::EventSetup &);
   };
 
 #endif


### PR DESCRIPTION
Added the edm::EventSetup to AddVariables in the EventVariableProducer

For example, useful for getting the L1 information in an event variable producer with 
```l1GtUtils_->retrieveL1(event,setup,algToken_);```

This PR will require everyone to make similar changes for all of their event variable producers in their respective packages.

Tested locally with the DisplacedSUSY event variable producer: can indeed retrieve the L1 info.