### PR TITLE
improvements for makeEfficiencyPlot.py and makeComparisonPlots.py

### DIFF
--- a/Configuration/python/cutUtilities.py
+++ b/Configuration/python/cutUtilities.py
@@ -59,12 +59,16 @@ electronD0WRTPV       = "((electron.vx - eventvariable.leadingPV_x) * electron.p
 
 electronSmearedD0WRTBeamspot = "(electron.d0SmearingVal + ((electron.vx - beamspot.x0) * electron.py - (electron.vy - beamspot.y0) * electron.px) / electron.pt)"
 
+electronGenVertexIsOriginD0WRTBeamspot = "((electron.genMatchedParticleOfSameType.noFlags.vx - beamspot.x0) * electron.genMatchedParticleOfSameType.noFlags.py - (electron.genMatchedParticleOfSameType.noFlags.vy - beamspot.y0) * electron.genMatchedParticleOfSameType.noFlags.px) / electron.genMatchedParticleOfSameType.noFlags.pt"
+
 muonD0WRTBeamspot = "((muon.vx - beamspot.x0) * muon.py - (muon.vy - beamspot.y0) * muon.px) / muon.pt"
 muonD0WRTBeamspotErr = "hypot(muon.innerTrack.d0Error, hypot(beamspot.x0Error, beamspot.y0Error))"
 muonD0WRTBeamspotSig = "(((muon.vx - beamspot.x0) * muon.py - (muon.vy - beamspot.y0) * muon.px) / muon.pt) / (hypot(muon.innerTrack.d0Error, hypot(beamspot.x0Error, beamspot.y0Error)))"
 muonD0WRTPV       = "((muon.vx - eventvariable.leadingPV_x) * muon.py - (muon.vy - eventvariable.leadingPV_y) * muon.px) / muon.pt"
 
 muonSmearedD0WRTBeamspot = "(muon.d0SmearingVal + ((muon.vx - beamspot.x0) * muon.py - (muon.vy - beamspot.y0) * muon.px) / muon.pt)"
+
+muonGenVertexIsOriginD0WRTBeamspot = "((muon.genMatchedParticleOfSameType.noFlags.vx - beamspot.x0) * muon.genMatchedParticleOfSameType.noFlags.py - (muon.genMatchedParticleOfSameType.noFlags.vy - beamspot.y0) * muon.genMatchedParticleOfSameType.noFlags.px) / muon.genMatchedParticleOfSameType.noFlags.pt"
 
 hardInteractionMcparticleD0WRTBeamspot = "((hardInteractionMcparticle.vx - beamspot.x0) * hardInteractionMcparticle.py - (hardInteractionMcparticle.vy - beamspot.y0) * hardInteractionMcparticle.px) / hardInteractionMcparticle.pt"
 

--- a/Configuration/python/cutUtilities.py
+++ b/Configuration/python/cutUtilities.py
@@ -59,16 +59,12 @@ electronD0WRTPV       = "((electron.vx - eventvariable.leadingPV_x) * electron.p
 
 electronSmearedD0WRTBeamspot = "(electron.d0SmearingVal + ((electron.vx - beamspot.x0) * electron.py - (electron.vy - beamspot.y0) * electron.px) / electron.pt)"
 
-electronGenVertexIsOriginD0WRTBeamspot = "((electron.genMatchedParticleOfSameType.noFlags.vx - beamspot.x0) * electron.genMatchedParticleOfSameType.noFlags.py - (electron.genMatchedParticleOfSameType.noFlags.vy - beamspot.y0) * electron.genMatchedParticleOfSameType.noFlags.px) / electron.genMatchedParticleOfSameType.noFlags.pt"
-
 muonD0WRTBeamspot = "((muon.vx - beamspot.x0) * muon.py - (muon.vy - beamspot.y0) * muon.px) / muon.pt"
 muonD0WRTBeamspotErr = "hypot(muon.innerTrack.d0Error, hypot(beamspot.x0Error, beamspot.y0Error))"
 muonD0WRTBeamspotSig = "(((muon.vx - beamspot.x0) * muon.py - (muon.vy - beamspot.y0) * muon.px) / muon.pt) / (hypot(muon.innerTrack.d0Error, hypot(beamspot.x0Error, beamspot.y0Error)))"
 muonD0WRTPV       = "((muon.vx - eventvariable.leadingPV_x) * muon.py - (muon.vy - eventvariable.leadingPV_y) * muon.px) / muon.pt"
 
 muonSmearedD0WRTBeamspot = "(muon.d0SmearingVal + ((muon.vx - beamspot.x0) * muon.py - (muon.vy - beamspot.y0) * muon.px) / muon.pt)"
