### PR TITLE
add overflow and underflow by default to 2D plots

### DIFF
--- a/Configuration/scripts/makePlots.py
+++ b/Configuration/scripts/makePlots.py
@@ -198,6 +198,17 @@ dir_y_bottom = 0.0
 dir_x_right  = ts_x_right
 dir_y_top    = ts_y_bottom
 
+noOverFlow = arguments.noOverFlow
+if arguments.paperConfig:
+    if 'noOverFlow' in paperHistogram:
+        noOverFlow = paperHistogram['noOverFlow']
+###############################################
+noUnderFlow = arguments.noUnderFlow
+if arguments.paperConfig:
+    if 'noUnderFlow' in paperHistogram:
+        noUnderFlow = paperHistogram['noUnderFlow']
+###############################################
+
 
 ##########################################################################################################################################
 
@@ -473,16 +484,6 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
     if arguments.paperConfig:
         if 'includeSystematics' in paperHistogram:
             includeSystematics = paperHistogram['includeSystematics']
-    ###############################################
-    noOverFlow = arguments.noOverFlow
-    if arguments.paperConfig:
-        if 'noOverFlow' in paperHistogram:
-            noOverFlow = paperHistogram['noOverFlow']
-    ###############################################
-    noUnderFlow = arguments.noUnderFlow
-    if arguments.paperConfig:
-        if 'noUnderFlow' in paperHistogram:
-            noUnderFlow = paperHistogram['noUnderFlow']
     ###############################################
     sortOrderByYields = arguments.sortOrderByYields
     if arguments.paperConfig:
@@ -1392,6 +1393,23 @@ def MakeTwoDHist(pathToDir,histogramName):
         else:
             histoTitle = ""
 
+        nbinsX = Histogram.GetNbinsX()
+        nbinsY = Histogram.GetNbinsY()
+        if not noOverFlow:
+            Histogram.SetBinContent(nbinsX, 1, Histogram.GetBinContent(nbinsX, 1) + Histogram.GetBinContent(nbinsX+1, 1)) # Add overflow to (last x bin, first y bin)
+            Histogram.SetBinError(nbinsX, 1, math.sqrt(math.pow(Histogram.GetBinError(nbinsX, 1),2) + math.pow(Histogram.GetBinError(nbinsX+1, 1),2))) # Set the errors to be the sum in quadrature
+            Histogram.SetBinContent(1, nbinsY, Histogram.GetBinContent(1, nbinsY) + Histogram.GetBinContent(1, nbinsY+1)) # Add overflow to (first x bin, last y bin)
+            Histogram.SetBinError(1, nbinsY, math.sqrt(math.pow(Histogram.GetBinError(1, nbinsY),2) + math.pow(Histogram.GetBinError(1, nbinsY+1),2))) # Set the errors to be the sum in quadrature
+            Histogram.SetBinContent(nbinsX, nbinsY, Histogram.GetBinContent(nbinsX, nbinsY) + Histogram.GetBinContent(nbinsX+1, nbinsY+1)) # Add overflow to (last x bin, last y bin)
+            Histogram.SetBinError(nbinsX, nbinsY, math.sqrt(math.pow(Histogram.GetBinError(nbinsX, nbinsY),2) + math.pow(Histogram.GetBinError(nbinsX+1, nbinsY+1),2))) # Set the errors to be the sum in quadrature
+        if not noUnderFlow:
+            Histogram.SetBinContent(1, 1, Histogram.GetBinContent(1, 1) + Histogram.GetBinContent(0, 0)) # Add underflow to (first x bin, first y bin)
+            Histogram.SetBinError(1, 1, math.sqrt(math.pow(Histogram.GetBinError(1, 1), 2) + math.pow(Histogram.GetBinError(0, 1), 2))) # Set the errors to be the sum in quadrature
+            Histogram.SetBinContent(1, nbinsY, Histogram.GetBinContent(1, nbinsY) + Histogram.GetBinContent(0, nbinsY)) # Add underflow to (first x bin, last y bin)
+            Histogram.SetBinError(1, nbinsY, math.sqrt(math.pow(Histogram.GetBinError(1, nbinsY), 2) + math.pow(Histogram.GetBinError(0, nbinsY), 2))) # Set the errors to be the sum in quadrature
+            Histogram.SetBinContent(nbinsX, 1, Histogram.GetBinContent(nbinsX, 1) + Histogram.GetBinContent(nbinsX, 0)) # Add underflow to (first x bin, last y bin)
+            Histogram.SetBinError(nbinsX, 1, math.sqrt(math.pow(Histogram.GetBinError(nbinsX, 1), 2) + math.pow(Histogram.GetBinError(nbinsX, 0), 2))) # Set the errors to be the sum in quadrature
+
         if( types[sample] == "bgMC"):
 
             numBgMCSamples += 1
@@ -1437,6 +1455,11 @@ def MakeTwoDHist(pathToDir,histogramName):
             SignalMCHistograms[0].GetXaxis().SetTitle(xAxisLabel)
             SignalMCHistograms[0].GetYaxis().SetTitle(yAxisLabel)
             SignalMCHistograms[0].Draw("colz")
+        elif(numBgMCSamples is not 0):
+            BgMCHistograms[0].SetTitle(histoTitle)
+            BgMCHistograms[0].GetXaxis().SetTitle(xAxisLabel)
+            BgMCHistograms[0].GetYaxis().SetTitle(yAxisLabel)
+            BgMCHistograms[0].Draw("colz")
 
     else:
         if(numBgMCSamples is not 0):

--- a/Configuration/scripts/makePlots.py
+++ b/Configuration/scripts/makePlots.py
@@ -198,6 +198,7 @@ dir_y_bottom = 0.0
 dir_x_right  = ts_x_right
 dir_y_top    = ts_y_bottom
 
+###############################################
 noOverFlow = arguments.noOverFlow
 if arguments.paperConfig:
     if 'noOverFlow' in paperHistogram:
@@ -208,6 +209,10 @@ if arguments.paperConfig:
     if 'noUnderFlow' in paperHistogram:
         noUnderFlow = paperHistogram['noUnderFlow']
 ###############################################
+if not noOverFlow:
+    print "Adding overflow to last bins, in 1D and 2D histograms"
+if not noUnderFlow:
+    print "Adding underflow to last bins, in 1D and 2D histograms"
 
 
 ##########################################################################################################################################


### PR DESCRIPTION
a 2D plot before the PR:
![beforePR](https://user-images.githubusercontent.com/5177191/102108526-5679a900-3e33-11eb-8754-1c69cbe8c7fb.png)

and after:
![afterPR](https://user-images.githubusercontent.com/5177191/102108532-59749980-3e33-11eb-9060-9a39c8829eaf.png)

Notice the top left, top right, and bottom right bins (there's no underflow in this particular plot)