### PR TITLE
Update DisplacedSUSY lifetime reweighting rule to use privately produced 0.1 mm samples

### DIFF
--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -9104,7 +9104,7 @@ for index, sample in enumerate(signal_datasets):
 
     sourceCTau = 0.1 * 10**(math.ceil(math.log10(float(lifetime(sample)))))
     # special case
-    if float(lifetime(sample)) <= 0.1: sourceCTau = 0.1 * 1.0
+    if float(lifetime(sample)) <= 0.01: sourceCTau = 0.1 * 0.1
     if float(lifetime(sample)) > 1000.: sourceCTau = 100.0
     destinationCTau = 0.1 * float(lifetime(sample))
 


### PR DESCRIPTION
Simple change to use privately produced 0.1mm samples instead of reweighting 1mm samples.  The current implementation will use the 1mm sample as the source for ctaus from 0.2-1mm and the 0.1mm sample for everything below that. @jalimena, we should make sure we agree on this choice before merging.