### PR TITLE
Add automatic sanity check for cut and histogram definitions

### DIFF
--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -255,10 +255,6 @@ def add_channels (process,
         'alias',
         'numberRequired',
         'isVeto',
-        '_isFrozen',
-        '_ParameterTypeBase__isTracked',
-        '_isModified',
-        '_Parameterizable__parameterNames',
     ]
     validHistAttributes = [
         'name',
@@ -266,17 +262,13 @@ def add_channels (process,
         'binsX', 'binsY', 'binsZ',
         'indexX', 'indexY', 'indexZ',
         'inputVariables',
-        '_isFrozen',
-        '_ParameterTypeBase__isTracked',
-        '_isModified',
-        '_Parameterizable__parameterNames',
     ]
 
     # find all cuts with invalid attributes
     exceptionString = ""
     for selection in channels:
         for cut in selection.cuts:
-            attributes = cut.__dict__.keys()
+            attributes = [a for a in cut.__dict__.keys() if not a.startswith('_')]
             invalidAttributes = list(set(attributes) - set(validCutAttributes))
             if invalidAttributes:
                 name = cut.alias if hasattr(cut, 'alias') else cut.cutString
@@ -286,7 +278,7 @@ def add_channels (process,
     # find all hists with invalid attributes
     for histogramSet in histogramSets:
         for hist in histogramSet.histograms:
-            attributes = hist.__dict__.keys()
+            attributes = [a for a in hist.__dict__.keys() if not a.startswith('_')]
             invalidAttributes = list(set(attributes) - set(validHistAttributes))
             if invalidAttributes:
                 name = str(hist.name)[12:-2]

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -247,6 +247,56 @@ def add_channels (process,
         channels                =  channels.channels
 
     ############################################################################
+    # Check that cut and histogram definitions contain no invalid attributes
+    ############################################################################
+    validCutAttributes = [
+        'inputCollection',
+        'cutString',
+        'alias',
+        'numberRequired',
+        'isVeto',
+        '_isFrozen',
+        '_ParameterTypeBase__isTracked',
+        '_isModified',
+        '_Parameterizable__parameterNames',
+    ]
+    validHistAttributes = [
+        'name',
+        'title',
+        'binsX', 'binsY', 'binsZ',
+        'indexX', 'indexY', 'indexZ',
+        'inputVariables',
+        '_isFrozen',
+        '_ParameterTypeBase__isTracked',
+        '_isModified',
+        '_Parameterizable__parameterNames',
+    ]
+
+    # find all cuts with invalid attributes
+    exceptionString = ""
+    for selection in channels:
+        for cut in selection.cuts:
+            attributes = cut.__dict__.keys()
+            invalidAttributes = list(set(attributes) - set(validCutAttributes))
+            if invalidAttributes:
+                name = cut.alias if hasattr(cut, 'alias') else cut.cutString
+                name = str(name)[12:-2]
+                exceptionString += "\ncut '{}' has invalid attributes: {}".format(name, invalidAttributes)
+
+    # find all hists with invalid attributes
+    for histogramSet in histogramSets:
+        for hist in histogramSet.histograms:
+            attributes = hist.__dict__.keys()
+            invalidAttributes = list(set(attributes) - set(validHistAttributes))
+            if invalidAttributes:
+                name = str(hist.name)[12:-2]
+                exceptionString += "\nhist '{}' has invalid attributes: {}".format(name, invalidAttributes)
+
+    # if necessary, raise exception listing all cuts or hists with invalid attributes
+    if exceptionString:
+        raise AttributeError(exceptionString)
+
+    ############################################################################
     # Check the directory of the first input file for SkimInputTags.pkl. If it
     # exists, update the input tags with those stored in the pickle file.
     ############################################################################


### PR DESCRIPTION
Add check to add_channels that raises an exception if any cuts or histograms have invalid attributes. This protects against typos like `IndexX` or `numberrequired` that currently pass silently.