### PR TITLE
Fix ratio plot y-axis range bug in makePlots

### DIFF
--- a/Configuration/scripts/makeComparisonPlots.py
+++ b/Configuration/scripts/makeComparisonPlots.py
@@ -515,7 +515,7 @@ def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
                 makeRatio = functools.partial (ratioHistogram,Histogram, Reference)
                 if arguments.ratioRelErrMax is not -1: # it gets initialized to this dummy value of -1
                     makeRatio =  functools.partial (makeRatio, relErrMax = float(arguments.ratioRelErrMax))
-                if addOneToRatio is not -1: # it gets initialized to this dummy value of -1
+                if addOneToRatio != -1: # it gets initialized to this dummy value of -1
                     makeRatio = functools.partial (makeRatio, addOne = bool (addOneToRatio))
                 Comparison = makeRatio()
             elif makeDiffPlots:
@@ -542,7 +542,7 @@ def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
                 RatioYRange = 1.15
                 if arguments.ratioYRange:
                     RatioYRange = float(arguments.ratioYRange)
-                if not addOneToRatio:
+                if addOneToRatio == -1: # it gets initialized to this dummy value of -1
                     Comparison.GetYaxis().SetRangeUser(-1*RatioYRange, RatioYRange)
                 else:
                     Comparison.GetYaxis().SetRangeUser(-1*RatioYRange + 1.0, RatioYRange + 1.0)

--- a/Configuration/scripts/makeEfficiencyPlots.py
+++ b/Configuration/scripts/makeEfficiencyPlots.py
@@ -446,7 +446,7 @@ def MakeOneHist(dirName, histogramName):
         Canvas.cd(2)
         if makeRatioPlots:
             makeRatio = functools.partial (ratioHistogram,HistogramClones[0],HistogramClones[1])
-            if addOneToRatio is not -1: # it gets initialized to this dummy value of -1
+            if addOneToRatio != -1: # it gets initialized to this dummy value of -1
                 makeRatio = functools.partial (makeRatio, addOne = bool (addOneToRatio))
             if ratioRelErrMax is not -1: # it gets initialized to this dummy value of -1
                 makeRatio = functools.partial (makeRatio, relErrMax = float (ratioRelErrMax))
@@ -469,7 +469,7 @@ def MakeOneHist(dirName, histogramName):
             RatioYRange = 1.15
             if arguments.ratioYRange:
                 RatioYRange = float(arguments.ratioYRange)
-            if not addOneToRatio:
+            if addOneToRatio == -1: # it gets initialized to this dummy value of -1
                 Comparison.GetYaxis().SetRangeUser(-1*RatioYRange, RatioYRange)
             else:
                 Comparison.GetYaxis().SetRangeUser(-1*RatioYRange + 1.0, RatioYRange + 1.0)

--- a/Configuration/scripts/makePlots.py
+++ b/Configuration/scripts/makePlots.py
@@ -1165,9 +1165,9 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
         BgSum = Stack.GetStack().Last()
         if makeRatioPlots:
             makeRatio = functools.partial (ratioHistogram, DataHistograms[0], BgSum)
-            if ratioRelErrMax is not -1: # it gets initialized to this dummy value of -1
+            if ratioRelErrMax != -1: # it gets initialized to this dummy value of -1
                 makeRatio = functools.partial (makeRatio, relErrMax = float (ratioRelErrMax))
-            if addOneToRatio is not -1: # it gets initialized to this dummy value of -1
+            if addOneToRatio != -1: # it gets initialized to this dummy value of -1
                 makeRatio = functools.partial (makeRatio, addOne = bool (addOneToRatio))
             Comparison = makeRatio ()
         elif makeDiffPlots:
@@ -1195,7 +1195,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
             if 'ratioYRange' in paperHistogram:
                 RatioYRange = paperHistogram['ratioYRange']
 
-        if not addOneToRatio:
+        if addOneToRatio == -1: # it gets initialized to this dummy value of -1
             Comparison.GetYaxis().SetRangeUser(-1*RatioYRange, RatioYRange)
         else:
             Comparison.GetYaxis().SetRangeUser(-1*RatioYRange + 1.0, RatioYRange + 1.0)


### PR DESCRIPTION
Fix a bug that lead to incorrect ratio plot y-axis ranges. Also fixed a couple related value comparisons with `is`. This works in CMSSW_10_2_12.