### PR TITLE
make framework work with AOD

### DIFF
--- a/AnaTools/interface/CommonUtils.h
+++ b/AnaTools/interface/CommonUtils.h
@@ -226,12 +226,14 @@ namespace anatools
 
   template<class T> bool jetPassesTightLepVeto (const T &);
 
+#if IS_VALID(trigobjs)
   template<class T> bool isMatchedToTriggerObject (const edm::Event &, const edm::TriggerResults &, const T &, const vector<pat::TriggerObjectStandAlone> &, const string &, const string &, const double = 0.1);
   bool getTriggerObjects (const edm::Event &, const edm::TriggerResults &, const vector<pat::TriggerObjectStandAlone> &, const string &, const string &, vector<const pat::TriggerObjectStandAlone *> &);
   bool getTriggerObjectsByFilterSubstring (const edm::Event &, const edm::TriggerResults &, const vector<pat::TriggerObjectStandAlone> &, const string &, const string &, vector<const pat::TriggerObjectStandAlone *> &, const vector<string> & = vector<string> ());
   template<class T> const pat::TriggerObjectStandAlone *getMatchedTriggerObject (const edm::Event &, const edm::TriggerResults &, const T &, const vector<pat::TriggerObjectStandAlone> &, const string &, const string &, const double = 0.1);
   bool triggerObjectExists (const edm::Event &, const edm::TriggerResults &, const vector<pat::TriggerObjectStandAlone> &, const string &, const string &);
   bool passesL1ETM (const edm::Event &, const edm::TriggerResults &, const vector<pat::TriggerObjectStandAlone> &, double &);
+#endif
 
   void logSpace (const double, const double, const unsigned, vector<double> &);
   void linSpace (const double, const double, const unsigned, vector<double> &);
@@ -283,6 +285,7 @@ anatools::jetPassesTightLepVeto (const T &jet)
 #endif
 }
 
+#if IS_VALID(trigobjs)
 template<class T> bool
 anatools::isMatchedToTriggerObject (const edm::Event &event, const edm::TriggerResults &triggers, const T &obj, const vector<pat::TriggerObjectStandAlone> &trigObjs, const string &collection, const string &filter, const double dR)
 {
@@ -361,4 +364,5 @@ anatools::getMatchedTriggerObject (const edm::Event &event, const edm::TriggerRe
   return NULL;
 }
 
+#endif
 #endif

--- a/AnaTools/interface/DataFormatAOD.h
+++ b/AnaTools/interface/DataFormatAOD.h
@@ -5,8 +5,8 @@
 #define  genjets_TYPE           INVALID_TYPE
 #define  jets_TYPE              reco::PFJet
 #define  bjets_TYPE             INVALID_TYPE
-#define  mcparticles_TYPE       INVALID_TYPE
-#define hardInteractionMcparticles_TYPE INVALID_TYPE
+#define  mcparticles_TYPE       reco::GenParticle
+#define  hardInteractionMcparticles_TYPE reco::GenParticle
 #define  mets_TYPE              reco::PFMET
 #define  muons_TYPE             reco::Muon
 #define  photons_TYPE           reco::Photon
@@ -32,8 +32,6 @@
 #define  bxlumis_INVALID
 #define  events_INVALID
 #define  genjets_INVALID
-#define  mcparticles_INVALID
-#define  hardInteractionMcparticles_INVALID
 #define  prescales_INVALID
 #define  superclusters_INVALID
 #define  trigobjs_INVALID
@@ -50,6 +48,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/METReco/interface/PFMET.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"

--- a/AnaTools/plugins/InfoPrinter.cc
+++ b/AnaTools/plugins/InfoPrinter.cc
@@ -495,7 +495,7 @@ InfoPrinter::printAllTriggers (const edm::Event &event)
     return false;
   }
 
-#if DATA_FORMAT != AOD
+#if DATA_FORMAT_FROM_MINIAOD
   const edm::TriggerNames &triggerNames = event.triggerNames (*handles_.triggers);
   for (unsigned i = 0; i < triggerNames.size (); i++)
     {

--- a/AnaTools/plugins/InfoPrinter.cc
+++ b/AnaTools/plugins/InfoPrinter.cc
@@ -495,6 +495,7 @@ InfoPrinter::printAllTriggers (const edm::Event &event)
     return false;
   }
 
