### PR TITLE
fix for lifetime weights: more than one possible LLP pdgid

### DIFF
--- a/AnaTools/plugins/LifetimeWeightProducer.h
+++ b/AnaTools/plugins/LifetimeWeightProducer.h
@@ -17,7 +17,10 @@ class LifetimeWeightProducer : public EventVariableProducer {
         edm::VParameterSet reweightingRules_;
         bool requireLastNotFirstCopy_;
         bool requireLastAndFirstCopy_;
-	 bool specialRHadronsForDispLeptons_;
+	bool specialRHadronsForDispLeptons_;
+	bool moreThanOneLLPType_;
+	std::string dummyPdgId_;
+	vector<int> multiplePdgIds_;
 
         vector<vector<double> > srcCTau_;
         vector<vector<double> > dstCTau_;

--- a/Configuration/python/LifetimeWeightProducer_cff.py
+++ b/Configuration/python/LifetimeWeightProducer_cff.py
@@ -22,5 +22,8 @@ LifetimeWeightProducer = cms.EDFilter ("LifetimeWeightProducer",
         ) for r in rules]),
     requireLastNotFirstCopy = cms.bool(False),
     requireLastAndFirstCopy = cms.bool(False),
-    specialRHadronsForDispLeptons = cms.bool(False)
+    specialRHadronsForDispLeptons = cms.bool(False),
+    moreThanOneLLPType = cms.bool(False),
+    dummyPdgId = cms.string(""),
+    multiplePdgIds = cms.vint32(),
 )

--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -9505,12 +9505,8 @@ for index, sample in enumerate(signal_datasetsSlSt):
     destinationCTau = round(0.1 * float(lifetime(sample)), 5)
 
     # set the default reweighting rules
-    rulesForLifetimeReweighting[sample] = [lifetimeReweightingRule([1000011], [sourceCTau], [destinationCTau], True),
-                                           lifetimeReweightingRule([1000013], [sourceCTau], [destinationCTau], True),
-                                           lifetimeReweightingRule([1000015], [sourceCTau], [destinationCTau], True),
-                                           lifetimeReweightingRule([2000011], [sourceCTau], [destinationCTau], True),
-                                           lifetimeReweightingRule([2000013], [sourceCTau], [destinationCTau], True),
-                                           lifetimeReweightingRule([2000015], [sourceCTau], [destinationCTau], True)]
+    # since we need rules for multiple pdgids (1000011, 1000013, 1000015, 2000011, 2000013, 2000015), set one dummy pdgid of 0000010 and fix it all in LifetimeWeightProducer
+    rulesForLifetimeReweighting[sample] = [lifetimeReweightingRule([0000010], [sourceCTau], [destinationCTau], True)]
 
     # set the non-default reweighting rules too
     # thus, for a reweighted (i.e. non-generated) sample, there is one rule and it is the default
@@ -9519,12 +9515,7 @@ for index, sample in enumerate(signal_datasetsSlSt):
     if sourceCTau == 0.01:
       destinationCTaus.append(float(0.001))
     if destinationCTau == sourceCTau:
-      rulesForLifetimeReweighting[sample] = [lifetimeReweightingRule([1000011], [sourceCTau], [d], (d == sourceCTau)) for d in destinationCTaus]
-      rulesForLifetimeReweighting[sample].extend(lifetimeReweightingRule([1000013], [sourceCTau], [d], (d == sourceCTau)) for d in destinationCTaus)
-      rulesForLifetimeReweighting[sample].extend(lifetimeReweightingRule([1000015], [sourceCTau], [d], (d == sourceCTau)) for d in destinationCTaus)
-      rulesForLifetimeReweighting[sample].extend(lifetimeReweightingRule([2000011], [sourceCTau], [d], (d == sourceCTau)) for d in destinationCTaus)
-      rulesForLifetimeReweighting[sample].extend(lifetimeReweightingRule([2000013], [sourceCTau], [d], (d == sourceCTau)) for d in destinationCTaus)
-      rulesForLifetimeReweighting[sample].extend(lifetimeReweightingRule([2000015], [sourceCTau], [d], (d == sourceCTau)) for d in destinationCTaus)
+      rulesForLifetimeReweighting[sample] = [lifetimeReweightingRule([0000010], [sourceCTau], [d], (d == sourceCTau)) for d in destinationCTaus]
 
 ################################################################################
 ### code to set relevant parameters for disappearing tracks signal samples,  ###


### PR DESCRIPTION
This PR implements a fix for the lifetime weights when there's more than one possible LLP pdgid, as is the case for the GMSB model for the displaced leptons search. 

For this GMSB model, you can have a LLP that is a slectron (pdg id 1000011 or 2000011), smuon (pdg id 1000013 or 2000013), or stau (pdg id 1000015 or 2000015), but only 1 abs pdgid appears in any given event. Originally, a set of lifetime weights could be assigned for each pdgid, but then if an event has another pdgid, then the weights are all set to 1, which creates at spike at 1 in the lifetime weight distribution.

Therefore, in this PR, I have made an option for "multiple pdgids", where you have only 1 set of lifetime weights (assigned to a dummy pdgid), and thus removes the spike at 1 in the individual distributions. To turn on this option, you set the bool `moreThanOneLLPType` to true, put in a number (string) for your dummy pdgid `dummyPdgId` (which you should then use in configurationOptions), and give the list of true pdgids to check (`multiplePdgIds`).