### PR TITLE
Add beamspot and gen-level lepton track reference point information to electrons and muons

### DIFF
--- a/Collections/interface/Electron.h
+++ b/Collections/interface/Electron.h
@@ -24,6 +24,10 @@ namespace osu
         const double sumChargedHadronPtCorr () const;
         const double sumPUPtCorr () const;
         const int electronPVIndex () const;
+        const double genVx () const;
+        const double genVy () const;
+        const double genPx () const;
+        const double genPy () const;
         const double genD0 () const;
         const double d0SmearingVal () const;
         const float dEtaInSeed () const;
@@ -53,6 +57,10 @@ namespace osu
         void set_sumChargedHadronPtCorr (double value) { sumChargedHadronPtCorr_  = value; };
         void set_sumPUPtCorr (double value) { sumPUPtCorr_  = value; };
         void set_electronPVIndex (int value) { electronPVIndex_  = value; };
+        void set_genVx (double value) { genVx_  = value; };
+        void set_genVy (double value) { genVy_  = value; };
+        void set_genPx (double value) { genPx_  = value; };
+        void set_genPy (double value) { genPy_  = value; };
         void set_genD0 (double value) { genD0_  = value; };
         void set_d0SmearingVal (double value) { d0SmearingVal_  = value; };
         void set_passesTightID_noIsolation_LegacySpring15 (const reco::BeamSpot &, const TYPE(primaryvertexs) &, const edm::Handle<vector<reco::Conversion> > &);
@@ -103,6 +111,10 @@ namespace osu
         double sumChargedHadronPtCorr_;
         int electronPVIndex_;
         double sumPUPtCorr_;
+        double genVx_;
+        double genVy_;
+        double genPx_;
+        double genPy_;
         double genD0_;
         double d0SmearingVal_;
         bool passesTightID_noIsolation_LegacySpring15_;

--- a/Collections/interface/Muon.h
+++ b/Collections/interface/Muon.h
@@ -24,6 +24,10 @@ namespace osu
         const double sumChargedHadronPtCorr () const;
         const double sumPUPtCorr () const;
         const int muonPVIndex () const;
+        const double genVx () const;
+        const double genVy () const;
+        const double genPx () const;
+        const double genPy () const;
         const double genD0 () const;
         const double d0SmearingVal () const;
         const bool isTightMuonWRTVtx() const { return isTightMuonWRTVtx_; }
@@ -35,6 +39,10 @@ namespace osu
         void set_sumChargedHadronPtCorr (double value) { sumChargedHadronPtCorr_  = value; };
         void set_sumPUPtCorr (double value) { sumPUPtCorr_  = value; };
         void set_muonPVIndex (int value) { muonPVIndex_  = value; };
+        void set_genVx (double value) { genVx_  = value; };
+        void set_genVy (double value) { genVy_  = value; };
+        void set_genPx (double value) { genPx_  = value; };
+        void set_genPy (double value) { genPy_  = value; };
         void set_genD0 (double value) { genD0_  = value; };
         void set_d0SmearingVal (double value) { d0SmearingVal_  = value; };
 
@@ -76,6 +84,10 @@ namespace osu
         double sumChargedHadronPtCorr_;
         int muonPVIndex_;
         double sumPUPtCorr_;
+        double genVx_;
+        double genVy_;
+        double genPx_;
+        double genPy_;
         double genD0_;
         double d0SmearingVal_;
 

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -146,7 +146,15 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	    {
 	      if (!(abs(cand->pdgId()) == 11 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < 0.1))
 		continue;
+	      double gen_vx = cand->vx();
+	      double gen_vy = cand->vy();
+	      double gen_px = cand->px();
+	      double gen_py = cand->py();
 	      double gen_d0 = ((-(cand->vx() - beamspot->x0())*cand->py() + (cand->vy() - beamspot->y0())*cand->px())/cand->pt());
+	      electron.set_genVx(gen_vx);
+	      electron.set_genVy(gen_vy);
+	      electron.set_genPx(gen_px);
+	      electron.set_genPy(gen_py);
 	      electron.set_genD0(gen_d0);
 	    }
 	}

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -145,7 +145,7 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	  for (auto cand = prunedParticles->begin(); cand != prunedParticles->end(); cand++)
 	    {
 	      if (!(cand->status() == 1 && abs(cand->pdgId()) == 11 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < 0.1))
-               continue;
+            continue;
 	      double gen_vx = cand->vx();
 	      double gen_vy = cand->vy();
 	      double gen_px = cand->px();
@@ -156,7 +156,7 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	      electron.set_genPx(gen_px);
 	      electron.set_genPy(gen_py);
 	      electron.set_genD0(gen_d0);
-             break;
+          break;
 	    }
 	}
 

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -144,8 +144,8 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	{
 	  for (auto cand = prunedParticles->begin(); cand != prunedParticles->end(); cand++)
 	    {
-	      if (!(abs(cand->pdgId()) == 11 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < 0.1))
-		continue;
+	      if (!(cand->status() == 1 && abs(cand->pdgId()) == 11 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < 0.1))
+               continue;
 	      double gen_vx = cand->vx();
 	      double gen_vy = cand->vy();
 	      double gen_px = cand->px();
@@ -156,6 +156,7 @@ OSUElectronProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	      electron.set_genPx(gen_px);
 	      electron.set_genPy(gen_py);
 	      electron.set_genD0(gen_d0);
+             break;
 	    }
 	}
 