+#if DATA_FORMAT != AOD
   const edm::TriggerNames &triggerNames = event.triggerNames (*handles_.triggers);
   for (unsigned i = 0; i < triggerNames.size (); i++)
     {
@@ -517,6 +518,7 @@ InfoPrinter::printAllTriggers (const edm::Event &event)
       else
         ss_ << "\033[2;33m" << trigger.second.second << A_RESET << endl;
     }
+#endif
 
   return true;
 }

--- a/AnaTools/python/osuAnalysis_cfi.py
+++ b/AnaTools/python/osuAnalysis_cfi.py
@@ -5,7 +5,7 @@ import copy
 ##### Define the datatier being used ####
 #########################################
 
-dataFormat = "AOD"
+dataFormat = "MINI_AOD"
 
 ###########################################################
 ##### Set up the standard input collections in miniAOD ####

--- a/AnaTools/python/osuAnalysis_cfi.py
+++ b/AnaTools/python/osuAnalysis_cfi.py
@@ -5,7 +5,7 @@ import copy
 ##### Define the datatier being used ####
 #########################################
 
-dataFormat = "MINI_AOD"
+dataFormat = "AOD"
 
 ###########################################################
 ##### Set up the standard input collections in miniAOD ####
@@ -49,16 +49,19 @@ collectionMapMiniAOD2017.trigobjs        = cms.InputTag  ('slimmedPatTrigger') #
 ###########################################################
 
 collectionMapAOD = cms.PSet (
-    electrons         =  cms.InputTag  ('uncleanedOnlyGsfElectrons'),
-    generatorweights  =  cms.InputTag  ('generator',                   ''),
-    genjets           =  cms.InputTag  ('ak4GenJets'),
-    jets              =  cms.InputTag  ('ak4PFJets'),
-    mcparticles       =  cms.InputTag  ('genParticles'),
-    mets              =  cms.InputTag  ('pfMet'),
-    muons             =  cms.InputTag  ('muons'),
-    taus              =  cms.InputTag  ('hpsPFTauProducer'),
-    tracks            =  cms.InputTag  ('generalTracks'),
-    triggers          =  cms.InputTag  ('TriggerResults',              '',   'HLT'),
-    photons           =  cms.InputTag  ('photons'),
-    primaryvertexs    =  cms.InputTag  ('offlinePrimaryVertices'),
+    beamspots                  =  cms.InputTag  ('offlineBeamSpot'),
+    electrons                  =  cms.InputTag  ('uncleanedOnlyGsfElectrons'),
+    generatorweights           =  cms.InputTag  ('generator',                   ''),
+    genjets                    =  cms.InputTag  ('ak4GenJets'),
+    jets                       =  cms.InputTag  ('ak4PFJets'),
+    mcparticles                =  cms.InputTag  ('genParticles'),
+    hardInteractionMcparticles =  cms.InputTag  ('genParticles'),
+    mets                       =  cms.InputTag  ('pfMet'),
+    muons                      =  cms.InputTag  ('muons'),
+    taus                       =  cms.InputTag  ('hpsPFTauProducer'),
+    tracks                     =  cms.InputTag  ('generalTracks'),
+    triggers                   =  cms.InputTag  ('TriggerResults',              '',   'HLT'),
+    photons                    =  cms.InputTag  ('photons'),
+    pileupinfos                =  cms.InputTag  ('addPileupInfo'),
+    primaryvertexs             =  cms.InputTag  ('offlinePrimaryVertices'),
 )

--- a/AnaTools/src/CommonUtils.cc
+++ b/AnaTools/src/CommonUtils.cc
@@ -951,6 +951,7 @@ anatools::getAllTokens (const edm::ParameterSet &collections, edm::ConsumesColle
     }
 }
 
+#if IS_VALID(trigobjs)
 bool
 anatools::getTriggerObjects (const edm::Event &event, const edm::TriggerResults &triggers, const vector<pat::TriggerObjectStandAlone> &trigObjs, const string &collection, const string &filter, vector<const pat::TriggerObjectStandAlone *> &selectedTrigObjs)
 {
@@ -1105,6 +1106,7 @@ anatools::passesL1ETM (const edm::Event &event, const edm::TriggerResults &trigg
     }
   return false;
 }
+#endif
 
 void
 anatools::logSpace (const double a, const double b, const unsigned n, vector<double> &bins)