-
-muonGenVertexIsOriginD0WRTBeamspot = "((muon.genMatchedParticleOfSameType.noFlags.vx - beamspot.x0) * muon.genMatchedParticleOfSameType.noFlags.py - (muon.genMatchedParticleOfSameType.noFlags.vy - beamspot.y0) * muon.genMatchedParticleOfSameType.noFlags.px) / muon.genMatchedParticleOfSameType.noFlags.pt"
 
 hardInteractionMcparticleD0WRTBeamspot = "((hardInteractionMcparticle.vx - beamspot.x0) * hardInteractionMcparticle.py - (hardInteractionMcparticle.vy - beamspot.y0) * hardInteractionMcparticle.px) / hardInteractionMcparticle.pt"
 

--- a/Configuration/scripts/makeEfficiencyPlots.py
+++ b/Configuration/scripts/makeEfficiencyPlots.py
@@ -3,6 +3,7 @@ import sys
 import os
 import re
 import shutil
+import functools
 from math import *
 from array import *
 from decimal import *
@@ -27,6 +28,8 @@ parser.add_option("-f", "--fancy", action="store_true", dest="makeFancy", defaul
                   help="removes the title and replaces it with the official CMS plot heading")
 parser.add_option("--dontRebinRatio", action="store_true", dest="dontRebinRatio", default=False,
                   help="don't do the rebinning of ratio plots")