--- a/Collections/plugins/OSUElectronProducer.h
+++ b/Collections/plugins/OSUElectronProducer.h
@@ -50,6 +50,7 @@ class OSUElectronProducer : public edm::EDProducer
     edm::InputTag      vidTightIdMap_;
     EffectiveAreas     effectiveAreas_;
     double             d0SmearingWidth_;
+    double             genD0DR_;
 
     TRandom3* rng;
 

--- a/Collections/plugins/OSUMuonProducer.cc
+++ b/Collections/plugins/OSUMuonProducer.cc
@@ -110,7 +110,7 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	  for (auto cand = prunedParticles->begin(); cand != prunedParticles->end(); cand++)
 	    {
 	      if (!(cand->status() == 1 && abs(cand->pdgId()) == 13 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < 0.1))
-               continue;
+            continue;
 	      double gen_vx = cand->vx();
 	      double gen_vy = cand->vy();
 	      double gen_px = cand->px();
@@ -121,7 +121,7 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	      muon.set_genPx(gen_px);
 	      muon.set_genPy(gen_py);
 	      muon.set_genD0(gen_d0);
-             break;
+           break;
 	    }
 	}
 

--- a/Collections/plugins/OSUMuonProducer.cc
+++ b/Collections/plugins/OSUMuonProducer.cc
@@ -109,8 +109,8 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	{
 	  for (auto cand = prunedParticles->begin(); cand != prunedParticles->end(); cand++)
 	    {
-	      if (!(abs(cand->pdgId()) == 13 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < 0.1))
-		continue;
+	      if (!(cand->status() == 1 && abs(cand->pdgId()) == 13 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < 0.1))
+               continue;
 	      double gen_vx = cand->vx();
 	      double gen_vy = cand->vy();
 	      double gen_px = cand->px();
@@ -121,6 +121,7 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	      muon.set_genPx(gen_px);
 	      muon.set_genPy(gen_py);
 	      muon.set_genD0(gen_d0);
+             break;
 	    }
 	}
 

--- a/Collections/plugins/OSUMuonProducer.cc
+++ b/Collections/plugins/OSUMuonProducer.cc
@@ -13,6 +13,7 @@ OSUMuonProducer::OSUMuonProducer (const edm::ParameterSet &cfg) :
   pfCandidate_     (cfg.getParameter<edm::InputTag>     ("pfCandidate")),
   rho_             (cfg.getParameter<edm::InputTag>     ("rho")),
   d0SmearingWidth_ (cfg.getParameter<double>            ("d0SmearingWidth")),
+  genD0DR_         (cfg.getParameter<double>            ("genD0DR")),
   hltMatchingInfo_ (cfg.getParameter<vector<edm::ParameterSet> > ("hltMatchingInfo"))
 {
   collection_ = collections_.getParameter<edm::InputTag> ("muons");
@@ -104,12 +105,13 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
           }
         }
 