--- a/Collections/interface/GenMatchable.h
+++ b/Collections/interface/GenMatchable.h
@@ -3,6 +3,7 @@
 
 //#if DATA_FORMAT_FROM_MINIAOD
 
+#include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Common/interface/Handle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/Collections/interface/Met.h
+++ b/Collections/interface/Met.h
@@ -21,6 +21,7 @@ namespace osu
         //       it is "MET::JetResUp" for the case of MET::Type1Smear
         //       See https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_14/DataFormats/PatCandidates/src/MET.cc#L208-L209
 
+#if DATA_FORMAT != AOD
         const double pt_JetResUp () const          { return this->shiftedPt(MET::JetResUp); }
         const double pt_JetEnUp () const           { return this->shiftedPt(MET::JetEnUp); }
         const double pt_MuonEnUp () const          { return this->shiftedPt(MET::MuonEnUp); }
@@ -36,6 +37,7 @@ namespace osu
         const double pt_TauEnDown () const         { return this->shiftedPt(MET::TauEnDown); }
         const double pt_UnclusteredEnDown () const { return this->shiftedPt(MET::UnclusteredEnDown); }
         const double pt_PhotonEnDown () const      { return this->shiftedPt(MET::PhotonEnUp); }
+#endif
 
         const double noMuPt () const;
         const double noMuPx () const;

--- a/Collections/interface/Met.h
+++ b/Collections/interface/Met.h
@@ -21,7 +21,7 @@ namespace osu
         //       it is "MET::JetResUp" for the case of MET::Type1Smear
         //       See https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_14/DataFormats/PatCandidates/src/MET.cc#L208-L209
 
-#if DATA_FORMAT != AOD
+#if DATA_FORMAT_FROM_MINIAOD
         const double pt_JetResUp () const          { return this->shiftedPt(MET::JetResUp); }
         const double pt_JetEnUp () const           { return this->shiftedPt(MET::JetEnUp); }
         const double pt_MuonEnUp () const          { return this->shiftedPt(MET::MuonEnUp); }

--- a/Collections/interface/Muon.h
+++ b/Collections/interface/Muon.h
@@ -1,6 +1,8 @@
 #ifndef OSU_MUON
 #define OSU_MUON
 
+#include "TVector2.h"
+
 #include "OSUT3Analysis/Collections/interface/GenMatchable.h"
 #include "OSUT3Analysis/Collections/interface/Met.h"
 

--- a/Collections/interface/Tau.h
+++ b/Collections/interface/Tau.h
@@ -1,6 +1,8 @@
 #ifndef OSU_TAU
 #define OSU_TAU
 
+#include "TVector2.h"
+
 #include "OSUT3Analysis/Collections/interface/GenMatchable.h"
 #include "OSUT3Analysis/Collections/interface/Met.h"
 

--- a/Collections/plugins/OSUElectronProducer.cc
+++ b/Collections/plugins/OSUElectronProducer.cc
@@ -34,7 +34,9 @@ OSUElectronProducer::OSUElectronProducer (const edm::ParameterSet &cfg) :
   conversionsToken_ = consumes<vector<reco::Conversion> > (conversions_);
   rhoToken_ = consumes<double> (rho_);
   triggersToken_ = consumes<edm::TriggerResults> (collections_.getParameter<edm::InputTag> ("triggers"));
+#if IS_VALID(trigobjs)
   trigobjsToken_ = consumes<vector<pat::TriggerObjectStandAlone> > (collections_.getParameter<edm::InputTag> ("trigobjs"));
+#endif
 
   vidVetoIdMapToken_   = consumes<edm::ValueMap<bool> > (vidVetoIdMap_);
   vidLooseIdMapToken_  = consumes<edm::ValueMap<bool> > (vidLooseIdMap_);

--- a/Collections/plugins/OSUElectronProducer.h
+++ b/Collections/plugins/OSUElectronProducer.h
@@ -33,7 +33,9 @@ class OSUElectronProducer : public edm::EDProducer
     edm::EDGetTokenT<vector<reco::Conversion> > conversionsToken_;
     edm::EDGetTokenT<double> rhoToken_;
     edm::EDGetTokenT<edm::TriggerResults> triggersToken_;
+#if IS_VALID(trigobjs)
     edm::EDGetTokenT<vector<pat::TriggerObjectStandAlone> > trigobjsToken_;
