### PR TITLE
Lifetime reweighting fixes and debugging help

### DIFF
--- a/AnaTools/plugins/LifetimeWeightProducer.h
+++ b/AnaTools/plugins/LifetimeWeightProducer.h
@@ -16,6 +16,8 @@ class LifetimeWeightProducer : public EventVariableProducer {
 
         edm::VParameterSet reweightingRules_;
         bool requireLastNotFirstCopy_;
+        bool requireLastAndFirstCopy_;
+	 bool specialRHadronsForDispLeptons_;
 
         vector<vector<double> > srcCTau_;
         vector<vector<double> > dstCTau_;

--- a/Configuration/python/LifetimeWeightProducer_cff.py
+++ b/Configuration/python/LifetimeWeightProducer_cff.py
@@ -9,13 +9,18 @@ if osusub.batchMode:
         if osusub.datasetLabel in rulesForLifetimeReweighting:
             rules.extend(rulesForLifetimeReweighting[osusub.datasetLabel])
 
+# hack to test LifetimeWeightProducer interactively
+#rules.extend(rulesForLifetimeReweighting['stopToLB1000_10mm'])
+
 LifetimeWeightProducer = cms.EDFilter ("LifetimeWeightProducer",
     reweightingRules = cms.VPSet([
         cms.PSet(
-            pdgIds = cms.vint32(r.pdgIds), 
-            srcCTaus = cms.vdouble(r.srcCTaus), 
-            dstCTaus = cms.vdouble(r.dstCTaus), 
+            pdgIds = cms.vint32(r.pdgIds),
+            srcCTaus = cms.vdouble(r.srcCTaus),
+            dstCTaus = cms.vdouble(r.dstCTaus),
             isDefaultRule = cms.bool(r.isDefaultRule)
         ) for r in rules]),
-    requireLastNotFirstCopy = cms.bool(False)
+    requireLastNotFirstCopy = cms.bool(False),
+    requireLastAndFirstCopy = cms.bool(False),
+    specialRHadronsForDispLeptons = cms.bool(False)
 )

--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -9105,11 +9105,11 @@ for index, sample in enumerate(signal_datasets):
 
     # source and destination CTau are in cm, while lifetime(sample) is in mm
     # LifetimeWeightProducer expects cm to cm
-    sourceCTau = 0.1 * 10**(math.ceil(math.log10(float(lifetime(sample)))))
+    sourceCTau = round(0.1 * 10**(math.ceil(math.log10(float(lifetime(sample))))), 5)
     # special case
-    if float(lifetime(sample)) <= 0.01: sourceCTau = 0.1 * 0.1
+    if float(lifetime(sample)) <= 0.01: sourceCTau = 0.01
     if float(lifetime(sample)) > 1000.: sourceCTau = 100.0
-    destinationCTau = 0.1 * float(lifetime(sample))
+    destinationCTau = round(0.1 * float(lifetime(sample)), 5)
 
     # set the default reweighting rules
     rulesForLifetimeReweighting[sample] = [lifetimeReweightingRule([1000006], [sourceCTau], [destinationCTau], True)]
@@ -9117,11 +9117,11 @@ for index, sample in enumerate(signal_datasets):
     # set the non-default reweighting rules too
     # thus, for a reweighted (i.e. non-generated) sample, there is one rule and it is the default
     # but for the generated samples, there are many rules and only one is default
-    destinationCTaus = [float(0.1 * i * sourceCTau) for i in range(2, 11)]
+    destinationCTaus = [round(float(0.1 * i * sourceCTau), 5) for i in range(2, 11)]
     if sourceCTau == 0.01:
-        destinationCTaus.extend([0.001])
-    if sourceCTau == 100:
-        destinationCTaus.extend([float(1 * i * sourceCTau) for i in range(2, 11)])
+      destinationCTaus.append(float(0.001))
+    elif sourceCTau == 100:
+      destinationCTaus.extend([float(1 * i * sourceCTau) for i in range(2, 11)])
     if destinationCTau == sourceCTau:
       rulesForLifetimeReweighting[sample] = [lifetimeReweightingRule([1000006], [sourceCTau], [d], (d == sourceCTau)) for d in destinationCTaus]
 

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -262,6 +262,7 @@ def add_channels (process,
         'binsX', 'binsY', 'binsZ',
         'indexX', 'indexY', 'indexZ',
         'inputVariables',
+        'weight',
     ]
 
     # find all cuts with invalid attributes

--- a/Configuration/scripts/checkLifetimeReweighting.py
+++ b/Configuration/scripts/checkLifetimeReweighting.py
@@ -1,0 +1,17 @@
+# this script prints out a bunch of info about your reweighting in configurationOptions.py
+# so you can check if you're doing it right
+
+from OSUT3Analysis.Configuration.configurationOptions import rulesForLifetimeReweighting
+
+for sample in rulesForLifetimeReweighting:
+    #if not sample.startswith('AMSB_chargino_100GeV_'): continue
+    #if not sample.endswith('_94X'): continue
+    if not sample.startswith('stopToLB1000_'): continue
+
+    print 'Rules for sample:', sample
+
+    for rule in rulesForLifetimeReweighting[sample]:
+        print '\t******'
+        print '\tPDG IDs:', rule.pdgIds
+        print '\tCTaus:', rule.srcCTaus, '-->', rule.dstCTaus
+        print '\tIs default rule:', rule.isDefaultRule


### PR DESCRIPTION
This PR has some fixes for Displaced SUSY lifetime reweighting:
- it adds the non-default reweighting rules for Displaced SUSY samples in configurationOptions.py
- it fixes the string conversion of type 0.1 to 0p1
- it adds options to deal with special Displaced SUSY pythia generation of stops to R-hadrons to final stops

and also adds some lifetime reweighting help in general:
- it adds a script to check if lifetime reweighting rules in configurationOptions.py are right
- it adds a hack in LifetimeWeightProducer_cff in order to run LifetimeWeightProducer interactively

This PR has been tested in 10_2_X. The lifetime reweighting event variables in the trees now look right - see some plots of the tree variables for stopToLB1000_10mm attached.
<img width="544" alt="eventvariable_lifetimeWeight" src="https://user-images.githubusercontent.com/5177191/101142032-5d274580-3615-11eb-88c5-271af39cdb96.png">
<img width="547" alt="eventvariable_lifetimeWeight_1000006_1cmTo1cm" src="https://user-images.githubusercontent.com/5177191/101142049-60bacc80-3615-11eb-9e11-af006adc44ac.png">
<img width="547" alt="eventvariable_lifetimeWeight_1000006_1cmTo0p9cm" src="https://user-images.githubusercontent.com/5177191/101142048-60bacc80-3615-11eb-9af2-beae93800e15.png">
<img width="545" alt="eventvariable_lifetimeWeight_1000006_1cmTo0p8cm" src="https://user-images.githubusercontent.com/5177191/101142045-60223600-3615-11eb-95ea-a47d24bf9039.png">
<img width="550" alt="eventvariable_lifetimeWeight_1000006_1cmTo0p5cm" src="https://user-images.githubusercontent.com/5177191/101142039-5f899f80-3615-11eb-92ca-ff1414996cb2.png">
<img width="547" alt="eventvariable_lifetimeWeight_1000006_1cmTo0p2cm" src="https://user-images.githubusercontent.com/5177191/101142036-5e587280-3615-11eb-921b-9a12257de7ae.png">









