### PR TITLE
Fixing edm::LogWarning issue with CMSSW_12_0_X

### DIFF
--- a/AnaTools/BuildFile.xml
+++ b/AnaTools/BuildFile.xml
@@ -14,6 +14,7 @@
 <use  name="DataFormats/TrackReco"/>
 <use  name="DataFormats/VertexReco"/>
 <use  name="FWCore/Framework"/>
+<use  name="FWCore/MessageLogger"/>
 <use  name="FWCore/ParameterSet"/>
 <use  name="FWCore/Utilities"/>
 <use  name="OSUT3Analysis/Collections"/>

--- a/AnaTools/interface/CommonUtils.h
+++ b/AnaTools/interface/CommonUtils.h
@@ -15,7 +15,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "OSUT3Analysis/AnaTools/interface/BaseWithDict.h"

--- a/Collections/BuildFile.xml
+++ b/Collections/BuildFile.xml
@@ -12,6 +12,7 @@
 <use  name="DataFormats/TauReco"/>
 <use  name="DataFormats/TrackReco"/>
 <use  name="DataFormats/VertexReco"/>
+<use  name="FWCore/MessageLogger"/>
 <use  name="FWCore/ParameterSet"/>
 <use  name="RecoEgamma/EgammaTools"/>
 <use  name="SimDataFormats/PileupSummaryInfo"/>

--- a/Collections/interface/GenMatchable.h
+++ b/Collections/interface/GenMatchable.h
@@ -6,6 +6,7 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Common/interface/Handle.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "OSUT3Analysis/Collections/interface/Mcparticle.h"

--- a/Collections/plugins/OSUGenericJetProducer.h
+++ b/Collections/plugins/OSUGenericJetProducer.h
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "OSUT3Analysis/Collections/interface/Jet.h"

--- a/Collections/plugins/OSUGenericTrackProducer.h
+++ b/Collections/plugins/OSUGenericTrackProducer.h
@@ -2,10 +2,11 @@
 #define TRACK_PRODUCER
 
 #include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"

--- a/Collections/plugins/OSUMetProducer.h
+++ b/Collections/plugins/OSUMetProducer.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "OSUT3Analysis/Collections/interface/Met.h"


### PR DESCRIPTION
Minor changes made, including MessageLogger to fix  "error: 'LogWarning' is not a member of 'edm'" while compiling OSUT3Analysis under CMSSW_12_0_X environment