+#endif
 
     edm::EDGetTokenT<edm::ValueMap<bool> > vidVetoIdMapToken_;
     edm::EDGetTokenT<edm::ValueMap<bool> > vidLooseIdMapToken_;

--- a/Collections/plugins/OSUGenericJetProducer.cc
+++ b/Collections/plugins/OSUGenericJetProducer.cc
@@ -12,7 +12,7 @@
 #include "TRandom3.h"
 #endif
 
-template<class T> 
+template<class T>
 OSUGenericJetProducer<T>::OSUGenericJetProducer (const edm::ParameterSet &cfg) :
   collections_ (cfg.getParameter<edm::ParameterSet> ("collections")),
   rho_         (cfg.getParameter<edm::InputTag>  ("rho")),
@@ -158,12 +158,14 @@ OSUGenericJetProducer<T>::produce (edm::Event &event, const edm::EventSetup &set
     {
 #ifndef STOPPPED_PTLS
       pl_->emplace_back (object, particles, cfg_);
-      T &jet = pl_->back ();
+
 #else // STOPPPED_PTLS
       pl_->emplace_back (object);
 #endif
 
 #if DATA_FORMAT_FROM_MINIAOD
+
+      T &jet = pl_->back ();
 
       // medianLog10(ipsig) CALC
       std::vector<double> ipsigVector;
@@ -287,7 +289,7 @@ OSUGenericJetProducer<T>::produce (edm::Event &event, const edm::EventSetup &set
               break;
             }
           }
-            
+
         } // for genjets
 
         if(!isMatchedToGenJet) {

--- a/Collections/plugins/OSUMuonProducer.cc
+++ b/Collections/plugins/OSUMuonProducer.cc
@@ -87,7 +87,7 @@ OSUMuonProducer::produce (edm::Event &event, const edm::EventSetup &setup)
       if(rho.isValid())
         muon.set_rho((float)(*rho));
 
-#if DATA_FORMAT != AOD
+#if DATA_FORMAT_FROM_MINIAOD
       if (!vertices->empty ())
         {
           const reco::Vertex &vtx = vertices->at (0);

--- a/Collections/plugins/OSUMuonProducer.h
+++ b/Collections/plugins/OSUMuonProducer.h
@@ -32,7 +32,9 @@ class OSUMuonProducer : public edm::EDProducer
     edm::EDGetTokenT<vector<osu::Met> > metToken_;
     edm::EDGetTokenT<double> rhoToken_;
     edm::EDGetTokenT<edm::TriggerResults> triggersToken_;
+#if IS_VALID(trigobjs)
     edm::EDGetTokenT<vector<pat::TriggerObjectStandAlone> > trigobjsToken_;
+#endif
 
     edm::ParameterSet  cfg_;
     edm::InputTag      pfCandidate_;

--- a/Collections/plugins/OSUTauProducer.cc
+++ b/Collections/plugins/OSUTauProducer.cc
@@ -46,9 +46,10 @@ OSUTauProducer::produce (edm::Event &event, const edm::EventSetup &setup)
   for (const auto &object : *collection)
     {
       pl_->emplace_back (object, particles, cfg_, met->at (0));
-      osu::Tau &tau = pl_->back ();
 
 #if IS_VALID(trigobjs)
+      osu::Tau &tau = pl_->back ();
+
       if(trigobjs.isValid()) {
         tau.set_match_HLT_LooseIsoPFTau50_Trk30_eta2p1_v (anatools::isMatchedToTriggerObject (event, *triggers, object, *trigobjs, "hltSelectedPFTausTrackPt30AbsOrRelIsolation::HLT", "hltPFTau50TrackPt30LooseAbsOrRelIso"));
         tau.set_match_HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v (anatools::isMatchedToTriggerObject (event, *triggers, object, *trigobjs, "hltSelectedPFTausTrackPt30MediumAbsOrRelIsolation1Prong::HLT", "hltPFTau50TrackPt30MediumAbsOrRelIso1Prong"));

--- a/Collections/plugins/OSUTauProducer.h
+++ b/Collections/plugins/OSUTauProducer.h
@@ -26,7 +26,9 @@ class OSUTauProducer : public edm::EDProducer
     edm::EDGetTokenT<vector<osu::Mcparticle> > mcparticleToken_;
     edm::EDGetTokenT<vector<osu::Met> > metToken_;
     edm::EDGetTokenT<edm::TriggerResults> triggersToken_;
+#if IS_VALID(trigobjs)
     edm::EDGetTokenT<vector<pat::TriggerObjectStandAlone> > trigobjsToken_;
+#endif
     edm::ParameterSet  cfg_;
     ////////////////////////////////////////////////////////////////////////////
 

--- a/Collections/src/Met.cc
+++ b/Collections/src/Met.cc
@@ -57,6 +57,7 @@ osu::Met::Met (const TYPE(mets) &met, const edm::Handle<vector<pat::PackedCandid
   if (pfCandidates.isValid ()) {
       TVector2 metNoMu (met.px(), met.py());
 
+#if DATA_FORMAT != AOD
       TVector2 metNoMu_JetResUp          (met.shiftedP2(MET::JetResUp).px, met.shiftedP2(MET::JetResUp).py);
       TVector2 metNoMu_JetEnUp           (met.shiftedP2(MET::JetEnUp).px, met.shiftedP2(MET::JetEnUp).py);
       TVector2 metNoMu_ElectronEnUp      (met.shiftedP2(MET::ElectronEnUp).px, met.shiftedP2(MET::ElectronEnUp).py);
@@ -70,6 +71,7 @@ osu::Met::Met (const TYPE(mets) &met, const edm::Handle<vector<pat::PackedCandid
       TVector2 metNoMu_TauEnDown         (met.shiftedP2(MET::TauEnDown).px, met.shiftedP2(MET::TauEnDown).py);
       TVector2 metNoMu_UnclusteredEnDown (met.shiftedP2(MET::UnclusteredEnDown).px, met.shiftedP2(MET::UnclusteredEnDown).py);
       TVector2 metNoMu_PhotonEnDown      (met.shiftedP2(MET::PhotonEnDown).px, met.shiftedP2(MET::PhotonEnDown).py);
+#endif
 
       for (const auto &pfCandidate : *pfCandidates) {
           if (abs (pfCandidate.pdgId ()) != 13) continue;
@@ -78,6 +80,7 @@ osu::Met::Met (const TYPE(mets) &met, const edm::Handle<vector<pat::PackedCandid
 
           metNoMu += muon;
 
+#if DATA_FORMAT != AOD
           metNoMu_JetResUp += muon;
           metNoMu_JetEnUp += muon;
           metNoMu_ElectronEnUp += muon;
@@ -89,6 +92,7 @@ osu::Met::Met (const TYPE(mets) &met, const edm::Handle<vector<pat::PackedCandid
           metNoMu_ElectronEnDown += muon;
           metNoMu_TauEnDown += muon;
           metNoMu_UnclusteredEnDown += muon;
+#endif
         }
 
       noMuPt_ = metNoMu.Mod ();
@@ -96,6 +100,7 @@ osu::Met::Met (const TYPE(mets) &met, const edm::Handle<vector<pat::PackedCandid
       noMuPy_ = metNoMu.Py ();
       noMuPhi_ = metNoMu.Phi ();
 
+#if DATA_FORMAT != AOD
       noMuPt_JetResUp_ = metNoMu_JetResUp.Mod();
       noMuPt_JetEnUp_ = metNoMu_JetEnUp.Mod();
       noMuPt_ElectronEnUp_ = metNoMu_ElectronEnUp.Mod();
@@ -109,6 +114,7 @@ osu::Met::Met (const TYPE(mets) &met, const edm::Handle<vector<pat::PackedCandid
       noMuPt_TauEnDown_ = metNoMu_TauEnDown.Mod();
       noMuPt_UnclusteredEnDown_ = metNoMu_UnclusteredEnDown.Mod();
       noMuPt_PhotonEnDown_ = metNoMu_PhotonEnDown.Mod();
+#endif
 
     }
 }

--- a/Collections/src/Met.cc
+++ b/Collections/src/Met.cc
@@ -57,7 +57,7 @@ osu::Met::Met (const TYPE(mets) &met, const edm::Handle<vector<pat::PackedCandid
   if (pfCandidates.isValid ()) {
       TVector2 metNoMu (met.px(), met.py());
 
-#if DATA_FORMAT != AOD
+#if DATA_FORMAT_FROM_MINIAOD
       TVector2 metNoMu_JetResUp          (met.shiftedP2(MET::JetResUp).px, met.shiftedP2(MET::JetResUp).py);
       TVector2 metNoMu_JetEnUp           (met.shiftedP2(MET::JetEnUp).px, met.shiftedP2(MET::JetEnUp).py);
       TVector2 metNoMu_ElectronEnUp      (met.shiftedP2(MET::ElectronEnUp).px, met.shiftedP2(MET::ElectronEnUp).py);
@@ -80,7 +80,7 @@ osu::Met::Met (const TYPE(mets) &met, const edm::Handle<vector<pat::PackedCandid
 
           metNoMu += muon;
 
-#if DATA_FORMAT != AOD
+#if DATA_FORMAT_FROM_MINIAOD
           metNoMu_JetResUp += muon;
           metNoMu_JetEnUp += muon;
           metNoMu_ElectronEnUp += muon;
@@ -100,7 +100,7 @@ osu::Met::Met (const TYPE(mets) &met, const edm::Handle<vector<pat::PackedCandid
       noMuPy_ = metNoMu.Py ();
       noMuPhi_ = metNoMu.Phi ();
 
-#if DATA_FORMAT != AOD
+#if DATA_FORMAT_FROM_MINIAOD
       noMuPt_JetResUp_ = metNoMu_JetResUp.Mod();
       noMuPt_JetEnUp_ = metNoMu_JetEnUp.Mod();
       noMuPt_ElectronEnUp_ = metNoMu_ElectronEnUp.Mod();

--- a/Collections/src/Tau.cc
+++ b/Collections/src/Tau.cc
@@ -125,6 +125,7 @@ osu::Tau::~Tau ()
 // names for 76X samples found here:
 // https://github.com/cms-sw/cmssw/blob/CMSSW_7_6_X/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cfi.py#L62-L106
 
+#if DATA_FORMAT != AOD
 const bool
 osu::Tau::passesDecayModeReconstruction () const
 {
@@ -216,6 +217,7 @@ osu::Tau::passesTightMVAIsolation () const
       return false;
     }
 }
+#endif
 
 const double
 osu::Tau::metMinusOnePt () const

--- a/Collections/src/Tau.cc
+++ b/Collections/src/Tau.cc
@@ -125,7 +125,7 @@ osu::Tau::~Tau ()
 // names for 76X samples found here:
 // https://github.com/cms-sw/cmssw/blob/CMSSW_7_6_X/PhysicsTools/PatAlgos/python/producersLayer1/tauProducer_cfi.py#L62-L106
 
-#if DATA_FORMAT != AOD
+#if DATA_FORMAT_FROM_MINIAOD
 const bool
 osu::Tau::passesDecayModeReconstruction () const
 {

--- a/ExampleAnalysis/plugins/MyVariableProducer.cc
+++ b/ExampleAnalysis/plugins/MyVariableProducer.cc
@@ -4,18 +4,30 @@
 MyVariableProducer::MyVariableProducer(const edm::ParameterSet &cfg) :
   EventVariableProducer(cfg)
 {
-  if (collections_.exists ("electrons"))
-    tokens_.electrons = consumes<vector<pat::Electron> > (collections_.getParameter<edm::InputTag> ("electrons"));
-  if (collections_.exists ("jets"))
-    tokens_.jets = consumes<vector<pat::Jet> > (collections_.getParameter<edm::InputTag> ("jets"));
-  if (collections_.exists ("muons"))
-    tokens_.muons = consumes<vector<pat::Muon> > (collections_.getParameter<edm::InputTag> ("muons"));
+
   if (collections_.exists ("primaryvertexs"))
     tokens_.primaryvertexs = consumes<vector<reco::Vertex> > (collections_.getParameter<edm::InputTag> ("primaryvertexs"));
   if (collections_.exists ("pileupinfos"))
     tokens_.pileupinfos = consumes<vector<PileupSummaryInfo> > (collections_.getParameter<edm::InputTag> ("pileupinfos"));
   if (collections_.exists ("triggers"))
     tokens_.triggers = consumes<edm::TriggerResults> (collections_.getParameter<edm::InputTag> ("triggers"));
+
+#if DATA_FORMAT == AOD
+  if (collections_.exists ("electrons"))
+    tokens_.electrons = consumes<vector<reco::GsfElectron> > (collections_.getParameter<edm::InputTag> ("electrons"));
+  if (collections_.exists ("jets"))
+    tokens_.jets = consumes<vector<reco::PFJet> > (collections_.getParameter<edm::InputTag> ("jets"));
+  if (collections_.exists ("muons"))
+    tokens_.muons = consumes<vector<reco::Muon> > (collections_.getParameter<edm::InputTag> ("muons"));
+#else
+  if (collections_.exists ("electrons"))
+    tokens_.electrons = consumes<vector<pat::Electron> > (collections_.getParameter<edm::InputTag> ("electrons"));
+  if (collections_.exists ("jets"))
+    tokens_.jets = consumes<vector<pat::Jet> > (collections_.getParameter<edm::InputTag> ("jets"));
+  if (collections_.exists ("muons"))
+    tokens_.muons = consumes<vector<pat::Muon> > (collections_.getParameter<edm::InputTag> ("muons"));
+#endif
+
 }
 
 MyVariableProducer::~MyVariableProducer() {}

--- a/ExampleAnalysis/plugins/MyVariableProducer.cc
+++ b/ExampleAnalysis/plugins/MyVariableProducer.cc
@@ -12,14 +12,14 @@ MyVariableProducer::MyVariableProducer(const edm::ParameterSet &cfg) :
   if (collections_.exists ("triggers"))
     tokens_.triggers = consumes<edm::TriggerResults> (collections_.getParameter<edm::InputTag> ("triggers"));
 
-#if DATA_FORMAT == AOD
+#if DATA_FORMAT_FROM_AOD
   if (collections_.exists ("electrons"))
     tokens_.electrons = consumes<vector<reco::GsfElectron> > (collections_.getParameter<edm::InputTag> ("electrons"));
   if (collections_.exists ("jets"))
     tokens_.jets = consumes<vector<reco::PFJet> > (collections_.getParameter<edm::InputTag> ("jets"));
   if (collections_.exists ("muons"))
     tokens_.muons = consumes<vector<reco::Muon> > (collections_.getParameter<edm::InputTag> ("muons"));
-#else
+#elif DATA_FORMAT_FROM_MINIAOD
   if (collections_.exists ("electrons"))
     tokens_.electrons = consumes<vector<pat::Electron> > (collections_.getParameter<edm::InputTag> ("electrons"));
   if (collections_.exists ("jets"))

--- a/ExampleAnalysis/plugins/MyVariableProducer.h
+++ b/ExampleAnalysis/plugins/MyVariableProducer.h
@@ -14,11 +14,11 @@ struct OriginalCollections
   edm::Handle<vector<PileupSummaryInfo>>    pileupinfos;
   edm::Handle<edm::TriggerResults>          triggers;
 
-#if DATA_FORMAT == AOD
+#if DATA_FORMAT_FROM_AOD
   edm::Handle<vector<reco::GsfElectron> >    electrons;
   edm::Handle<vector<reco::PFJet> >          jets;
   edm::Handle<vector<reco::Muon> >           muons;
-#else
+#elif DATA_FORMAT_FROM_MINIAOD
   edm::Handle<vector<pat::Electron> >       electrons;
   edm::Handle<vector<pat::Jet> >            jets;
   edm::Handle<vector<pat::Muon> >           muons;
@@ -33,11 +33,11 @@ struct OriginalTokens
   edm::EDGetTokenT<vector<PileupSummaryInfo>>    pileupinfos;
   edm::EDGetTokenT<edm::TriggerResults>          triggers;
 
-#if DATA_FORMAT == AOD
+#if DATA_FORMAT_FROM_AOD
   edm::EDGetTokenT<vector<reco::GsfElectron> >    electrons;
   edm::EDGetTokenT<vector<reco::PFJet> >          jets;
   edm::EDGetTokenT<vector<reco::Muon> >           muons;
-#else
+#elif DATA_FORMAT_FROM_MINIAOD
   edm::EDGetTokenT<vector<pat::Electron> >       electrons;
   edm::EDGetTokenT<vector<pat::Jet> >            jets;
   edm::EDGetTokenT<vector<pat::Muon> >           muons;

--- a/ExampleAnalysis/plugins/MyVariableProducer.h
+++ b/ExampleAnalysis/plugins/MyVariableProducer.h
@@ -9,22 +9,40 @@
 
 struct OriginalCollections
 {
-  edm::Handle<vector<pat::Electron> >       electrons;
-  edm::Handle<vector<pat::Jet> >            jets;
-  edm::Handle<vector<pat::Muon> >           muons;
+
   edm::Handle<vector<reco::Vertex> >        primaryvertexs;
   edm::Handle<vector<PileupSummaryInfo>>    pileupinfos;
   edm::Handle<edm::TriggerResults>          triggers;
+
+#if DATA_FORMAT == AOD
+  edm::Handle<vector<reco::GsfElectron> >    electrons;
+  edm::Handle<vector<reco::PFJet> >          jets;
+  edm::Handle<vector<reco::Muon> >           muons;
+#else
+  edm::Handle<vector<pat::Electron> >       electrons;
+  edm::Handle<vector<pat::Jet> >            jets;
+  edm::Handle<vector<pat::Muon> >           muons;
+#endif
+
 };
 
 struct OriginalTokens
 {
-  edm::EDGetTokenT<vector<pat::Electron> >       electrons;
-  edm::EDGetTokenT<vector<pat::Jet> >            jets;
-  edm::EDGetTokenT<vector<pat::Muon> >           muons;
+
   edm::EDGetTokenT<vector<reco::Vertex> >        primaryvertexs;
   edm::EDGetTokenT<vector<PileupSummaryInfo>>    pileupinfos;
   edm::EDGetTokenT<edm::TriggerResults>          triggers;
+
+#if DATA_FORMAT == AOD
+  edm::EDGetTokenT<vector<reco::GsfElectron> >    electrons;
+  edm::EDGetTokenT<vector<reco::PFJet> >          jets;
+  edm::EDGetTokenT<vector<reco::Muon> >           muons;
+#else
+  edm::EDGetTokenT<vector<pat::Electron> >       electrons;
+  edm::EDGetTokenT<vector<pat::Jet> >            jets;
+  edm::EDGetTokenT<vector<pat::Muon> >           muons;
+#endif
+
 };
 
 class MyVariableProducer : public EventVariableProducer


### PR DESCRIPTION
This PR allows the framework to work with AOD (and AODSIM) data formats. The collectionMapAOD and DataFormatAOD.h needed to have a few additions, a few more files needed to be included, and some parts of the code only work if the format is not AOD or if trigobjs is valid.



**Tests I did:** 
Compiles in 8_0, 9_4, and 10_2, 

with both the 
`AnaTools/scripts/setupFramework.py -f AOD`
and the 
`AnaTools/scripts/setupFramework.py -f MINI_AOD` or `MINI_AOD_2017`
options.

Can run over an AOD file in 8_0 and make histograms and skims.



**There are three warnings when I compile with -f AOD that I'm not sure how to fix, help welcome:**

1.
`>> Compiling  /uscms_data/d3/alimena/DisplacedLeptons/CosmicMC/CMSSW_10_2_12/src/OSUT3Analysis/AnaTools/src/EventVariableProducer.cc 
In member function 'anatools::TypeWithDict anatools::TypeWithDict::toType() const':
cc1plus: warning: 'void* __builtin_memset(void*, int, long unsigned int)': specified size 18446744073709551608 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]`

2.
`/uscms_data/d3/alimena/DisplacedLeptons/CosmicMC/CMSSW_9_4_8/src/OSUT3Analysis/Collections/plugins/OSUTauProducer.cc: In member function 'virtual void OSUTauProducer::produce(edm::Event&, const edm::EventSetup&)':
/uscms_data/d3/alimena/DisplacedLeptons/CosmicMC/CMSSW_9_4_8/src/OSUT3Analysis/Collections/plugins/OSUTauProducer.cc:49:17: warning: unused variable 'tau' [-Wunused-variable]
       osu::Tau &tau = pl_->back ();
                 ^~~
`

3.
`/uscms_data/d3/alimena/DisplacedLeptons/CosmicMC/CMSSW_9_4_8/src/OSUT3Analysis/Collections/plugins/OSUGenericJetProducer.cc: In instantiation of 'void OSUGenericJetProducer<T>::produce(edm::Event&, const edm::EventSetup&) [with T = osu::Jet]':
/uscms_data/d3/alimena/DisplacedLeptons/CosmicMC/CMSSW_9_4_8/src/OSUT3Analysis/Collections/plugins/OSUGenericJetProducer.cc:378:34:   required from here
/uscms_data/d3/alimena/DisplacedLeptons/CosmicMC/CMSSW_9_4_8/src/OSUT3Analysis/Collections/plugins/OSUGenericJetProducer.cc:161:10: warning: unused variable 'jet' [-Wunused-variable]
       T &jet = pl_->back ();
          ^~~
`