### PR TITLE
Updates for CMSSW 11_2_X

### DIFF
--- a/AnaTools/interface/DataFormat.h
+++ b/AnaTools/interface/DataFormat.h
@@ -49,7 +49,7 @@
 
 #define XSTR(x) STR(x)
 #define STR(x) #x
-#define IS_VALID(x) !(defined (x##_INVALID))
+#define IS_VALID(x) (x##_INVALID != 1)
 #define EQ_VALID(s,x) (strcmp (XSTR(x##_TYPE), XSTR(INVALID_TYPE)) && !strcmp (s.c_str (), XSTR(x)))
 
 #define TYPE(x) x##_TYPE

--- a/AnaTools/interface/DataFormatAOD.h
+++ b/AnaTools/interface/DataFormatAOD.h
@@ -29,18 +29,17 @@
 #define  prescales_TYPE       INVALID_TYPE
 #define  generatorweights_TYPE  GenEventInfoProduct
 
-#define  bxlumis_INVALID
-#define  events_INVALID
-#define  genjets_INVALID
-#define  prescales_INVALID
-#define  superclusters_INVALID
-#define  trigobjs_INVALID
-#define  bjets_INVALID
-
-#define  cschits_INVALID
-#define  cscsegs_INVALID
-#define  dtsegs_INVALID
-#define  rpchits_INVALID
+#define  bxlumis_INVALID       1
+#define  events_INVALID        1
+#define  genjets_INVALID       1
+#define  prescales_INVALID     1
+#define  superclusters_INVALID 1
+#define  trigobjs_INVALID      1
+#define  bjets_INVALID         1
+#define  cschits_INVALID       1
+#define  cscsegs_INVALID       1
+#define  dtsegs_INVALID        1
+#define  rpchits_INVALID       1
 
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"

--- a/AnaTools/interface/DataFormatMiniAOD.h
+++ b/AnaTools/interface/DataFormatMiniAOD.h
@@ -29,15 +29,14 @@
 #define  prescales_TYPE         pat::PackedTriggerPrescales
 #define  generatorweights_TYPE  GenEventInfoProduct
 
-#define  bxlumis_INVALID
-#define  events_INVALID
-#define  tracks_INVALID
-#define  secondaryTracks_INVALID
-
-#define  cschits_INVALID
-#define  cscsegs_INVALID
-#define  dtsegs_INVALID
-#define  rpchits_INVALID
+#define  bxlumis_INVALID         1
+#define  events_INVALID          1
+#define  tracks_INVALID          1
+#define  secondaryTracks_INVALID 1
+#define  cschits_INVALID         1
+#define  cscsegs_INVALID         1
+#define  dtsegs_INVALID          1
+#define  rpchits_INVALID         1
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/Common/interface/TriggerResults.h"

--- a/Collections/plugins/OSUElectronProducer.h
+++ b/Collections/plugins/OSUElectronProducer.h
@@ -6,7 +6,13 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "OSUT3Analysis/Collections/interface/Electron.h"
+
+#if CMSSW_VERSION_CODE >= CMSSW_VERSION(11,2,0)
+#include "CommonTools/Egamma/interface/EffectiveAreas.h"
+#else
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
+#endif
+
 #include "TRandom3.h"
 
 class OSUElectronProducer : public edm::EDProducer

--- a/Collections/plugins/OSUPhotonProducer.h
+++ b/Collections/plugins/OSUPhotonProducer.h
@@ -5,9 +5,13 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
-
 #include "OSUT3Analysis/Collections/interface/Photon.h"
+
+#if CMSSW_VERSION_CODE >= CMSSW_VERSION(11,2,0)
+#include "CommonTools/Egamma/interface/EffectiveAreas.h"
+#else
+#include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
+#endif
 
 class OSUPhotonProducer : public edm::EDProducer
 {

--- a/Collections/src/Electron.cc
+++ b/Collections/src/Electron.cc
@@ -1,7 +1,12 @@
 #include "TVector2.h"
 
 #include "OSUT3Analysis/Collections/interface/Electron.h"
+
+#if CMSSW_VERSION_CODE >= CMSSW_VERSION(11,2,0)
+#include "CommonTools/Egamma/interface/ConversionTools.h"
+#else
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
+#endif
 
 #if IS_VALID(electrons)
 


### PR DESCRIPTION
Fixes compilation of IS_INVALID for a new GCC 9.x warning/error, and checks for moved RecoEgamma tools.

If users have their own custom DataFormat.h in their analysis repo, they must change x_INVALID similarly to what I've changed here. E.g.

```
#define something_INVALID
```
-->
```
#define something_INVALID 1
```

This PR addresses compiling in 11_2_X, but I haven't checked for any further issues that will arise -- more may come!