### PR TITLE
Higgs to LL scalar samples: add a scalar mass for 125 GeV Higgs

### DIFF
--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -9332,6 +9332,7 @@ for mH in massesH:
   if int(mH)==125:
     for ctau in lifetimesS:
       signal_datasetsH.append("HToSSTo4L"+mH+"_30_"+ctau+"mm")
+      signal_datasetsH.append("HToSSTo4L"+mH+"_50_"+ctau+"mm")
   elif int(mH)==300:
     for ctau in lifetimesS:
       signal_datasetsH.append("HToSSTo4L"+mH+"_20_"+ctau+"mm")


### PR DESCRIPTION
adds 50 GeV scalar masses to H(125) case. for displaced leptons analysis.

tested in 94X

should be pretty straightforward