+parser.add_option("-A", "--addOneToRatio", action='store_true', dest="addOneToRatio",
+                  help="add one to the ratio so that data/MC is plotted")
 parser.add_option("--noTGraph", action="store_true", dest="noTGraph", default=False,
                   help="don't make a TGraph; just make a TH1")
 parser.add_option("--ylog", action="store_true", dest="setLogY", default=False,
@@ -68,7 +71,7 @@ if arguments.makeRatioPlots and not arguments.noTGraph:
     arguments.makeRatioPlots = False
 
 
-
+from OSUT3Analysis.Configuration.histogramUtilities import ratioHistogram
 from ROOT import TFile, gROOT, gStyle, gDirectory, TStyle, TH1F, TCanvas, TString, TLegend, TLegendEntry, TIter, TKey, TPaveLabel, gPad, TGraphAsymmErrors
 
 
@@ -114,28 +117,29 @@ if arguments.line_width:
 #set the text for the luminosity label
 if(intLumi < 1000.):
     LumiInPb = intLumi
-    LumiText = "L_{int} = " + str(intLumi) + " pb^{-1}"
-    LumiText = "L_{int} = " + str.format('{0:.1f}', LumiInPb) + " pb^{-1}"
+    LumiText = str(intLumi) + " pb^{-1}"
+    LumiText = str.format('{0:.1f}', LumiInPb) + " pb^{-1}"
 else:
     LumiInFb = intLumi/1000.
-    LumiText = "L_{int} = " + str.format('{0:.1f}', LumiInFb) + " fb^{-1}"
+    LumiText = str.format('{0:.1f}', LumiInFb) + " fb^{-1}"
 
 #bestest place for lumi. label, in top left corner
-topLeft_x_left    = 0.1375839
-topLeft_x_right   = 0.4580537
-topLeft_y_bottom  = 0.8479021
-topLeft_y_top     = 0.9475524
-topLeft_y_offset  = 0.035
+topLeft_x_left    = 0.16129
+topLeft_y_bottom  = 0.8
+topLeft_x_right   = 0.512673
+topLeft_y_top     = 0.892944
+topLeft_y_offset  = 0.04
 
 #set the text for the fancy heading
-HeaderText = "CMS Preliminary: " + LumiText + " at #sqrt{s} = 8 TeV"
+HeaderText = LumiText + " (13 TeV)"
 
 #position for header
-header_x_left    = 0.2181208
-header_x_right   = 0.9562937
-header_y_bottom  = 0.9479866
-header_y_top     = 0.9947552
+header_x_left    = 0.602535
+header_y_bottom  = 0.928224
+header_x_right   = 0.963134
+header_y_top     = 0.980535
 
+makeFancy = arguments.makeFancy
 
 colors = {
     'black'  : 1,
@@ -171,85 +175,36 @@ fills = {
 ##########################################################################################################################################
 ##########################################################################################################################################
 
-# some fancy-ass code from Andrzej Zuranski to merge bins in the ratio plot until the error goes below some threshold
-def ratioHistogram( dataHist, mcHist, relErrMax=0.10):
-
-    def groupR(group):
-        Data,MC = [float(sum(hist.GetBinContent(i) for i in group)) for hist in [dataHist,mcHist]]
-        if MC!=0:
-            return (Data-MC)/MC
-        else:
-            return 0
-
-    def groupErr(group):
-        Data,MC = [float(sum(hist.GetBinContent(i) for i in group)) for hist in [dataHist,mcHist]]
-        dataErr2,mcErr2 = [sum(hist.GetBinError(i)**2 for i in group) for hist in [dataHist,mcHist]]
-        if MC > 0 and Data > 0 and Data != MC:
-            return abs(math.sqrt( (dataErr2+mcErr2)/(Data-MC)**2 + mcErr2/MC**2 ) * (Data-MC)/MC)
-        else:
-            return 0
-
-
-    def regroup(groups):
-        err,iG = max( (groupErr(g),groups.index(g)) for g in groups )
-        if err < relErrMax or len(groups)<3 : return groups
-        iH = max( [iG-1,iG+1], key = lambda i: groupErr(groups[i]) if 0<=i<len(groups) else -1 )
-        iLo,iHi = sorted([iG,iH])
-        return regroup(groups[:iLo] + [groups[iLo]+groups[iHi]] + groups[iHi+1:])
-
-    #don't rebin the histograms of the number of a given object (except for the pileup ones)
-    if ((dataHist.GetName().find("num") is not -1 and dataHist.GetName().find("Primaryvertexs") is -1) or
-        dataHist.GetName().find("CutFlow")  is not -1 or
-        dataHist.GetName().find("GenMatch") is not -1 or
-        arguments.dontRebinRatio):
-        ratio = dataHist.Clone()
-        ratio.Add(mcHist,-1)
-        ratio.Divide(mcHist)
-        ratio.SetTitle("")
-    else:
-        groups = regroup( [(i,) for i in range(1,1+dataHist.GetNbinsX())] )
-        ratio = TH1F("ratio","",len(groups), array('d', [dataHist.GetBinLowEdge(min(g)) for g in groups ] + [dataHist.GetXaxis().GetBinUpEdge(dataHist.GetNbinsX())]) )
-        for i,g in enumerate(groups) :
-            ratio.SetBinContent(i+1,groupR(g))
-            ratio.SetBinError(i+1,groupErr(g))
-
-    ratio.GetYaxis().SetTitle("#frac{hist1-hist2}{hist2}")
-    ratio.GetXaxis().SetLabelOffset(0.03)
-    ratio.SetLineColor(1)
-    ratio.SetMarkerColor(1)
-    ratio.SetLineWidth(2)
-    return ratio
-
-##########################################################################################################################################
-##########################################################################################################################################
-##########################################################################################################################################
-
-
 def MakeOneHist(dirName, histogramName):
 
     HeaderLabel = TPaveLabel(header_x_left,header_y_bottom,header_x_right,header_y_top,HeaderText,"NDC")
     HeaderLabel.SetTextAlign(32)
+    HeaderLabel.SetTextFont(42)
+    HeaderLabel.SetTextSize(0.697674)
     HeaderLabel.SetBorderSize(0)
     HeaderLabel.SetFillColor(0)
     HeaderLabel.SetFillStyle(0)
 
-    LumiLabel = TPaveLabel(topLeft_x_left,topLeft_y_bottom,topLeft_x_right,topLeft_y_top,LumiText,"NDC")
+    CMSLabel = TPaveLabel(header_x_left,header_y_bottom,header_x_right,header_y_top,HeaderText,"NDC")
+    CMSLabel.SetTextAlign(32)
+    CMSLabel.SetTextFont(42)
+    CMSLabel.SetTextSize(0.697674)
+    CMSLabel.SetBorderSize(0)
+    CMSLabel.SetFillColor(0)
+    CMSLabel.SetFillStyle(0)
+
+    if makeFancy:
+        LumiLabel = TPaveLabel(topLeft_x_left,topLeft_y_bottom,topLeft_x_right,topLeft_y_top,"CMS Preliminary","NDC")
+        LumiLabel.SetTextFont(62)
+        LumiLabel.SetTextSize(0.7)
+        LumiLabel.SetTextAlign(12)
+    else:
+        LumiLabel = TPaveLabel(topLeft_x_left,topLeft_y_bottom,topLeft_x_right,topLeft_y_top,LumiText,"NDC")
+        LumiLabel.SetTextAlign(32)
+        LumiLabel.SetTextFont(42)
     LumiLabel.SetBorderSize(0)
     LumiLabel.SetFillColor(0)
     LumiLabel.SetFillStyle(0)
-
-    NormLabel = TPaveLabel()
-    NormLabel.SetDrawOption("NDC")
-    NormLabel.SetX1NDC(topLeft_x_left)
-    NormLabel.SetX2NDC(topLeft_x_right)
-
-    NormLabel.SetBorderSize(0)
-    NormLabel.SetFillColor(0)
-    NormLabel.SetFillStyle(0)
-
-    NormText = ""
-    if arguments.normalizeToUnitArea:
-        NormText = "Scaled to unit area"
 
     Legend = TLegend()
     Legend.SetBorderSize(0)
@@ -375,6 +330,9 @@ def MakeOneHist(dirName, histogramName):
 
     makeRatioPlots = arguments.makeRatioPlots
     makeDiffPlots = arguments.makeDiffPlots
+    addOneToRatio = -1
+    if arguments.addOneToRatio:
+        addOneToRatio = arguments.addOneToRatio
 
     yAxisMin = 0.0001
     if arguments.setYMin:
@@ -421,8 +379,6 @@ def MakeOneHist(dirName, histogramName):
             outputFile.cd()
             Canvas.SetName(histogram.GetName())
             Canvas.Write()
-            if arguments.makeFancy:
-                HeaderLabel.Draw()
 
         else:
             if histogram.InheritsFrom("TGraph") and histCounter==0:
@@ -463,7 +419,7 @@ def MakeOneHist(dirName, histogramName):
 
     if arguments.makeFancy:
         HeaderLabel.Draw()
-
+        LumiLabel.Draw()
 
 
 
@@ -472,7 +428,10 @@ def MakeOneHist(dirName, histogramName):
     if makeRatioPlots or makeDiffPlots:
         Canvas.cd(2)
         if makeRatioPlots:
-            Comparison = ratioHistogram(Histograms[0],Histograms[1])
+            makeRatio = functools.partial (ratioHistogram,Histograms[0],Histograms[1])
+            if addOneToRatio is not -1: # it gets initialized to this dummy value of -1
+                makeRatio = functools.partial (makeRatio, addOne = bool (addOneToRatio))
+            Comparison = makeRatio ()
         elif makeDiffPlots:
             Comparison = Histograms[0].Clone("diff")
             Comparison.Add(Histograms[1],-1)
@@ -489,7 +448,10 @@ def MakeOneHist(dirName, histogramName):
             RatioYRange = 1.15
             if arguments.ratioYRange:
                 RatioYRange = float(arguments.ratioYRange)
-            Comparison.GetYaxis().SetRangeUser(-1*RatioYRange, RatioYRange)
+            if not addOneToRatio:
+                Comparison.GetYaxis().SetRangeUser(-1*RatioYRange, RatioYRange)
+            else:
+                Comparison.GetYaxis().SetRangeUser(-1*RatioYRange + 1.0, RatioYRange + 1.0)
         elif makeDiffPlots:
             YMax = Comparison.GetMaximum()
             YMin = Comparison.GetMinimum()


### PR DESCRIPTION
makeEfficiencyPlot.py and makeComparisonPlots.py need a facelift. This PR:

- Adds the option addOneToRatio, so you can plot data/MC as in makePlots.py
- improves the cosmetics of the plot, as done in makePlots.py