-      //generator D0 must be done with prunedGenParticles because vertex is only right in this collection, not right in packedGenParticles
+      // generator D0 must be done with prunedGenParticles because vertex is only right in this collection, not right in packedGenParticles
+      // this is a temporary solution; extending GenMatchable to use prunedGenParticles would be better
       if(prunedParticles.isValid() && beamspot.isValid())
 	{
 	  for (auto cand = prunedParticles->begin(); cand != prunedParticles->end(); cand++)
 	    {
-	      if (!(cand->status() == 1 && abs(cand->pdgId()) == 13 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < 0.1))
+	      if (!(cand->status() == 1 && abs(cand->pdgId()) == 13 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < genD0DR_))
             continue;
 	      double gen_vx = cand->vx();
 	      double gen_vy = cand->vy();

--- a/Collections/plugins/OSUMuonProducer.cc
+++ b/Collections/plugins/OSUMuonProducer.cc
@@ -111,7 +111,15 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
 	    {
 	      if (!(abs(cand->pdgId()) == 13 && deltaR(object.eta(),object.phi(),cand->eta(),cand->phi()) < 0.1))
 		continue;
+	      double gen_vx = cand->vx();
+	      double gen_vy = cand->vy();
+	      double gen_px = cand->px();
+	      double gen_py = cand->py();
 	      double gen_d0 = ((-(cand->vx() - beamspot->x0())*cand->py() + (cand->vy() - beamspot->y0())*cand->px())/cand->pt());
+	      muon.set_genVx(gen_vx);
+	      muon.set_genVy(gen_vy);
+	      muon.set_genPx(gen_px);
+	      muon.set_genPy(gen_py);
 	      muon.set_genD0(gen_d0);
 	    }
 	}

--- a/Collections/plugins/OSUMuonProducer.h
+++ b/Collections/plugins/OSUMuonProducer.h
@@ -38,6 +38,7 @@ class OSUMuonProducer : public edm::EDProducer
     edm::InputTag      pfCandidate_;
     edm::InputTag      rho_;
     double             d0SmearingWidth_;
+    double             genD0DR_;
     vector<edm::ParameterSet> hltMatchingInfo_;
 
     TRandom3* rng;

--- a/Collections/src/Electron.cc
+++ b/Collections/src/Electron.cc
@@ -18,6 +18,10 @@ osu::Electron::Electron (const TYPE(electrons) &electron) :
   sumChargedHadronPtCorr_               (INVALID_VALUE),
   electronPVIndex_                      (INVALID_VALUE),
   sumPUPtCorr_                          (INVALID_VALUE),
+  genVx_                                (INVALID_VALUE),
+  genVy_                                (INVALID_VALUE),
+  genPx_                                (INVALID_VALUE),
+  genPy_                                (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
   d0SmearingVal_                        (INVALID_VALUE),
   passesTightID_noIsolation_LegacySpring15_ (false),
@@ -55,6 +59,10 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   sumChargedHadronPtCorr_               (INVALID_VALUE),
   electronPVIndex_                      (INVALID_VALUE),
   sumPUPtCorr_                          (INVALID_VALUE),
+  genVx_                                (INVALID_VALUE),
+  genVy_                                (INVALID_VALUE),
+  genPx_                                (INVALID_VALUE),
+  genPy_                                (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
   d0SmearingVal_                        (INVALID_VALUE),
   passesTightID_noIsolation_LegacySpring15_ (false),
@@ -92,6 +100,10 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   sumChargedHadronPtCorr_               (INVALID_VALUE),
   electronPVIndex_                      (INVALID_VALUE),
   sumPUPtCorr_                          (INVALID_VALUE),
+  genVx_                                (INVALID_VALUE),
+  genVy_                                (INVALID_VALUE),
+  genPx_                                (INVALID_VALUE),
+  genPy_                                (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
   d0SmearingVal_                        (INVALID_VALUE),
   passesTightID_noIsolation_LegacySpring15_ (false),
@@ -129,6 +141,10 @@ osu::Electron::Electron (const TYPE(electrons) &electron, const edm::Handle<vect
   sumChargedHadronPtCorr_               (INVALID_VALUE),
   electronPVIndex_                      (INVALID_VALUE),
   sumPUPtCorr_                          (INVALID_VALUE),
+  genVx_                                (INVALID_VALUE),
+  genVy_                                (INVALID_VALUE),
+  genPx_                                (INVALID_VALUE),
+  genPy_                                (INVALID_VALUE),
   genD0_                                (INVALID_VALUE),
   d0SmearingVal_                        (INVALID_VALUE),
   passesTightID_noIsolation_LegacySpring15_ (false),
@@ -268,6 +284,30 @@ const double
 osu::Electron::sumPUPtCorr () const
 {
   return sumPUPtCorr_;
+}
+
+const double
+osu::Electron::genVx () const
+{
+  return genVx_;
+}
+
+const double
+osu::Electron::genVy () const
+{
+  return genVy_;
+}
+
+const double
+osu::Electron::genPx () const
+{
+  return genPx_;
+}
+
+const double
+osu::Electron::genPy () const
+{
+  return genPy_;
 }
 
 const double

--- a/Collections/src/Muon.cc
+++ b/Collections/src/Muon.cc
@@ -18,6 +18,10 @@ osu::Muon::Muon (const TYPE(muons) &muon) :
   sumChargedHadronPtCorr_  (INVALID_VALUE),
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
+  genVx_                   (INVALID_VALUE),
+  genVy_                   (INVALID_VALUE),
+  genPx_                   (INVALID_VALUE),
+  genPy_                   (INVALID_VALUE),
   genD0_                   (INVALID_VALUE),
   d0SmearingVal_           (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
@@ -40,6 +44,10 @@ osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcpartic
   sumChargedHadronPtCorr_  (INVALID_VALUE),
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
+  genVx_                   (INVALID_VALUE),
+  genVy_                   (INVALID_VALUE),
+  genPx_                   (INVALID_VALUE),
+  genPy_                   (INVALID_VALUE),
   genD0_                   (INVALID_VALUE),
   d0SmearingVal_           (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
@@ -62,6 +70,10 @@ osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcpartic
   sumChargedHadronPtCorr_  (INVALID_VALUE),
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
+  genVx_                   (INVALID_VALUE),
+  genVy_                   (INVALID_VALUE),
+  genPx_                   (INVALID_VALUE),
+  genPy_                   (INVALID_VALUE),
   genD0_                   (INVALID_VALUE),
   d0SmearingVal_           (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
@@ -84,6 +96,10 @@ osu::Muon::Muon (const TYPE(muons) &muon, const edm::Handle<vector<osu::Mcpartic
   sumChargedHadronPtCorr_  (INVALID_VALUE),
   muonPVIndex_             (INVALID_VALUE),
   sumPUPtCorr_             (INVALID_VALUE),
+  genVx_                   (INVALID_VALUE),
+  genVy_                   (INVALID_VALUE),
+  genPx_                   (INVALID_VALUE),
+  genPy_                   (INVALID_VALUE),
   genD0_                   (INVALID_VALUE),
   d0SmearingVal_           (INVALID_VALUE),
   metMinusOnePt_           (INVALID_VALUE),
@@ -149,6 +165,30 @@ const double
 osu::Muon::sumPUPtCorr () const
 {
   return sumPUPtCorr_;
+}
+
+const double
+osu::Muon::genVx () const
+{
+  return genVx_;
+}
+
+const double
+osu::Muon::genVy () const
+{
+  return genVy_;
+}
+
+const double
+osu::Muon::genPx () const
+{
+  return genPx_;
+}
+
+const double
+osu::Muon::genPy () const
+{
+  return genPy_;
 }
 
 const double

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -77,6 +77,7 @@ collectionProducer.electrons = cms.EDProducer ("OSUElectronProducer",
     ootESClusters   = cms.InputTag ("reducedEgamma", "reducedOOTESClusters",   ""),
 
     d0SmearingWidth = cms.double (-1.0),
+    genD0DR         = cms.double (0.1),
 
 )
 
@@ -169,6 +170,7 @@ collectionProducer.muons = cms.EDProducer ("OSUMuonProducer",
     pfCandidate =  cms.InputTag  ('packedPFCandidates','',''),
     rho         =  cms.InputTag  ('fixedGridRhoFastjetAll','',''),
     d0SmearingWidth = cms.double (-1.0),
+    genD0DR         = cms.double (0.1),
     hltMatchingInfo = cms.VPSet (
         cms.PSet(name = cms.string("HLT_IsoMu20_v"),   collection = cms.string("hltL3MuonCandidates::HLT"),     filter = cms.string("hltL3crIsoL1sMu16L1f0L2f10QL3f20QL3trkIsoFiltered0p09")),
         cms.PSet(name = cms.string("HLT_IsoTkMu20_v"), collection = cms.string("hltHighPtTkMuonCands::HLT"),    filter = cms.string("hltL3fL1sMu16L1f0Tkf20QL3trkIsoFiltered0p09")),


### PR DESCRIPTION
This has been tested in CMSSW 10_2_12 and works as expected. I believe it can be merged as is, though if it makes sense to others, I can first add the minor improvement described below.

I notice that a small fraction of the time, the matched gen particle is really low pT. I haven't looked into it yet, but does anyone know if the prunedGenParticles is pT ordered? If so, it might be smarter to iterate backwards through the collection so the highest-pT match is saved instead of the lowest.