### PR TITLE
update OSUT3Analysis to python3 and 12_1_X

### DIFF
--- a/AnaTools/scripts/checkJobs
+++ b/AnaTools/scripts/checkJobs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import subprocess
@@ -11,7 +11,7 @@ def logsWithMatches(logs, matchingStrings, vetoStrings = None):
   for log in logs:
     f = open(log)
     s = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
-    
+
     isMatched = True
     if not vetoStrings is None:
       for v in vetoStrings:
@@ -82,10 +82,10 @@ def printJobs(logs, desc):
       jobRanges[dataset] = [jobNumber];
     else:
       jobRanges[dataset].append(jobNumber)
-  print desc
+  print(desc)
   for dataset in jobRanges:
     jobRanges[dataset].sort()
-    print dataset + ': ' + concatenateJobNumbers(jobRanges[dataset])
+    print(dataset + ': ' + concatenateJobNumbers(jobRanges[dataset]))
   print
 
 parser = OptionParser("usage: %prog [options] workDirectory")
@@ -106,7 +106,7 @@ if not len(args) == 1:
 workDir = args[0]
 
 if not os.path.isdir(workDir):
-  print "ERROR: " + workDir + " is not a directory."
+  print("ERROR: " + workDir + " is not a directory.")
   sys.exit()
 
 logs = subprocess.check_output('find ' + workDir + ' -type f -regex ".*\/condor_[^/]*\.log$"', shell = True).split('\n')[:-1]
@@ -152,14 +152,14 @@ runningFraction    = float(len(running))    / nTotal * 100.0
 queuedFraction     = float(len(queued))     / nTotal * 100.0
 
 print
-print 'Job summary: ' + workDir
+print('Job summary: ' + workDir)
 print
-print 'Jobs finished successfully:', len(successful), '/',  int(nTotal), '(' + "{0:.2f}".format(successfulFraction) + '%)'
-print 'Jobs failed:               ', len(failed),     '/',  int(nTotal), '(' + "{0:.2f}".format(failedFraction) + '%)'
-print 'Jobs removed by system:    ', len(removed),    '/',  int(nTotal), '(' + "{0:.2f}".format(removedFraction) + '%)'
-print 'Jobs aborted by user:      ', len(aborted),    '/',  int(nTotal), '(' + "{0:.2f}".format(abortedFraction) + '%)'
-print 'Jobs running:              ', len(running),    '/',  int(nTotal), '(' + "{0:.2f}".format(runningFraction) + '%)'
-print 'Jobs queued:               ', len(queued),     '/',  int(nTotal), '(' + "{0:.2f}".format(queuedFraction) + '%)'
+print('Jobs finished successfully:', len(successful), '/',  int(nTotal), '(' + "{0:.2f}".format(successfulFraction) + '%)')
+print('Jobs failed:               ', len(failed),     '/',  int(nTotal), '(' + "{0:.2f}".format(failedFraction) + '%)')
+print('Jobs removed by system:    ', len(removed),    '/',  int(nTotal), '(' + "{0:.2f}".format(removedFraction) + '%)')
+print('Jobs aborted by user:      ', len(aborted),    '/',  int(nTotal), '(' + "{0:.2f}".format(abortedFraction) + '%)')
+print('Jobs running:              ', len(running),    '/',  int(nTotal), '(' + "{0:.2f}".format(runningFraction) + '%)')
+print('Jobs queued:               ', len(queued),     '/',  int(nTotal), '(' + "{0:.2f}".format(queuedFraction) + '%)')
 print
 
 if options.printSuccess or options.printAll:
@@ -176,6 +176,6 @@ if options.printAborted or options.printAll:
 
 if options.printRunning or options.printAll:
   printJobs(running, "Running jobs:")
-  
+
 if options.printQueued or options.printAll:
   printJobs(queued, "Queued jobs:")

--- a/AnaTools/scripts/setupFramework.py
+++ b/AnaTools/scripts/setupFramework.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os
@@ -50,22 +50,22 @@ if arguments.version:
             if "#define DATA_FORMAT" in line:
                 data_line = line
                 break
-    print "Data type is currently '" + data_line.split()[2] + "'"
+    print("Data type is currently '" + data_line.split()[2] + "'")
     sys.exit(0)
 
 if arguments.reset:
     os.system('git checkout $CMSSW_BASE/src/OSUT3Analysis/AnaTools/interface/DataFormat.h')
-    print "Data format has been reset."
-    print "Do not forget to recompile."
+    print("Data format has been reset.")
+    print("Do not forget to recompile.")
     sys.exit(0)
 
 if not arguments.data_format:
-    print "Please specify data type with '-f' option"
+    print("Please specify data type with '-f' option")
     sys.exit(0)
 
 if arguments.data_format not in supported_formats:
-    print "'"+arguments.data_format+"' is not a supported format."
-    print "Supported formats are the following: ",supported_formats
+    print("'"+arguments.data_format+"' is not a supported format.")
+    print("Supported formats are the following: ",supported_formats)
     sys.exit(0)
 
 if arguments.custom_config:
@@ -73,7 +73,7 @@ if arguments.custom_config:
 
 if arguments.custom_define:
     for definition in arguments.custom_define.split(','):
-        print "Defining custom variable: #define " + definition
+        print("Defining custom variable: #define " + definition)
         os.system('sed -i "16i #define %s" $CMSSW_BASE/src/OSUT3Analysis/AnaTools/interface/DataFormat.h' % definition)
 
 # redefine the data format in C++
@@ -98,35 +98,35 @@ if arguments.custom_config:
     os.system('sed -i "s:.*CustomDataFormat.h.*:%s:" $CMSSW_BASE/src/OSUT3Analysis/AnaTools/interface/DataFormat.h' % ('  #include \\\"' + arguments.custom_config + '\\\"'))
 
 os.utime (os.environ["CMSSW_BASE"] + "/src/OSUT3Analysis/AnaTools/interface/DataFormat.h", None)
-print "Data format changed to " + arguments.data_format + "."
-print "Do not forget to recompile."
+print("Data format changed to " + arguments.data_format + ".")
+print("Do not forget to recompile.")
 
 #enable git hooks
 os.system("ln -s $CMSSW_BASE/src/OSUT3Analysis/githooks/* $CMSSW_BASE/src/OSUT3Analysis/.git/hooks/")
 
 # warn user about v2 photon ID availability in 9_4_X
 if os.environ["CMSSW_VERSION"].startswith("CMSSW_9_4_") and int(os.environ["CMSSW_VERSION"].split("_")[3]) < 13:
-    print ""
-    print "If using photons, note that v2 IDs are only available in >= 9_4_13"
-    print "Your current release uses v1 photon IDs; consider changing to a newer release"
+    print("")
+    print("If using photons, note that v2 IDs are only available in >= 9_4_13")
+    print("Your current release uses v1 photon IDs; consider changing to a newer release")
 
 # check that necessary merge-topics have been done
 if os.environ["CMSSW_VERSION"].startswith("CMSSW_9_4_") and int(os.environ["CMSSW_VERSION"].split("_")[3]) >= 9:
     if not os.path.isfile(os.environ["CMSSW_BASE"] + "/src/RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_Fall17_94X_V2_cff.py"):
-        print ""
-        print "If using electrons, please run the following before recompiling:"
-        print A_BRIGHT_RED + "  git cms-merge-topic UAEDF-tomc:eleCutBasedId_94X_V2" + A_RESET
+        print("")
+        print("If using electrons, please run the following before recompiling:")
+        print(A_BRIGHT_RED + "  git cms-merge-topic UAEDF-tomc:eleCutBasedId_94X_V2" + A_RESET)
     if not os.path.isfile(os.environ["CMSSW_BASE"] + "/src/L1Prefiring/EventWeightProducer/python/L1ECALPrefiringWeightProducer_cfi.py"):
-        print ""
-        print "If your analysis needs to correct for L1 ECAL prefiring issue, please run the following before recompling:"
-        print A_BRIGHT_RED + "  git cms-merge-topic lathomas:L1Prefiring_9_4_9" + A_RESET
+        print("")
+        print("If your analysis needs to correct for L1 ECAL prefiring issue, please run the following before recompling:")
+        print(A_BRIGHT_RED + "  git cms-merge-topic lathomas:L1Prefiring_9_4_9" + A_RESET)
 
 if os.environ["CMSSW_VERSION"].startswith("CMSSW_8_0_"):
     if not os.path.isfile(os.environ["CMSSW_BASE"] + "/src/RecoEgamma/PhotonIdentification/python/Identification/cutBasedPhotonID_PHYS14_PU20bx25_V1_cff.py"):
-        print ""
-        print "If using photons, please run the following before recompiling:"
-        print A_BRIGHT_RED + "  git cms-merge-topic ikrav:egm_id_80X_v3_photons" + A_RESET
+        print("")
+        print("If using photons, please run the following before recompiling:")
+        print(A_BRIGHT_RED + "  git cms-merge-topic ikrav:egm_id_80X_v3_photons" + A_RESET)
     if int(os.environ["CMSSW_VERSION"].split("_")[3]) >= 32 and not os.path.isfile(os.environ["CMSSW_BASE"] + "/src/L1Prefiring/EventWeightProducer/python/L1ECALPrefiringWeightProducer_cfi.py"):
-        print ""
-        print "If your analysis needs to correct for L1 ECAL prefiring issue, please run the following before recompling:"
-        print A_BRIGHT_RED + "  git cms-merge-topic lathomas:L1Prefiring_8_0_32" + A_RESET
+        print("")
+        print("If your analysis needs to correct for L1 ECAL prefiring issue, please run the following before recompling:")
+        print(A_BRIGHT_RED + "  git cms-merge-topic lathomas:L1Prefiring_8_0_32" + A_RESET)

--- a/AnaTools/test/Convolution.py
+++ b/AnaTools/test/Convolution.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time
 import os
@@ -24,7 +24,7 @@ if arguments.localConfig:
     sys.path.append(os.getcwd())
     exec("from " + re.sub (r".py$", r"", arguments.localConfig) + " import *")
 else:
-    print "No local config specified, shame on you"
+    print("No local config specified, shame on you")
     sys.exit(0)
 
 GausHist = TH1D("Gaus","Gaus",GausBins[0],GausBins[1],GausBins[2])
@@ -39,17 +39,17 @@ for i in range(0,numTrial):
     PoisHist.Fill(np.random.poisson(Lam))
     ConvHist.Fill(np.random.poisson(Lam) + np.random.normal(mu,sigma))
 
-print "The mean value is " + str(ConvHist.GetMean())
+print("The mean value is " + str(ConvHist.GetMean()))
 meanBin = ConvHist.FindBin(ConvHist.GetMean())
 rightInt = ConvHist.Integral(meanBin, ConvHist.GetNbinsX() + 1)
 for n in range(meanBin, ConvHist.GetNbinsX() + 1):
     if ConvHist.Integral(meanBin, n)/rightInt >= CLs:
-        print str(CLs) + "% Upper Limit is " + str(ConvHist.GetBinCenter(n-1))
+        print(str(CLs) + "% Upper Limit is " + str(ConvHist.GetBinCenter(n-1)))
         break
 leftInt = ConvHist.Integral(0, meanBin-1)
 for n in range(0, meanBin):
     if ConvHist.Integral(0, n)/leftInt >= 1 - CLs:
-        print str(CLs) + "% Lower Limit is " + str(ConvHist.GetBinCenter(n-1))
+        print(str(CLs) + "% Lower Limit is " + str(ConvHist.GetBinCenter(n-1)))
         break
 
 outPutFile.cd()

--- a/AnaTools/test/TriggerEfficiencyAnalyzerOptions.py
+++ b/AnaTools/test/TriggerEfficiencyAnalyzerOptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # import the definitions of all the datasets on the T3
 from OSUT3Analysis.Configuration.configurationOptions import *

--- a/Configuration/python/Color.py
+++ b/Configuration/python/Color.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # define some constants with meaningful names for the ANSI color codes
 # https://en.wikipedia.org/wiki/ANSI_escape_code#Colors

--- a/Configuration/python/Measurement.py
+++ b/Configuration/python/Measurement.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import math
 

--- a/Configuration/python/ProgressIndicator.py
+++ b/Configuration/python/ProgressIndicator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, time
 import OSUT3Analysis.Configuration.Color
@@ -28,20 +28,20 @@ class ProgressIndicator:
   def printProgress (self, finished = False):
     if (time.time () - self._timeOfLastPrint) > self._minTimeIntervalForPrinting or finished:
       if not self._isPrinted:
-        print self._title,
+        print(self._title,)
         if self._title:
-          print ": ",
+          print (": ",)
 
         self._isPrinted = True
       else:
         titleLength = len (self._title) + 2
         if self._title:
           titleLength += 2
-        print A_COLUMN (titleLength),
+        print(A_COLUMN (titleLength),)
 
-      print str ("%.2f" % round (self._percentDone, 2)).rjust (self._percentDonePadding) + "%",
+      print (str ("%.2f" % round (self._percentDone, 2)).rjust (self._percentDonePadding) + "%",)
       if finished:
-        print ""
+        print ("")
 
       sys.stdout.flush ()
       self._timeOfLastPrint = time.time ()

--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 
@@ -9185,7 +9185,7 @@ class lifetimeReweightingRule:
 
   def __init__(self, ids = [], srcs = [], dsts = [], isDefault = False):
     if len(ids) != len(srcs) or len(ids) != len(dsts):
-      print 'ids, srcs, and dsts must be of the same length when creating a lifetimeReweightingRule!'
+      print('ids, srcs, and dsts must be of the same length when creating a lifetimeReweightingRule!')
       return
     self.pdgIds = ids
     self.srcCTaus = srcs
@@ -9510,8 +9510,8 @@ for index, sample in enumerate(signal_datasetsSlSt):
     destinationCTau = round(0.1 * float(lifetime(sample)), 5)
 
     # set the default reweighting rules
-    # since we need rules for multiple pdgids (1000011, 1000013, 1000015, 2000011, 2000013, 2000015), set one dummy pdgid of 0000010 and fix it all in LifetimeWeightProducer
-    rulesForLifetimeReweighting[sample] = [lifetimeReweightingRule([0000010], [sourceCTau], [destinationCTau], True)]
+    # since we need rules for multiple pdgids (1000011, 1000013, 1000015, 2000011, 2000013, 2000015), set one dummy pdgid of 9990010 and fix it all in LifetimeWeightProducer
+    rulesForLifetimeReweighting[sample] = [lifetimeReweightingRule([9990010], [sourceCTau], [destinationCTau], True)]
 
     # set the non-default reweighting rules too
     # thus, for a reweighted (i.e. non-generated) sample, there is one rule and it is the default
@@ -9522,7 +9522,7 @@ for index, sample in enumerate(signal_datasetsSlSt):
     elif sourceCTau == 100:
       destinationCTaus.extend([float(1 * i * sourceCTau) for i in range(2, 11)])
     if destinationCTau == sourceCTau:
-      rulesForLifetimeReweighting[sample] = [lifetimeReweightingRule([0000010], [sourceCTau], [d], (d == sourceCTau)) for d in destinationCTaus]
+      rulesForLifetimeReweighting[sample] = [lifetimeReweightingRule([9990010], [sourceCTau], [d], (d == sourceCTau)) for d in destinationCTaus]
 
 ################################################################################
 ### code to set relevant parameters for disappearing tracks signal samples,  ###

--- a/Configuration/python/cutUtilities.py
+++ b/Configuration/python/cutUtilities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Utilities for applying cuts.
 
 import FWCore.ParameterSet.Config as cms
@@ -16,30 +16,30 @@ def addCuts(cutVPset, cutsToAdd):
 
 def addSingleCut(cutVPset, cutToAdd, previousExistingCut):
     # Add cutToAdd immediately after previousExistingCut
-    for i in xrange(0, len(cutVPset)):
+    for i in range(0, len(cutVPset)):
         if cutsAreEqual(cutVPset[i], previousExistingCut):
             cutVPset.insert(i+1, cutToAdd) # Use i+1 to put cutToAdd afterward
             return
-    print '[addSingleCut] Warning: previousExistingCut not found in VPSet with cutString:', previousExistingCut.cutString
+    print('[addSingleCut] Warning: previousExistingCut not found in VPSet with cutString:', previousExistingCut.cutString)
 
 def replaceSingleCut(cutVPset, replacementCut, cutToBeReplaced):
     # Add replacementCut in the same position as cutToBeReplaced
-    for i in xrange(len(cutVPset) - 1, -1, -1):
+    for i in range(len(cutVPset) - 1, -1, -1):
         if cutsAreEqual(cutVPset[i], cutToBeReplaced):
             del cutVPset[i]
             cutVPset.insert(i, replacementCut)
             return
-    print '[replaceSingleCut] Warning: cutToBeReplaced not found in VPSet with cutString:', cutToBeReplaced.cutString
+    print('[replaceSingleCut] Warning: cutToBeReplaced not found in VPSet with cutString:', cutToBeReplaced.cutString)
 
 def removeCuts(cutVPset, cutsToRemove):
     for cut in cutsToRemove:
-        for i in xrange(len(cutVPset) - 1, -1, -1):  # iterate backwards to avoid error
+        for i in range(len(cutVPset) - 1, -1, -1):  # iterate backwards to avoid error
             if cutsAreEqual(cutVPset[i], cut):
                 del cutVPset[i]
 
 def printCuts(cutVPset):  # For debugging
-    for i in xrange(len(cutVPset)):
-        print cutVPset[i].cutString
+    for i in range(len(cutVPset)):
+        print(cutVPset[i].cutString)
 
 
 ##################################################

--- a/Configuration/python/fileUtilities.py
+++ b/Configuration/python/fileUtilities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Utilities for management of ROOT files.
 
@@ -25,5 +25,3 @@ def filterKey(self, key, currentpath, keylist):
 
 TFile.filterKey = filterKey
 TFile.GetAllKeys = GetAllKeys
-
-

--- a/Configuration/python/formattingUtilities.py
+++ b/Configuration/python/formattingUtilities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import math
 import decimal
@@ -46,8 +46,8 @@ def modifyByPrecision(input, origin, originRounded):
                         output = decimal.Decimal(str(input)).quantize(decimal.Decimal("0"))
                 else:
                         for n in range(1,100):
-                                    if int(int(originRounded*math.pow(10,n))/(originRounded*math.pow(10,n))) is 1 and int(originRounded*math.pow(10,n)) is not 0:
-                                                if int(originRounded*math.pow(10,n)) is 0:
+                                    if int(int(originRounded*math.pow(10,n))/(originRounded*math.pow(10,n))) == 1 and int(originRounded*math.pow(10,n)) != 0:
+                                                if int(originRounded*math.pow(10,n)) == 0:
                                                         output = decimal.Decimal(originRounded).quantize(decimal.Decimal(str(base/10)))
                                                 else:
                                                         output = originRounded
@@ -57,7 +57,7 @@ def modifyByPrecision(input, origin, originRounded):
                                 output = round(input,1)
                 else:
                         for n in range(1,100):
-                                if int(originRounded*math.pow(10,n)) is not 0:
+                                if int(originRounded*math.pow(10,n)) != 0:
                                                 base = math.pow(10,-n-1)
                                                 output = decimal.Decimal(str(input)).quantize(decimal.Decimal(str(base)))
                                                 break
@@ -67,7 +67,7 @@ def modifyByPrecision(input, origin, originRounded):
                 else:
                         for n in range(0,100):
                                 precision = 0
-                                if int(originRounded/math.pow(10,n)) is 0:
+                                if int(originRounded/math.pow(10,n)) == 0:
                                         precision = math.pow(10,n-2)
                                         output = int((int(input/precision))*precision)
                                         break
@@ -101,7 +101,7 @@ def plainTextString(inputString):
 def formatNumber(inputNumber):
     inputList = list(inputNumber)
     decimalIndex = inputNumber.find(".")
-    if decimalIndex is not -1:# found decimal point
+    if decimalIndex != -1:# found decimal point
         numDigitsAboveOne = decimalIndex
         numDigitsBelowOne = len(inputList) - numDigitsAboveOne - 1
     else: # didn't find a decimal point
@@ -112,18 +112,18 @@ def formatNumber(inputNumber):
 
     for index in range(numDigitsAboveOne): #print digits > 1
         outputString = outputString + inputList[index]
-        if (numDigitsAboveOne - index - 1) % 3 is 0 and (numDigitsAboveOne - index - 1) is not 0:
+        if (numDigitsAboveOne - index - 1) % 3 == 0 and (numDigitsAboveOne - index - 1) != 0:
             outputString = outputString + "\;"
-    if decimalIndex is not -1: #print "." if needed
+    if decimalIndex != -1: #print "." if needed
         outputString = outputString + "."
     for index in range(numDigitsBelowOne): #print digits < 1
         outputString = outputString + inputList[index+numDigitsAboveOne+1]
-        if (index+1) % 3 is 0 and (numDigitsBelowOne - index -1) is not 0:
+        if (index+1) % 3 == 0 and (numDigitsBelowOne - index -1) != 0:
             outputString = outputString + "\;"
 
     outputString = outputString + "$"
 
-    if outputString.find('$$') is not -1:
+    if outputString.find('$$') != -1:
         outputString = '$0$'
 
     return outputString

--- a/Configuration/python/histogramUtilities.py
+++ b/Configuration/python/histogramUtilities.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Utilities for histogram manipulation.
 
 from array import *
 import math
-from ROOT import TFile, TH1F, TMath, Double, TH1D, TGraphAsymmErrors
+from ROOT import TFile, TH1F, TMath, TH1D, TGraphAsymmErrors
 
 def getEfficiency(passes, passesError, total, totalError):
     passesHist = TH1D ("passes", "", 1, 0.0, 1.0)
@@ -16,8 +16,8 @@ def getEfficiency(passes, passesError, total, totalError):
     totalHist.SetBinError (1, totalError)
 
     g = TGraphAsymmErrors (passesHist, totalHist)
-    x = Double (0.0)
-    y = Double (0.0)
+    x = double (0.0)
+    y = double (0.0)
     g.GetPoint (0, x, y)
 
     return (y, g.GetErrorYlow (0), g.GetErrorYhigh (0))
@@ -27,7 +27,7 @@ def getYield(sample,condor_dir,channel):
     inputFile = TFile(dataset_file)
     cutFlowHistogram = inputFile.Get(channel + "/cutFlow")
     if not cutFlowHistogram:
-        print "ERROR: didn't find cutflow histogram ", channel+str("/cutFlow"), "in file ", dataset_file
+        print("ERROR: didn't find cutflow histogram ", channel+str("/cutFlow"), "in file ", dataset_file)
         return 0
     yield_     = float(cutFlowHistogram.GetBinContent(cutFlowHistogram.GetNbinsX()))
     statError_ = float(cutFlowHistogram.GetBinError  (cutFlowHistogram.GetNbinsX()))
@@ -41,7 +41,7 @@ def getYieldInBin(sample,condor_dir,channel,ibin):
     inputFile = TFile(dataset_file)
     cutFlowHistogram = inputFile.Get(channel + "/cutFlow")
     if not cutFlowHistogram:
-        print "WARNING: didn't find cutflow histogram ", channel, "CutFlow in file ", dataset_file
+        print("WARNING: didn't find cutflow histogram ", channel, "CutFlow in file ", dataset_file)
         return 0
     yield_     = float(cutFlowHistogram.GetBinContent(ibin))
     statError_ = float(cutFlowHistogram.GetBinError  (ibin))
@@ -54,7 +54,7 @@ def getFirstBinWithLabel(sample,condor_dir,channel,label):
     inputFile = TFile(dataset_file)
     cutFlowHistogram = inputFile.Get(channel + "/cutFlow")
     if not cutFlowHistogram:
-        print "WARNING: didn't find cutflow histogram ", channel, "CutFlow in file ", dataset_file
+        print("WARNING: didn't find cutflow histogram ", channel, "CutFlow in file ", dataset_file)
         return 0
     # Get the appropriate bin
     ibin = -1
@@ -63,7 +63,7 @@ def getFirstBinWithLabel(sample,condor_dir,channel,label):
             ibin = i
             break
     if ibin < 0:
-        print "ERROR:  could not find bin with label containing", label, "for channel", channel
+        print("ERROR:  could not find bin with label containing", label, "for channel", channel)
     inputFile.Close()
     return ibin
 
@@ -72,9 +72,9 @@ def getNumEvents(sample,condor_dir,channel):  # Use in place of getYield if the 
     inputFile = TFile(dataset_file)
     numEvtHistogram = inputFile.Get("OSUAnalysis/"+channel+"/numEvents")
     if not numEvtHistogram:
-        print "WARNING: didn't find cutflow histogram ", channel, "CutFlow in file ", dataset_file
+        print("WARNING: didn't find cutflow histogram ", channel, "CutFlow in file ", dataset_file)
         return 0
-    statError_ = Double(0.0)
+    statError_ = double(0.0)
     yield_ = numEvtHistogram.IntegralAndError(1, numEvtHistogram.GetNbinsX(), statError_)
     inputFile.Close()
     return (yield_, statError_)
@@ -85,16 +85,16 @@ def getHistIntegral(sample,condor_dir,channel,hist,xlo,xhi):
     inputFile = TFile(dataset_file)
     histogram = inputFile.Get(channel+"/"+hist)
     if not histogram:
-        print "WARNING: didn't find histogram ", channel + "/" + hist, " in file ", dataset_file
+        print("WARNING: didn't find histogram ", channel + "/" + hist, " in file ", dataset_file)
         return 0
     Nxbins = histogram.GetNbinsX()
     xmax   = histogram.GetBinContent(Nxbins)
     xloBin = histogram.GetXaxis().FindBin(float(xlo))
     xhiBin = histogram.GetXaxis().FindBin(float(xhi))
     if xhi > xmax:
-        # print "xhi is outside the range of the histogram, will include all the overflow instead"
+        # print("xhi is outside the range of the histogram, will include all the overflow instead")
         xhiBin = histogram.GetXaxis().FindBin(float(xhi))
-    intError = Double (0.0)
+    intError = double (0.0)
     integral = histogram.IntegralAndError(xloBin, xhiBin, intError)
 
     inputFile.Close()
@@ -128,9 +128,9 @@ def ratioHistogram( dataHist, mcHist, dontRebinRatio=False, addOne=False, relErr
         return regroup(groups[:iLo] + [groups[iLo]+groups[iHi]] + groups[iHi+1:])
 
     #don't rebin the histograms of the number of a given object (except for the pileup ones)
-    if ((dataHist.GetName().find("num") is not -1 and dataHist.GetName().find("Primaryvertexs") is -1) or
-        dataHist.GetName().find("CutFlow")  is not -1 or
-        dataHist.GetName().find("GenMatch") is not -1 or
+    if ((dataHist.GetName().find("num") != -1 and dataHist.GetName().find("Primaryvertexs") == -1) or
+        dataHist.GetName().find("CutFlow")  != -1 or
+        dataHist.GetName().find("GenMatch") != -1 or
         dontRebinRatio):
         ratio = dataHist.Clone()
         ratio.Add(mcHist,-1)
@@ -161,7 +161,7 @@ def getUpperLimit(sample,condor_dir,channel):
     inputFile = TFile(dataset_file)
     cutFlowHistogram = inputFile.Get("OSUAnalysis/"+channel+"CutFlowUpperLimit")
     if not cutFlowHistogram:
-        print "WARNING: didn't find cutflow histogram ", channel, "CutFlow in file ", dataset_file
+        print("WARNING: didn't find cutflow histogram ", channel, "CutFlow in file ", dataset_file)
         return 0
     limit = float(cutFlowHistogram.GetBinContent(cutFlowHistogram.GetNbinsX()))
     inputFile.Close()
@@ -172,7 +172,7 @@ def getTruthYield(sample,condor_dir,channel,truthParticle):
     inputFile = TFile(dataset_file)
     matchHistogram = inputFile.Get("OSUAnalysis/"+channel+"/trackGenMatchId")
     if not matchHistogram:
-        print "WARNING: didn't find match histogram ", channel, "/trackGenMatchId in file ", dataset_file
+        print("WARNING: didn't find match histogram ", channel, "/trackGenMatchId in file ", dataset_file)
         return 0
 
     idx = -1
@@ -180,7 +180,7 @@ def getTruthYield(sample,condor_dir,channel,truthParticle):
         if truthParticle == matchHistogram.GetXaxis().GetBinLabel(i):
             idx = i
     if idx < 0:
-        print "Error:  could not find bin with label " + truthParticle
+        print("Error:  could not find bin with label " + truthParticle)
         yield_ = -1
         statError_ = -1
     else:
@@ -204,11 +204,9 @@ def getHist(sample,condor_dir,channel,hist):
     inputFile = TFile(dataset_file)
     h0 = inputFile.Get(channel + "/" + hist)
     if not h0:
-        print "ERROR [getHist]: didn't find histogram ", channel+str("/")+hist, "in file", dataset_file
+        print("ERROR [getHist]: didn't find histogram ", channel+str("/")+hist, "in file", dataset_file)
         return 0
     h = h0.Clone()
     h.SetDirectory(0)
     inputFile.Close()
     return h
-
-

--- a/Configuration/python/mergeUtilities.py
+++ b/Configuration/python/mergeUtilities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import py_compile
 import imp
 import sys
@@ -29,28 +29,28 @@ def MakeSubmissionScriptForMerging(Directory, currentCondorSubArgumentsSet, spli
     SubmitFile = open(Directory + '/condorMerging.sub','w')
     wroteCPUs = False
     for argument in sorted(currentCondorSubArgumentsSet):
-        if currentCondorSubArgumentsSet[argument].has_key('Executable') and currentCondorSubArgumentsSet[argument]['Executable'] == "":
+        if 'Executable' in currentCondorSubArgumentsSet[argument] and currentCondorSubArgumentsSet[argument]['Executable'] == "":
             SubmitFile.write('Executable = merge.py\n')
-        elif currentCondorSubArgumentsSet[argument].has_key('Arguments') and currentCondorSubArgumentsSet[argument]['Arguments'] == "":
+        elif 'Arguments' in currentCondorSubArgumentsSet[argument] and currentCondorSubArgumentsSet[argument]['Arguments'] == "":
             SubmitFile.write('Arguments = $(Process) ' + '\n\n')
-        elif currentCondorSubArgumentsSet[argument].has_key('Transfer_Input_files') and currentCondorSubArgumentsSet[argument]['Transfer_Input_files'] == "":
+        elif 'Transfer_Input_files' in currentCondorSubArgumentsSet[argument] and currentCondorSubArgumentsSet[argument]['Transfer_Input_files'] == "":
              datasetInfoString = ''
              for dataset in split_datasets:
                  oneDataset = './' + dataset + '/datasetInfo_' + dataset +'_cfg.py'
                  if os.path.exists(os.path.join(Directory, oneDataset)):
                      datasetInfoString = datasetInfoString + oneDataset + ","
                  else:
-                     print "ERROR: ", os.path.join(Directory, oneDataset), "does not exist.  Will proceed to merge other datasets."
+                     print("ERROR: ", os.path.join(Directory, oneDataset), "does not exist.  Will proceed to merge other datasets.")
              SubmitFile.write('Transfer_Input_files = merge.py,' + datasetInfoString + '\n')
-        elif len (currentCondorSubArgumentsSet[argument].keys ()) > 0 and currentCondorSubArgumentsSet[argument].keys ()[0].lower () == "request_cpus":
+        elif len (list(currentCondorSubArgumentsSet[argument].keys ())) > 0 and list(currentCondorSubArgumentsSet[argument].keys ())[0].lower () == "request_cpus":
             SubmitFile.write ('request_cpus = ' + str (NTHREADS_FOR_BATCH_MERGING) + '\n') # explicitly request 8 CPU cores
             wroteCPUs = True
-        elif currentCondorSubArgumentsSet[argument].has_key('Queue'):
+        elif 'Queue' in currentCondorSubArgumentsSet[argument]:
             if not wroteCPUs:
                 SubmitFile.write ('request_cpus = ' + str (NTHREADS_FOR_BATCH_MERGING) + '\n') # explicitly request 8 CPU cores
             SubmitFile.write('Queue ' + str(len(split_datasets)) +'\n')
         else:
-            SubmitFile.write(currentCondorSubArgumentsSet[argument].keys()[0] + ' = ' + currentCondorSubArgumentsSet[argument].values()[0] + '\n')
+            SubmitFile.write(list(currentCondorSubArgumentsSet[argument].keys())[0] + ' = ' + list(currentCondorSubArgumentsSet[argument].values())[0] + '\n')
     SubmitFile.close()
 
 ###############################################################################
@@ -70,7 +70,7 @@ def MakeMergingConfigForCondor(Directory, OutputDirectory, split_datasets, IntLu
     MergeScript.write('mergeOneDataset(dataset, IntLumi, os.getcwd(), "", ' + str (optional_dict_ntupleEff) + ', ' + str (NTHREADS_FOR_BATCH_MERGING) + ')\n') # use 8 CPU cores by default
     MergeScript.write("print 'Finished merging dataset ' + dataset\n")
     MergeScript.close()
-    os.chmod (Directory + '/merge.py', 0755)
+    os.chmod (Directory + '/merge.py', 755)
 
 ###############################################################################
 #                       Get the exit code of condor jobs.                     #
@@ -105,7 +105,7 @@ def GetNumberOfEvents(FilesSet):
     for histFile in FilesSet:
         ScoutFile = TFile(histFile)
         if ScoutFile.IsZombie():
-            print histFile + " is a bad root file."
+            print(histFile + " is a bad root file.")
             FilesSet.remove(histFile)
             continue
         randomChannelDirectory = ""
@@ -115,16 +115,16 @@ def GetNumberOfEvents(FilesSet):
                 continue
             randomChannelDirectory = key.GetName()
             channelName = randomChannelDirectory[0:len(randomChannelDirectory)-14]
-            if not NumberOfEvents['SkimNumber'].has_key(channelName):
+            if not channelName in NumberOfEvents['SkimNumber']:
                 NumberOfEvents['SkimNumber'][channelName] = 0
             OriginalCounterObj = ScoutFile.Get(randomChannelDirectory + "/eventCounter")
             SkimCounterObj = ScoutFile.Get(randomChannelDirectory + "/cutFlow")
             TotalNumberTmp = 0
             if not OriginalCounterObj:
-                print "Could not find eventCounter histogram in " + str(histFile) + " !"
+                print("Could not find eventCounter histogram in " + str(histFile) + " !")
                 continue
             elif not SkimCounterObj:
-                print "Could not find cutFlow histogram in " + str(histFile) + " !"
+                print("Could not find cutFlow histogram in " + str(histFile) + " !")
             else:
                 OriginalCounter = OriginalCounterObj.Clone()
                 OriginalCounter.SetDirectory(0)
@@ -148,7 +148,7 @@ def MakeFilesForSkimDirectoryEOS(Member, Directory, DirectoryOut, TotalNumber, S
     try:
         subprocess.check_output(['xrdcp', '-f', outfile, xrootdDestination])
     except subprocess.CalledProcessError as e:
-        print 'Failed to copy OriginalNumberOfEvents.txt:', e
+        print('Failed to copy OriginalNumberOfEvents.txt:', e)
     outfile = os.path.join(tmpDir, 'SkimNumberOfEvents.txt')
     fout = open(outfile, 'w')
     fout.write(str(SkimNumber[Member]) + '\n')
@@ -156,7 +156,7 @@ def MakeFilesForSkimDirectoryEOS(Member, Directory, DirectoryOut, TotalNumber, S
     try:
         subprocess.check_output(['xrdcp', '-f', outfile, xrootdDestination])
     except subprocess.CalledProcessError as e:
-        print 'Failed to copy SkimNumber.txt:', e
+        print('Failed to copy SkimNumber.txt:', e)
     shutil.rmtree(tmpDir)
 
     listOfSkimFiles = subprocess.check_output(['xrdfs', 'root://cmseos.fnal.gov', 'ls', os.path.realpath(DirectoryOut + '/' + Member)])
@@ -213,7 +213,7 @@ def MakeFilesForSkimDirectory(Directory, DirectoryOut, TotalNumber, SkimNumber, 
             try:
                 subprocess.check_output(['xrdfs', 'root://cmseos.fnal.gov', 'rm', skimFile[len('root://cmseos.fnal.gov/'):]])
             except subprocess.CalledProcessError as e:
-                print 'Failed to remove file', skimFile, ':', e
+                print('Failed to remove file', skimFile, ':', e)
         else:
             os.unlink(skimFile)
 
@@ -221,7 +221,7 @@ def MakeFilesForSkimDirectory(Directory, DirectoryOut, TotalNumber, SkimNumber, 
 #           Produce a pickle file containing the skim input tags.             #
 ###############################################################################
 def GetSkimInputTags(File, xrootdDestination = ""):
-    print "Getting skim input tags..."
+    print("Getting skim input tags...")
     if xrootdDestination != "":
         eventContent = subprocess.check_output (["edmDumpEventContent", "--all", "root://cmseos.fnal.gov/" + File[len('/eos/uscms'):]])
     else:
@@ -264,7 +264,7 @@ def GetSkimInputTags(File, xrootdDestination = ""):
         try:
             subprocess.check_output(['xrdcp', '-f', outfile, xrootdDestination])
         except subprocess.CalledProcessError as e:
-            print 'Failed to copy SkimInputTags.pkl:', e
+            print('Failed to copy SkimInputTags.pkl:', e)
         shutil.rmtree(tmpDir)
     else:
         if os.path.exists("SkimInputTags.pkl"):
@@ -305,7 +305,7 @@ def MakeResubmissionScript(badIndices, originalSubmissionScript):
     for index in badIndices:
         resubScript.write ("rm -f condor_" + str(index) + ".*\n")
     resubScript.close ()
-    os.chmod ("condor_resubmit.sh", 0755)
+    os.chmod ("condor_resubmit.sh", 755)
 ###############################################################################
 #                       Determine whether a skim file is valid.               #
 ###############################################################################
@@ -340,7 +340,7 @@ def MergeIntermediateFile (files, outputDir, dataset, weight, threadIndex, verbo
 
     semaphore.acquire ()
     if verbose:
-        print "Executing: ", cmd
+        print("Executing: ", cmd)
     try:
         localThreadLog += subprocess.check_output (cmd.split (), stderr = subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
@@ -367,7 +367,7 @@ def mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir="", optional_dict_ntu
     os.chdir(CondorDir)
     directory = CondorDir + '/' + dataSet
     if not os.path.exists(directory):
-        print directory + " does not exist, will skip it and continue!"
+        print(directory + " does not exist, will skip it and continue!")
         return
     if not OutputDir:
         OutputDir = CondorDir
@@ -379,18 +379,18 @@ def mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir="", optional_dict_ntu
     log = "....................Merging dataset " + dataSet + " ....................\n"
     os.chdir(directory)
     if verbose:
-        print "Moved to directory: ", directory
+        print("Moved to directory: ", directory)
     ReturnValues = []
     StdErrErrors = []
     if os.path.islink(directory + '/hist.root'):
         os.unlink (directory + '/hist.root')
     # check to see if any jobs ran
     if not len(glob.glob('condor_*.log')):
-        print "no jobs were run for dataset '" + dataSet + "', will skip it and continue!"
+        print("no jobs were run for dataset '" + dataSet + "', will skip it and continue!")
         return
     LogFiles = os.popen('ls condor_*.log').readlines()
     if verbose:
-        print "parsing log files to find good jobs"
+        print("parsing log files to find good jobs")
 
     for i in range(0,len(LogFiles)):
         ReturnValues.append('condor_' + str(i) + '.log' + str(os.popen('grep -E "return value|condor_rm|Abnormal termination" condor_' + str(i)  + '.log | tail -1').readline().rstrip('\n')))
@@ -407,18 +407,18 @@ def mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir="", optional_dict_ntu
         if 'was not found or could not be opened, and will be skipped.' in open(errFile).read():
             BadIndices.append(index)
             if verbose:
-                print "  job" + ' ' * (4-len(str(index))) + index + " had bad/skipped input file"
+                print("  job" + ' ' * (4-len(str(index))) + index + " had bad/skipped input file")
 
     # check for any corrupted skim output files
     skimDirs = [member for member in  os.listdir(os.getcwd()) if not os.path.isfile(member)]
     FilesToRemove = []
     for channel in skimDirs:
         if lpcCAF and os.path.realpath(channel).startswith('/eos/uscms'):
-            print 'Testing skim files in: root://cmseos.fnal.gov/' + os.path.realpath(channel)
+            print('Testing skim files in: root://cmseos.fnal.gov/' + os.path.realpath(channel))
             listOfSkimFiles = subprocess.check_output(['xrdfs', 'root://cmseos.fnal.gov', 'ls', os.path.realpath(channel)])
             listOfSkimFiles = ['root://cmseos.fnal.gov/' + x for x in listOfSkimFiles.split('\n') if x.endswith('.root')]
         else:
-            print 'Testing skim files in:', os.path.realpath(channel)
+            print('Testing skim files in:', os.path.realpath(channel))
             listOfSkimFiles = glob.glob(channel + '/*.root')
         for skimFile in listOfSkimFiles:
             # don't check for good skims of jobs we already know are bad
@@ -429,7 +429,7 @@ def mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir="", optional_dict_ntu
             if not Valid:
                 BadIndices.append(index)
                 if verbose:
-                    print "  job" + ' ' * (4-len(str(index))) + index + " had bad skim output file"
+                    print("  job" + ' ' * (4-len(str(index))) + index + " had bad skim output file")
             if InvalidOrEmpty:
                 FilesToRemove.append (skimFile)
 
@@ -461,7 +461,7 @@ def mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir="", optional_dict_ntu
     for i in GoodIndices:
         GoodRootFiles.append(GetGoodRootFiles(i))
     if not len(GoodRootFiles):
-        print "For dataset", dataSet, ": Unfortunately there are no good root files to merge!\n"
+        print("For dataset", dataSet, ": Unfortunately there are no good root files to merge!\n")
         return
     exec('import datasetInfo_' + dataSet + '_cfg as datasetInfo')
 
@@ -469,7 +469,7 @@ def mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir="", optional_dict_ntu
     TotalNumber = NumberOfEvents['TotalNumber']
     SkimNumber = NumberOfEvents['SkimNumber']
     if verbose:
-        print "TotalNumber =", TotalNumber, ", SkimNumber =", SkimNumber
+        print("TotalNumber =", TotalNumber, ", SkimNumber =", SkimNumber)
     if not TotalNumber:
         MakeFilesForSkimDirectory(directory, directoryOut, TotalNumber, SkimNumber, BadIndices, FilesToRemove, lpcCAF)
         return
@@ -503,7 +503,7 @@ def mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir="", optional_dict_ntu
         threadLog = ""
         outputFiles = []
         semaphore = Semaphore (nThreadsActive)
-    
+
         # start threads, each of which merges some fraction of the input files
         filesPerThread = 100 # to be adjusted if need be
         nThreadTarget = nThreadsActive
@@ -521,21 +521,21 @@ def mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir="", optional_dict_ntu
         for thread in threads:
             thread.join ()
         log += threadLog
-    
+
         # merge the intermediate files produced by the threads above
         cmd = 'mergeTFileServiceHistograms -i ' + " ".join (outputFiles) + ' -o ' + OutputDir + "/" + dataSet + '.root'
         if verbose:
-            print "Executing: ", cmd
+            print("Executing: ", cmd)
         try:
             log += subprocess.check_output (cmd.split (), stderr = subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             log += e.output
-    
+
         # remove the intermediate files produced by the threads above
         for outputFile in outputFiles:
             os.unlink (outputFile)
     else:
-        print '\nNot merging dataset histograms due to --skipMerging flag...\n'
+        print('\nNot merging dataset histograms due to --skipMerging flag...\n')
 
     log += "\nFinished merging dataset " + dataSet + ":\n"
     log += "    "+ str(len(GoodRootFiles)) + " good files are used for merging out of " + str(len(LogFiles)) + " submitted jobs.\n"

--- a/Configuration/python/pdgIdBins.py
+++ b/Configuration/python/pdgIdBins.py
@@ -447,7 +447,7 @@ def getPdgBins (categories):
     for category in categories:
         category = str (category)
         if not hasattr (pdgId, category):
-            print "WARNING: unknown category \"" + category + "\""
+            print("WARNING: unknown category \"" + category + "\"")
             continue
         ids = ids + getattr (pdgId, category)
     ids = sorted (list (set (ids)))

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import subprocess
 import re
@@ -61,7 +62,7 @@ def set_condor_submit_dir(arguments):
         now = datetime.datetime.now()
         date_hash = now.strftime("%Y_%m_%d_%H:%M:%S")
         condor_dir = "condor/condor_%s" % date_hash
-    #print "Condor submit directory set to ",condor_dir
+    #print("Condor submit directory set to ",condor_dir)
     return condor_dir
 
 def set_condor_output_dir(arguments):
@@ -70,13 +71,13 @@ def set_condor_output_dir(arguments):
     else: #get most recent condor submission directory
         dir_list = []
         for directory in os.listdir("./condor/"):
-            if directory.find("condor_") is not -1:
+            if directory.find("condor_") != -1:
                 dir_list.append(directory)
-        if len(dir_list) is 0:
+        if len(dir_list) == 0:
             sys.exit("Cannot find last condor working directory")
         dir_list.sort(reverse=True)
         condor_dir = "condor/%s" % dir_list[0]
-    #print "Condor output directory set to ",condor_dir
+    #print("Condor output directory set to ",condor_dir)
     return condor_dir
 
 def set_commandline_arguments(parser):
@@ -202,9 +203,9 @@ def set_skim_tags (inputFileName, collections):
             inputFileName = inputFileName[5:]
         inputTagPickleName = os.path.dirname (os.path.realpath (inputFileName)) + '/SkimInputTags.pkl'
     if not os.path.isfile (inputTagPickleName):
-        print "ERROR:  The input file appears to be a skim file but no SkimInputTags.pkl file found in the skim directory."
-        print "Input file is", inputFileName
-        print "Be sure that you have run mergeOut.py."
+        print("ERROR:  The input file appears to be a skim file but no SkimInputTags.pkl file found in the skim directory.")
+        print("Input file is", inputFileName)
+        print("Be sure that you have run mergeOut.py.")
         if inputFileName.startswith ('root:'):
             shutil.rmtree (tmpDir)
         sys.exit(1)
@@ -229,8 +230,8 @@ def add_channels (process,
                   ignoreSkimmedCollections = False,
                   forceNonEmptySkim = False):
     if skim is not None:
-        print "# The \"skim\" parameter of add_channels is obsolete and will soon be deprecated."
-        print "# Please remove from your config files."
+        print("# The \"skim\" parameter of add_channels is obsolete and will soon be deprecated.")
+        print("# Please remove from your config files.")
 
     ############################################################################
     # If there are only two arguments, then channels is actually an
@@ -313,9 +314,9 @@ def add_channels (process,
         if osusub.batchMode:
             fileName = osusub.secondaryRunList[0]
         if fileName is None:
-            print "ERROR:  The input file appears to be an empty skim file but no secondary files were found."
-            print "Input file is", primaryFileName
-            print "This should not be."
+            print("ERROR:  The input file appears to be an empty skim file but no secondary files were found.")
+            print("Input file is", primaryFileName)
+            print("This should not be.")
             sys.exit(1)
         rootFile = fileName.split("/")[-1]  # e.g., skim_0.root
     elif rootFile.startswith ("skim_"):
@@ -326,7 +327,7 @@ def add_channels (process,
     if makeEmptySkim:
         # If we deliberately ignore this by user flag, just print a message
         if ignoreSkimmedCollections:
-            print "INFO: user has set ignoreSkimmedCollections, meaning that the original data collections will be used instead of skimmed framework collections."
+            print("INFO: user has set ignoreSkimmedCollections, meaning that the original data collections will be used instead of skimmed framework collections.")
         else:
             set_skim_tags (fileName, collections)
 
@@ -418,7 +419,7 @@ def add_channels (process,
             print ("WARNING [add_channels]: The '" +
                    channelName +
                    "' channel has been added more than once")
-            print "  Skipping this channel!"
+            print("  Skipping this channel!")
             continue
 
         ########################################################################
@@ -549,7 +550,7 @@ def add_channels (process,
         # Add keep statements for all collections except uservariables and
         # eventvariables.
         ########################################################################
-        for collection in [a for a in dir (collections) if not a.startswith('_') and not callable (getattr (collections, a)) and a is not "uservariables" and a is not "eventvariables"]:
+        for collection in [a for a in dir (collections) if not a.startswith('_') and not callable (getattr (collections, a)) and a != "uservariables" and a != "eventvariables"]:
             collectionTag = getattr (collections, collection)
             outputCommand = "keep *_"
             outputCommand += collectionTag.getModuleLabel ()
@@ -584,7 +585,7 @@ def add_channels (process,
             if hasattr (collections, collection):
                 usedCollections.insert (0, collection)
         for collection in usedCollections:
-            if collection is "uservariables" or collection is "eventvariables":
+            if collection == "uservariables" or collection == "eventvariables":
                 newInputTags = cms.VInputTag()
                 if hasattr (collections, collection):
                     inputTags = getattr (collections, collection)
@@ -692,7 +693,7 @@ def add_channels (process,
         for collection in cutCollections:
             # Temporary fix for user-defined variables
             # For the moment, they won't be filtered
-            if collection is "uservariables" or collection is "eventvariables":
+            if collection == "uservariables" or collection == "eventvariables":
                 continue
             filterName = collection[0].upper () + collection[1:-1] + "ObjectSelector"
             objectSelector = cms.EDFilter (filterName,
@@ -908,8 +909,8 @@ def set_input(process, input_string):
     # print a warning if the input source has already been set
     sourceType =  type(process.source).__name__
     if sourceType != 'NoneType':
-        print "WARNING [set_input]: There are multiple calls to set_input!"
-        print "  The previous input source will be overwritten!"
+        print("WARNING [set_input]: There are multiple calls to set_input!")
+        print("  The previous input source will be overwritten!")
 
     # initialize the process source
     datasetInfo = cms.PSet ()
@@ -941,13 +942,13 @@ def set_input(process, input_string):
     # print error and exit if the input is invalid
     if not isValidFileOrDir and not isValidDataset and not isAAAFile:
         if input_string in composite_dataset_definitions.keys():
-            print "ERROR [set_input]: '" + input_string + "' is a composite dataset"
-            print "  Composite datasets should not processed interactively",
-            print "because their components won't have the proper relative weights."
-            print "  No files have been added to process.source.fileNames"
+            print("ERROR [set_input]: '" + input_string + "' is a composite dataset")
+            print("  Composite datasets should not processed interactively")
+            print("because their components won't have the proper relative weights.")
+            print("  No files have been added to process.source.fileNames")
         else:
-            print "ERROR [set_input]: '" + input_string + "' is not a valid root file, directory, or dataset name."
-            print "  No files have been added to process.source.fileNames"
+            print("ERROR [set_input]: '" + input_string + "' is not a valid root file, directory, or dataset name.")
+            print("  No files have been added to process.source.fileNames")
         return
 
 

--- a/Configuration/scripts/addPUHists.py
+++ b/Configuration/scripts/addPUHists.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # addPUHists.py
 # Takes the histograms from pu.root for the dataset(s) and condor directory specified in the local options file,
@@ -32,7 +32,7 @@ parser.add_option("-i", "--inputFile", dest="inputFile", default = "", help="Spe
 parser.add_option("--delete", dest="delete", action="store_true", default=False, help="Delete given datasets in the pu.root")
 (arguments, args) = parser.parse_args()
 
-from ROOT import TFile, gROOT, gStyle, gDirectory, TStyle, THStack, TH1F, TCanvas, TString, TLegend, TArrow, THStack, TIter, TKey, TGraphErrors, Double
+from ROOT import TFile, gROOT, gStyle, gDirectory, TStyle, THStack, TH1F, TCanvas, TString, TLegend, TArrow, THStack, TIter, TKey, TGraphErrors
 
 def copyOneFile(dataset):
     # If the input and output files are defined outside the loop, histograms after the first instance are not found.
@@ -40,30 +40,30 @@ def copyOneFile(dataset):
 
     fin  = TFile(condor_dir+"/pu.root", "READ");
     fout = TFile(os.environ['CMSSW_BASE']+"/src/OSUT3Analysis/Configuration/data/pu.root", "UPDATE");
-    print "Copying histogram " + dataset + " from " + fin.GetName() + " to " + fout.GetName()
+    print("Copying histogram " + dataset + " from " + fin.GetName() + " to " + fout.GetName())
 
     fin.cd()
     h = fin.Get(dataset)
     if not h:
-        print "  Could not find hist named " + dataset + " in " + fin.GetName()
+        print("  Could not find hist named " + dataset + " in " + fin.GetName())
         return
 
     fout.cd()
     if dataset != h.GetName():
-        # print "  Resetting name from " + h.GetName() + " to " + dataset
+        # print("  Resetting name from " + h.GetName() + " to " + dataset)
         h.SetName(dataset)
 
     # Check if the histogram already exists in the destination file
     h2 = fout.Get(dataset)
     if h2:
-        print "  The histogram " + h2.GetName() + " already exists in the destination file."
+        print("  The histogram " + h2.GetName() + " already exists in the destination file.")
         overwrite = raw_input("  Do you want to overwrite it? (y/n): ")
         if not (overwrite is "y"):
-            print "  Will not overwrite existing histogram."
+            print("  Will not overwrite existing histogram.")
             return # Only overwrite if the user enters "y"
 
         # delete all previously existing instances of the histogram
-        print "  Will overwrite existing histogram."
+        print("  Will overwrite existing histogram.")
         fout.Delete(dataset+";*")
 
     h.Write()
@@ -91,7 +91,7 @@ def copyAndRenameOneFile(fout, datasets):
                 h2 = fout.Get(dataset)
         else:
                 Name = str(dataset)
-    print " Will use the existing " + str(h2.GetName()) + " pu distribution as the pu distribution for " + Name
+    print(" Will use the existing " + str(h2.GetName()) + " pu distribution as the pu distribution for " + Name)
     h2.SetName(Name)
     fout.cd()
     h2.Write()
@@ -101,19 +101,19 @@ def addDataDistribution(fout, inputFile):
     fin = TFile(inputFile)
     h1 = fin.Get('pileup')
     if not (h1):
-        print fin + " does not have pileup histograms"
+        print(fin + " does not have pileup histograms")
         return
     else:
         h2 = fout.Get(str(inputFile.split('.')[0]))
         if h2:
-            print "  The histogram " + h2.GetName() + " already exists in the destination file."
+            print("  The histogram " + h2.GetName() + " already exists in the destination file.")
             overwrite = raw_input("  Do you want to overwrite it? (y/n): ")
             if not (overwrite is "y"):
-                print "  Will not overwrite existing histogram."
+                print("  Will not overwrite existing histogram.")
                 return # Only overwrite if the user enters "y"
 
         # delete all previously existing instances of the histogram
-            print "  Will overwrite existing histogram."
+            print("  Will overwrite existing histogram.")
             fout.Delete(str(inputFile.split('.')[0])+";*")
         h1.SetName(str(inputFile.split('.')[0]))
         fout.cd()
@@ -156,9 +156,4 @@ elif arguments.inputFile:
     addDataDistribution(fout, str(arguments.inputFile))
 
 
-print "Finished addPUHists.py successfully."
-
-
-
-
-
+print("Finished addPUHists.py successfully.")

--- a/Configuration/scripts/addProfiles.py
+++ b/Configuration/scripts/addProfiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import re
@@ -44,14 +44,14 @@ for sample in datasets:
     fileName = condor_dir + "/" + sample + ".root"
 
     if not os.path.exists(fileName):
-        print "WARNING: didn't find ",fileName
+        print("WARNING: didn't find ",fileName)
         continue
     testFile = TFile(fileName)
     if testFile.IsZombie() or not testFile.GetNkeys():
         continue
     processed_datasets.append(sample)
 
-if len(processed_datasets) is 0:
+if len(processed_datasets) == 0:
     sys.exit("No datasets have been processed")
 
 
@@ -207,5 +207,3 @@ for dataset in processed_datasets:
                         ##############################################
 
     inputFile.Close()
-
-

--- a/Configuration/scripts/crossSectionExtractor.py
+++ b/Configuration/scripts/crossSectionExtractor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Script to extract the cross sections and filter efficiencies from MC samples.
 # Produces output file, configurationOptionsXsecs.py, with content that can be
 # appended to configurationOptions.py in the crossSections section.
@@ -56,7 +56,7 @@ for dataset in split_datasets:
     xrootdPath = 'root://cmsxrootd.fnal.gov/' + str(fileList[0])
     f = TFile.Open(xrootdPath)  # Check that file is valid
     if not f:
-        print "ERROR:  Could not open file: ", xrootdPath
+        print("ERROR:  Could not open file: ", xrootdPath)
         continue
     runs = Runs (xrootdPath)
     handle  = Handle ('GenRunInfoProduct')
@@ -64,11 +64,11 @@ for dataset in split_datasets:
     for run in runs:
         run.getByLabel (label, handle)
         runGenInfo = handle.product()
-        print "crossSection of      " + str(dataset) + " is: " + str(runGenInfo.crossSection())
-        print "internal xsec of     " + str(dataset) + " is: " + str(runGenInfo.internalXSec().value())
-        print "external LO xsec of  " + str(dataset) + " is: " + str(runGenInfo.externalXSecLO().value())
-        print "external NLO xsec of " + str(dataset) + " is: " + str(runGenInfo.externalXSecNLO().value())
-        print "filterEfficiency of  " + str(dataset) + " is: " + str(runGenInfo.filterEfficiency())
+        print("crossSection of      " + str(dataset) + " is: " + str(runGenInfo.crossSection()))
+        print("internal xsec of     " + str(dataset) + " is: " + str(runGenInfo.internalXSec().value()))
+        print("external LO xsec of  " + str(dataset) + " is: " + str(runGenInfo.externalXSecLO().value()))
+        print("external NLO xsec of " + str(dataset) + " is: " + str(runGenInfo.externalXSecNLO().value()))
+        print("filterEfficiency of  " + str(dataset) + " is: " + str(runGenInfo.filterEfficiency()))
     content += "    " + ("'"+dataset+"'").ljust(35)
     content += ": "   + (str(runGenInfo.crossSection()) + "*" + str(runGenInfo.filterEfficiency())).rjust(20)
     content += ", \n"
@@ -81,9 +81,6 @@ content += "############################################################# \n"
 fout.write(content)
 fout.close()
 
-print "\n\n\n"
-print "The content of configurationOptionsXsecs.py below may be added to configurationOptions.py in the crossSections section."
-print content
-
-
-
+print("\n\n\n")
+print("The content of configurationOptionsXsecs.py below may be added to configurationOptions.py in the crossSections section.")
+print(content)

--- a/Configuration/scripts/exportToOverleaf.py
+++ b/Configuration/scripts/exportToOverleaf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.spawn import find_executable
 import sys, os, re, subprocess, tempfile, shutil, tarfile
@@ -29,9 +29,9 @@ def executeCommand (command, stdout, stderr):
     if status:
         stdout.close ()
         stderr.close ()
-        print "\n\nERROR: A Git command failed. Please check the output in:"
-        print "  " + os.path.realpath (stdout.name)
-        print "  " + os.path.realpath (stderr.name)
+        print("\n\nERROR: A Git command failed. Please check the output in:")
+        print("  " + os.path.realpath (stdout.name))
+        print("  " + os.path.realpath (stderr.name))
         sys.exit (executeCommand.exitCode)
 
     executeCommand.exitCode += 1
@@ -44,16 +44,16 @@ def executeCommand (command, stdout, stderr):
 #-------------------------------------------------------------------------------
 tdrIsSetup = (find_executable ("tdr") is not None)
 if not tdrIsSetup:
-    print "Please setup TDR environment before executing."
+    print("Please setup TDR environment before executing.")
     sys.exit (1)
 
 if os.path.exists (".git"):
-    print "This is already a Git repository."
-    print "Has this project already been exported? Quitting."
+    print("This is already a Git repository.")
+    print("Has this project already been exported? Quitting.")
     sys.exit (2)
 
 if len (sys.argv) < 2:
-    print "Usage: " + os.path.basename (sys.argv[0]) + " OVERLEAF_GIT_LINK"
+    print("Usage: " + os.path.basename (sys.argv[0]) + " OVERLEAF_GIT_LINK")
     sys.exit (0)
 overleafRepo = sys.argv[1]
 ################################################################################
@@ -69,7 +69,7 @@ documentType = "UNKNOWN"
 if re.match (r".*\/(notes|papers)\/[^/]*\/trunk", cwd):
     cadiNumber = re.sub (r".*\/(notes|papers)\/([^/]*)\/trunk", r"\2", cwd)
 else:
-    print "Please change to the \"trunk\" directory of some note/paper before executing."
+    print("Please change to the \"trunk\" directory of some note/paper before executing.")
     sys.exit (3)
 
 if re.match (r".*\/notes\/[^/]*\/trunk", cwd):
@@ -81,18 +81,18 @@ else:
     documentType = "PAPER"
 
 if os.path.exists (cadiNumber + "_temp.tex"):
-    print "There already exists a \"" + cadiNumber + "_temp.tex\"."
-    print "Has this project already been exported? Quitting."
+    print("There already exists a \"" + cadiNumber + "_temp.tex\".")
+    print("Has this project already been exported? Quitting.")
     sys.exit (4)
 
-print "Document is of type " + documentType + " with number " + cadiNumber + ".\n"
+print("Document is of type " + documentType + " with number " + cadiNumber + ".\n")
 ################################################################################
 
 ################################################################################
 # Run the tdr command with the --export option and copy the resulting tarball
 # to a temporary directory and name it export.tgz.
 #-------------------------------------------------------------------------------
-print "Exporting document with requisite files...",
+print("Exporting document with requisite files...",)
 sys.stdout.flush ()
 tmpDir = re.sub (r"Removing all contents of temporary directory: (.*)", r"\1", subprocess.check_output (["tdr", "clean"])).strip ().rstrip ()
 if os.path.exists (tmpDir):
@@ -108,13 +108,13 @@ for line in tdrOutput.splitlines ():
     shutil.copy (exportName, exportDir + "/export.tgz")
     break
 os.chdir (exportDir)
-print " Done."
+print(" Done.")
 ################################################################################
 
 ################################################################################
 # Extract files from tarball and copy missing files back to original directory.
 #-------------------------------------------------------------------------------
-print "Extracting export tarball and copying back requisite files...",
+print("Extracting export tarball and copying back requisite files...",)
 sys.stdout.flush ()
 export = tarfile.open ("export.tgz")
 export.extractall ()
@@ -127,7 +127,7 @@ for f in os.listdir ("."):
         shutil.copy (f, cwd)
 shutil.rmtree (exportDir)
 os.chdir (cwd)
-print " Done."
+print(" Done.")
 ################################################################################
 
 ################################################################################
@@ -136,7 +136,7 @@ print " Done."
 # main file within the temp file with an \input{} command of the original main
 # document file.
 #-------------------------------------------------------------------------------
-print "Reformatting temp document file...",
+print("Reformatting temp document file...",)
 sys.stdout.flush ()
 mainFile = open (cadiNumber + ".tex", "r")
 tempFile = open (cadiNumber + "_temp.tex", "r")
@@ -164,7 +164,7 @@ for lineInTemp in temp:
 newTempFile.close ()
 os.remove (cadiNumber + "_temp.tex")
 shutil.move (newTempFileName, cadiNumber + "_temp.tex")
-print " Done."
+print(" Done.")
 ################################################################################
 
 ################################################################################
@@ -180,9 +180,9 @@ gitignore.close ()
 ################################################################################
 
 ################################################################################
-# Push the files to our blank 
+# Push the files to our blank
 #-------------------------------------------------------------------------------
-print "Pushing to Overleaf git repository...",
+print("Pushing to Overleaf git repository...",)
 sys.stdout.flush ()
 gitOutName = createTempFile (suffix = ".out", prefix = "git_")
 gitErrName = createTempFile (suffix = ".err", prefix = "git_")
@@ -201,7 +201,7 @@ gitOut.close ()
 gitErr.close ()
 os.remove (gitOutName)
 os.remove (gitErrName)
-print " Done."
+print(" Done.")
 ################################################################################
 
-print "\nProject successfully exported to Overleaf."
+print("\nProject successfully exported to Overleaf.")

--- a/Configuration/scripts/fitExpo.py
+++ b/Configuration/scripts/fitExpo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Fits an exponential function to a histogram in a specified file.
 # Reports the fitted parameters and prints the plot.
@@ -35,7 +35,7 @@ if not arguments.nobatch:
 inputFile = TFile(arguments.infile, "READ")
 hist = inputFile.Get(arguments.histName).Clone()
 if not hist:
-    print "Could not find TH1 " + arguments.histName + " in " + inputFile
+    print("Could not find TH1 " + arguments.histName + " in " + inputFile)
 
 if arguments.rebinFactor:
     hist.Rebin(int(arguments.rebinFactor))
@@ -48,22 +48,22 @@ if arguments.lo:
     lo = float(arguments.lo)
 if arguments.hi:
     hi = float(arguments.hi)
-print "lo = " + str(lo)
+print("lo = " + str(lo))
 myfunc = TF1("myfunc", "expo", lo, hi)
 can = TCanvas()
 hist.Fit("myfunc", "R")   # Fit in range
 hist.Draw("pe")
 can.SetLogy(1)
 
-print "Fit function:  exp([0]+[1]*x) in range (" + str(lo) + "," + str(hi) + ")"
-print "Fitted parameters:  [0] = " + str(myfunc.GetParameter(0))
-print "Fitted parameters:  [1] = " + str(myfunc.GetParameter(1))
+print("Fit function:  exp([0]+[1]*x) in range (" + str(lo) + "," + str(hi) + ")")
+print("Fitted parameters:  [0] = " + str(myfunc.GetParameter(0)))
+print("Fitted parameters:  [1] = " + str(myfunc.GetParameter(1)))
 
 ctau      =  -1.0 /  myfunc.GetParameter(1)
 ctauErrHi = (-1.0 / (myfunc.GetParameter(1) + myfunc.GetParError(1))) - ctau
 ctauErrLo = (-1.0 / (myfunc.GetParameter(1) - myfunc.GetParError(1))) - ctau
 
-print "Fitted parameters:  ctau = -1./[1] = " + str(ctau) + "; ctau error =  + " + str(ctauErrHi) + " - " + str(ctauErrLo)
+print("Fitted parameters:  ctau = -1./[1] = " + str(ctau) + "; ctau error =  + " + str(ctauErrHi) + " - " + str(ctauErrLo))
 
 histName = arguments.histName
 histName = histName[histName.rfind('/')+1:]  # strip off anything before the last '/'
@@ -88,13 +88,6 @@ can.Write()
 outputFile.Close()
 outfilePdf = outfileRoot.replace(".root", ".pdf")
 can.SaveAs(outfilePdf)
-print "Saved plot in " + outfilePdf + " and " + outfileRoot
+print("Saved plot in " + outfilePdf + " and " + outfileRoot)
 
-print "Finished doExpoFit.py"
-
-
-
-
-
-
-
+print("Finished doExpoFit.py")

--- a/Configuration/scripts/fitMCToData.py
+++ b/Configuration/scripts/fitMCToData.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import re
@@ -45,20 +45,20 @@ if arguments.localConfig:
 
 #### deal with conflicting arguments
 if arguments.normalizeToData and arguments.normalizeToUnitArea:
-    print "Conflicting normalizations requsted, will normalize to unit area"
+    print("Conflicting normalizations requsted, will normalize to unit area")
     arguments.normalizeToData = False
 if arguments.normalizeToData and arguments.noStack:
-    print "You have asked to scale non-stacked backgrounds to data.  This is a very strange request.  Will normalize to unit area instead"
+    print("You have asked to scale non-stacked backgrounds to data.  This is a very strange request.  Will normalize to unit area instead")
     arguments.normalizeToData = False
     arguments.normalizeToUnitArea = True
 if arguments.makeRatioPlots and arguments.makeDiffPlots:
-    print "You have requested both ratio and difference plots.  Will make just ratio plots instead"
+    print("You have requested both ratio and difference plots.  Will make just ratio plots instead")
     arguments.makeRatioPlots = False
 if arguments.makeRatioPlots and arguments.noStack:
-    print "You have asked to make a ratio plot and to not stack the backgrounds.  This is a very strange request.  Will skip making the ratio plot."
+    print("You have asked to make a ratio plot and to not stack the backgrounds.  This is a very strange request.  Will skip making the ratio plot.")
     arguments.makeRatioPlots = False
 if arguments.makeDiffPlots and arguments.noStack:
-    print "You have asked to make a difference plot and to not stack the backgrounds.  This is a very strange request.  Will skip making the difference plot."
+    print("You have asked to make a difference plot and to not stack the backgrounds.  This is a very strange request.  Will skip making the difference plot.")
     arguments.makeDiffPlots = False
 
 
@@ -136,11 +136,11 @@ header_y_top     = 0.9947552
 def ratioHistogram( dataHist, mcHist, relErrMax=0.10):
 
     if not dataHist:
-        print "Error:  trying to run ratioHistogram but dataHist is invalid"
+        print("Error:  trying to run ratioHistogram but dataHist is invalid")
         return
 
     if not mcHist:
-        print "Error:  trying to run ratioHistogram but mcHist is invalid"
+        print("Error:  trying to run ratioHistogram but mcHist is invalid")
         return
 
     def groupR(group):
@@ -163,9 +163,9 @@ def ratioHistogram( dataHist, mcHist, relErrMax=0.10):
         return regroup(groups[:iLo] + [groups[iLo]+groups[iHi]] + groups[iHi+1:])
 
     #don't rebin the histograms of the number of a given object (except for the pileup ones)
-    if ((dataHist.GetName().find("num") is not -1 and dataHist.GetName().find("Primaryvertexs") is -1) or
-        dataHist.GetName().find("CutFlow")  is not -1 or
-        dataHist.GetName().find("GenMatch") is not -1):
+    if ((dataHist.GetName().find("num") != -1 and dataHist.GetName().find("Primaryvertexs") == -1) or
+        dataHist.GetName().find("CutFlow")  != -1 or
+        dataHist.GetName().find("GenMatch") != -1):
         ratio = dataHist.Clone()
         ratio.Add(mcHist,-1)
         ratio.Divide(mcHist)
@@ -277,7 +277,7 @@ def MakeOneDHist(pathToDir,distribution):
     if arguments.rebinFactor:
         RebinFactor = int(arguments.rebinFactor)
         #don't rebin histograms which will have less than 5 bins or any gen-matching histograms
-        if Target.GetNbinsX() >= RebinFactor*5 and Target.GetName().find("GenMatch") is -1:
+        if Target.GetNbinsX() >= RebinFactor*5 and Target.GetName().find("GenMatch") == -1:
             Target.Rebin(RebinFactor)
 
 
@@ -297,7 +297,7 @@ def MakeOneDHist(pathToDir,distribution):
         inputFile = TFile(dataset_file)
         HistogramObj = inputFile.Get(pathToDir+"/"+distribution['channel']+"/"+distribution['name'])
         if not HistogramObj:
-            print "WARNING:  Could not find histogram " + pathToDir + "/" + distribution['channel'] + "/" + distribution['name'] + " in file " + dataset_file + ".  Will skip it and continue."
+            print("WARNING:  Could not find histogram " + pathToDir + "/" + distribution['channel'] + "/" + distribution['name'] + " in file " + dataset_file + ".  Will skip it and continue.")
             continue
         Histogram = HistogramObj.Clone()
         Histogram.SetDirectory(0)
@@ -305,14 +305,14 @@ def MakeOneDHist(pathToDir,distribution):
         if arguments.rebinFactor:
             RebinFactor = int(arguments.rebinFactor)
             #don't rebin histograms which will have less than 5 bins or any gen-matching histograms
-            if Histogram.GetNbinsX() >= RebinFactor*5 and Histogram.GetName().find("GenMatch") is -1:
+            if Histogram.GetNbinsX() >= RebinFactor*5 and Histogram.GetName().find("GenMatch") == -1:
                 Histogram.Rebin(RebinFactor)
 
         xAxisLabel = Histogram.GetXaxis().GetTitle()
         unitBeginIndex = xAxisLabel.find("[")
         unitEndIndex = xAxisLabel.find("]")
 
-        if unitBeginIndex is not -1 and unitEndIndex is not -1: #x axis has a unit
+        if unitBeginIndex != -1 and unitEndIndex != -1: #x axis has a unit
             yAxisLabel = "Entries / " + str(Histogram.GetXaxis().GetBinWidth(1)) + " " + xAxisLabel[unitBeginIndex+1:unitEndIndex]
         else:
             yAxisLabel = "Entries per bin (" + str(Histogram.GetXaxis().GetBinWidth(1)) + " width)"
@@ -415,9 +415,9 @@ def MakeOneDHist(pathToDir,distribution):
                 # perform new fit
                 for k in range (0, distribution['iterations'] - 1):
                     if j == -1:
-                        print "Scale down " + labels[FittingHistogramDatasets[i]] + " iteration " + str (k + 1) + "..."
+                        print("Scale down " + labels[FittingHistogramDatasets[i]] + " iteration " + str (k + 1) + "...")
                     if j == 1:
-                        print "Scale up " + labels[FittingHistogramDatasets[i]] + " iteration " + str (k + 1) + "..."
+                        print("Scale up " + labels[FittingHistogramDatasets[i]] + " iteration " + str (k + 1) + "...")
                     Target.Fit ("fit", "QEMR0")
                 Target.Fit ("fit", "VEMR0")
 
@@ -433,7 +433,7 @@ def MakeOneDHist(pathToDir,distribution):
         func.FixParameter (i, 0)
     # do the fit to get the central values
     for i in range (0, distribution['iterations'] - 1):
-        print "Iteration " + str (i + 1) + "..."
+        print("Iteration " + str (i + 1) + "...")
         Target.Fit ("fit", "QEMR0")
     Target.Fit ("fit", "VEMR0")
 
@@ -536,7 +536,7 @@ def MakeOneDHist(pathToDir,distribution):
             if i == 1:
                 Legend.AddEntry(ErrorHisto,"Stat. Errors","F")
             for Histogram in HistogramsToFit:
-                if Histogram is not HistogramsToFit[0]:
+                if Histogram != HistogramsToFit[0]:
                     ErrorHisto.Add(Histogram)
 
         if i == 0:
@@ -568,7 +568,7 @@ def MakeOneDHist(pathToDir,distribution):
 
         ### finding the maximum value of anything going on the canvas, so we know how to set the y-axis
         finalMax = 0
-        if numFittingSamples is not 0 and not arguments.noStack:
+        if numFittingSamples != 0 and not arguments.noStack:
             finalMax = ErrorHisto.GetMaximum() + ErrorHisto.GetBinError(ErrorHisto.GetMaximumBin())
         else:
             for bgMCHist in HistogramsToFit:
@@ -614,7 +614,7 @@ def MakeOneDHist(pathToDir,distribution):
         y_max = 0.9
         entry_height = 0.05
 
-        if(numFittingSamples is not 0): #then draw the data & bgMC legend
+        if(numFittingSamples != 0): #then draw the data & bgMC legend
 
             numExtraEntries = 2 # count the target and (lack of) title
             Legend.SetX1NDC(x_left)

--- a/Configuration/scripts/getDatasetJSON.py
+++ b/Configuration/scripts/getDatasetJSON.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Usage: getDatasetJSON.py /DATA/SET/NAME
 # The output is a JSON file called DATA_SET_NAME.txt containing the lumi
@@ -10,11 +10,11 @@ try:
     from CRABClient.ClientExceptions import ClientException
     from WMCore.DataStructs.LumiList import LumiList
 except ImportError:
-    print "This tool relies on CRAB. Please set up the environment for CRAB before using."
+    print("This tool relies on CRAB. Please set up the environment for CRAB before using.")
     sys.exit (2)
 
 if len (sys.argv) < 2:
-    print "Usage: " + os.path.basename (sys.argv[0]) + " DATASET [OUTPUT_FILE]"
+    print("Usage: " + os.path.basename (sys.argv[0]) + " DATASET [OUTPUT_FILE]")
     sys.exit (1)
 
 dataset = sys.argv[1]
@@ -27,11 +27,11 @@ if len (sys.argv) > 2:
 dataset0 = re.sub (r"^\/([^/]*)\/([^/]*)\/([^/]*)$", r"\1", dataset)
 dataset1 = re.sub (r"^\/([^/]*)\/([^/]*)\/([^/]*)$", r"\2", dataset)
 dataset2 = re.sub (r"^\/([^/]*)\/([^/]*)\/([^/]*)$", r"\3", dataset)
-print "Getting JSON from DBS instance " + instance + "..."
+print("Getting JSON from DBS instance " + instance + "...")
 try:
     taskALumis = getLumiListInValidFiles(dataset=dataset, dbsurl=instance)
 except ClientException:
-    print "Error accessing DAS. Please initialize your grid proxy before using."
+    print("Error accessing DAS. Please initialize your grid proxy before using.")
     sys.exit (3)
 taskALumis.writeJSON(dataset0 + "_" + dataset1 + "_" + dataset2 + ".txt")
-print "Wrote JSON to \"" + dataset0 + "_" + dataset1 + "_" + dataset2 + ".txt\"."
+print("Wrote JSON to \"" + dataset0 + "_" + dataset1 + "_" + dataset2 + ".txt\".")

--- a/Configuration/scripts/getHistIntegrals.py
+++ b/Configuration/scripts/getHistIntegrals.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # getHistIntegrals.py
 # Prints the integral of specified histograms over the specified range.
@@ -27,7 +27,7 @@ parser.add_option("-m", "--getMean", action="store_true", dest="getMean", defaul
                   help="report the mean for each histogram (upper and lower bounds are ignored)")
 (arguments, args) = parser.parse_args()
 
-from ROOT import TFile, gROOT, gStyle, gDirectory, TStyle, THStack, TH1F, TCanvas, TString, TLegend, TArrow, THStack, TIter, TKey, TGraphErrors, Double
+from ROOT import TFile, gROOT, gStyle, gDirectory, TStyle, THStack, TH1F, TCanvas, TString, TLegend, TArrow, THStack, TIter, TKey, TGraphErrors
 
 if arguments.localConfig:
     sys.path.append(os.getcwd())
@@ -37,11 +37,11 @@ DoRatio = False
 for hist in input_hists:     # loop over different input hists in config file
 
     inputFile = TFile("condor/"+hist['condor_dir']+"/"+hist['dataset']+".root")
-    #print "Reading file:  " + inputFile.GetName()
+    #print("Reading file:  " + inputFile.GetName())
 
     HistogramObj = inputFile.Get("OSUAnalysis/"+hist['channel']+"/"+hist['histName'])
     if not HistogramObj:
-        print "WARNING: Could not find histogram " + "OSUAnalysis/"+hist['channel']+"/"+hist['histName'] + " in file " + hist['dataset']+".root" + ". Will skip it and continue."
+        print("WARNING: Could not find histogram " + "OSUAnalysis/"+hist['channel']+"/"+hist['histName'] + " in file " + hist['dataset']+".root" + ". Will skip it and continue.")
         continue
     histogram = HistogramObj.Clone()
     histogram.SetDirectory(0)
@@ -54,20 +54,20 @@ for hist in input_hists:     # loop over different input hists in config file
 
     xloBin = histogram.GetXaxis().FindBin(float(xlo))
     if xhi > xmax:
-        print "xhi is outside the range of the histogram, will include all the overflow instead"
+        print("xhi is outside the range of the histogram, will include all the overflow instead")
     xhiBin = histogram.GetXaxis().FindBin(float(xhi))
     xlo = histogram.GetXaxis().GetBinLowEdge(xloBin)   # lo edge is the left edge of the first bin
     if xhi > xmax:
         xhi = "All to infinity"
     else:
         xhi = histogram.GetXaxis().GetBinLowEdge(xhiBin+1)
-    intError = Double (0.0)
+    intError = double (0.0)
     integral = histogram.IntegralAndError(xloBin, xhiBin, intError)
 
     line = "Integral of " + hist['histName'] + " in " + inputFile.GetName() + " from " + str(xlo) + " to " + str(xhi) + ": " + str (integral) + " +- " + str (intError)
     if arguments.getMean:
          line += "; Mean of entire histogram= " + str(histogram.GetMean()) + " +- " + str(histogram.GetMeanError())
-    print line
+    print(line)
     if hist.has_key('role in ratioDic'):
         DoRatio = True
         for key in RatioDic.keys():
@@ -85,11 +85,8 @@ if DoRatio:
                 NumError = RatioDic[key]['Numerator']['error']
                 DenError = RatioDic[key]['Denominator']['error']
                 if DenValue == 0:
-                        print "Denominator of " + str(key) + " is 0 ! Please Check! "
+                        print("Denominator of " + str(key) + " is 0 ! Please Check! ")
                         break
                 Ratio = NumValue/DenValue
                 RatioError = math.pow(math.pow(NumError,2)/math.pow(DenValue,2) + math.pow(DenError,2)*math.pow(NumValue,2)/math.pow(DenValue,4),0.5)
-                print str(key) + " is " + str(Ratio) + " +- " + str(RatioError)
-
-
-
+                print(str(key) + " is " + str(Ratio) + " +- " + str(RatioError))

--- a/Configuration/scripts/getRatioFromCanvas.py
+++ b/Configuration/scripts/getRatioFromCanvas.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Script to extract the ratio histogram from a given canvas, that was produced with makePlots.py or makeEfficiencyPlots.py
 # Ratio histogram is saved in specified output file.
@@ -25,7 +25,7 @@ from ROOT import TFile, gDirectory, TH1F, TCanvas, TPad
 inputFile = TFile(arguments.infile, "READ")
 can = inputFile.Get(arguments.canName).Clone()
 if not can:
-    print "Could not find TCanvas " + can + " in " + inputFile
+    print("Could not find TCanvas " + can + " in " + inputFile)
 padName = arguments.canName + "_2" # by convention, the pad with the ratio has the same name as the canvas but with a suffix of "_2"
 padName = padName[padName.rfind('/')+1:]  # strip off anything before the last '/'
 pad  = can.GetPrimitive(padName)
@@ -34,13 +34,11 @@ if not hist:
     padName = padName.replace("_2", "")
     hist = pad.GetPrimitive(padName);               # the ratio hist made by makeEfficiencyPlots.py will have the same name as the canvas
 if not hist:
-    print "Error:  could not extract ratio histogram from canvas " + arguments.canName + " in file " + arguments.infile
+    print("Error:  could not extract ratio histogram from canvas " + arguments.canName + " in file " + arguments.infile)
     sys.exit(0)
 outputFile = TFile(arguments.outfile, "RECREATE")
 hist.Write()
 outputFile.Close()
 inputFile.Close()
 
-print "Finished writing ratio histogram " + arguments.canName + " to " + arguments.outfile
-
-
+print("Finished writing ratio histogram " + arguments.canName + " to " + arguments.outfile)

--- a/Configuration/scripts/listContents.py
+++ b/Configuration/scripts/listContents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Prints the keys of all objects in a .root file.
 #
@@ -10,9 +10,9 @@ import sys
 from OSUT3Analysis.Configuration.fileUtilities import *
 
 if len(sys.argv) <= 1:
-    print "Missing input file name."
-    print "Sample usage: "
-    print "> listContents.py myfile.root"
+    print("Missing input file name.")
+    print("Sample usage: ")
+    print("> listContents.py myfile.root")
     sys.exit()
 
 fname = sys.argv[1]
@@ -22,5 +22,5 @@ keys = f.GetAllKeys()
 
 for key in keys:
     obj = f.Get(key)
-    print obj.ClassName(), ": ", key
-print "Found", len(keys), "objects in ", fname
+    print(obj.ClassName(), ": ", key)
+print("Found", len(keys), "objects in ", fname)

--- a/Configuration/scripts/makeBgMCTable.py
+++ b/Configuration/scripts/makeBgMCTable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import fileinput
@@ -80,7 +80,7 @@ def makeReplacements(line):
 #### check which bgMC input datasets have valid output files
 ## processed_datasets = []
 ## for dataset in datasets:
-##     if types[dataset] is not "bgMC":
+##     if types[dataset] != "bgMC":
 ##         continue
 ##     fileName = condor_dir + "/" + dataset + ".root"
 ##     if not os.path.exists(fileName):
@@ -89,7 +89,7 @@ def makeReplacements(line):
 ##     if not (testFile.IsZombie()):
 ##         processed_datasets.append(dataset)
 
-## if len(processed_datasets) is 0:
+## if len(processed_datasets) == 0:
 ##     sys.exit("Can't find any output root files for the given list of datasets")
 
 
@@ -159,7 +159,7 @@ fout.write (headerLine.rstrip(" & ")+endLine+newLine+hLine)
 
 # for dataset in processed_datasets:
 for dataset in datasets:
-    if types[dataset] is not "bgMC":
+    if types[dataset] != "bgMC":
         continue
 
     datasetLines = ""
@@ -252,6 +252,3 @@ if arguments.replacements:
 
 fout.write("\\end{tabular}}")
 fout.close()
-
-
-

--- a/Configuration/scripts/makeComparisonPlots.py
+++ b/Configuration/scripts/makeComparisonPlots.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import re
@@ -68,14 +68,14 @@ noUnderFlow = arguments.noUnderFlow
 #### deal with conflicting arguments
 
 if arguments.makeRatioPlots and arguments.makeDiffPlots:
-    print "You have requested both ratio and difference plots.  Will make just ratio plots instead"
+    print("You have requested both ratio and difference plots.  Will make just ratio plots instead")
     arguments.makeRatioPlots = False
 
 if arguments.makeSignificancePlots and arguments.makeRatioPlots:
-    print "You have asked to make a ratio plot and significance plots. This is a very strange request.  Will skip making the ratio plot."
+    print("You have asked to make a ratio plot and significance plots. This is a very strange request.  Will skip making the ratio plot.")
     arguments.makeRatioPlots = False
 if arguments.makeSignificancePlots and arguments.makeDiffPlots:
-    print "You have asked to make a difference plot and significance plots. This is a very strange request.  Will skip making the difference plot."
+    print("You have asked to make a difference plot and significance plots. This is a very strange request.  Will skip making the difference plot.")
     arguments.makeDiffPlots = False
 
 from OSUT3Analysis.Configuration.histogramUtilities import ratioHistogram
@@ -201,7 +201,7 @@ fillList = [
 def MakeIntegralHist(hist, integrateDir):
     # return the integrated histogram, in the direction specified
     # integrateDir values: "left", "right", "none"
-    if integrateDir is "none":
+    if integrateDir == "none":
         return hist  # do nothing
     integral = 0
     error = 0
@@ -209,7 +209,7 @@ def MakeIntegralHist(hist, integrateDir):
     # always include underflow and overflow
     lowLimit = 0 # underflow bin
     uppLimit = nbins+1 # overflow bin
-    if integrateDir is "left":
+    if integrateDir == "left":
         for i in range(lowLimit,nbins+1):  # start with underflow bin
             integral += hist.GetBinContent(i)
             error = math.sqrt(error*error + hist.GetBinError(i)*hist.GetBinError(i)) # sum errors in quadrature
@@ -218,7 +218,7 @@ def MakeIntegralHist(hist, integrateDir):
             # Then include overflow bin in the last bin
             hist.SetBinContent(nbins, hist.GetBinContent(nbins) + hist.GetBinContent(nbins+1))
             hist.SetBinError  (nbins, math.sqrt(hist.GetBinError(nbins)*hist.GetBinError(nbins) + hist.GetBinError(nbins+1)*hist.GetBinError(nbins+1)))
-    elif integrateDir is "right":
+    elif integrateDir == "right":
         for i in xrange(uppLimit, 0, -1):  # start with overflow bin
             integral += hist.GetBinContent(i)
             error = math.sqrt(error*error + hist.GetBinError(i)*hist.GetBinError(i)) # sum errors in quadrature
@@ -240,7 +240,7 @@ def MakeIntegralHist(hist, integrateDir):
 def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
 
     if arguments.verbose:
-        print "Creating histogram", histogramName, "in directory", histogramDirectory
+        print("Creating histogram", histogramName, "in directory", histogramDirectory)
 
     HeaderLabel = TPaveLabel(header_x_left,header_y_bottom,header_x_right,header_y_top,HeaderText,"NDC")
     HeaderLabel.SetTextAlign(32)
@@ -277,9 +277,9 @@ def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
     Legend.SetFillStyle(0)
 
     canvasName = histogramName
-    if integrateDir is "left":
+    if integrateDir == "left":
         canvasName += "_CumulativeLeft"
-    elif integrateDir is "right":
+    elif integrateDir == "right":
         canvasName += "_CumulativeRight"
     Canvas = TCanvas(canvasName)
     Histograms = []
@@ -304,18 +304,18 @@ def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
         else:
             HistogramObj = inputFile.Get(source['channel'] + "Plotter/" + histogramDirectory + "/" + histogramName)
         if not HistogramObj:
-            print "WARNING:  Could not find histogram " + source['channel'] + "/" + histogramName + " in file " + dataset_file + ".  Will skip it and continue."
+            print("WARNING:  Could not find histogram " + source['channel'] + "/" + histogramName + " in file " + dataset_file + ".  Will skip it and continue.")
             return
         Histogram = HistogramObj.Clone()
         Histogram.SetDirectory(0)
         inputFile.Close()
         Histogram.Sumw2()
         if arguments.verbose:
-            print "  Got histogram", Histogram.GetName(), "from file", dataset_file
+            print("  Got histogram", Histogram.GetName(), "from file", dataset_file)
         if arguments.rebinFactor:
             RebinFactor = int(arguments.rebinFactor)
             #don't rebin histograms which will have less than 5 bins or any gen-matching histograms
-            if Histogram.GetNbinsX() >= RebinFactor*5 and Histogram.GetTitle().find("GenMatch") is -1:
+            if Histogram.GetNbinsX() >= RebinFactor*5 and Histogram.GetTitle().find("GenMatch") == -1:
                 Histogram.Rebin(RebinFactor)
 
         # correct bin contents of object multiplcity plots
@@ -335,7 +335,7 @@ def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
             yAxisLabel = Histogram.GetYaxis().GetTitle()
         else:
 
-            if unitBeginIndex is not -1 and unitEndIndex is not -1: #x axis has a unit
+            if unitBeginIndex != -1 and unitEndIndex != -1: #x axis has a unit
                 yAxisLabel = "Entries / " + str(Histogram.GetXaxis().GetBinWidth(1)) + " " + xAxisLabel[unitBeginIndex+1:unitEndIndex]
                 xAxisLabelVar = xAxisLabel[0:unitBeginIndex]
             else:
@@ -347,9 +347,9 @@ def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
                 unit = "Efficiency"
             else:
                 unit = "Yield"
-            if integrateDir is "left":
+            if integrateDir == "left":
                 yAxisLabel = unit + ", " + xAxisLabelVar + "< x (" + str(Histogram.GetXaxis().GetBinWidth(1)) + " bin width)"
-            if integrateDir is "right":
+            if integrateDir == "right":
                 yAxisLabel = unit + ", " + xAxisLabelVar + "> x (" + str(Histogram.GetXaxis().GetBinWidth(1)) + " bin width)"
 
 
@@ -378,10 +378,10 @@ def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
             Histogram.SetMarkerColor(colors[colorList[colorIndex]])
             Histogram.SetLineColor(colors[colorList[colorIndex]])
             colorIndex = colorIndex + 1
-            if colorIndex is len(colorList):
+            if colorIndex == len(colorList):
                 colorIndex = 0
                 markerStyleIndex = markerStyleIndex + 1
-                if markerStyleIndex is len(markerStyleList):
+                if markerStyleIndex == len(markerStyleList):
                     markerStyleIndex = 0
                     fillIndex = fillIndex + 1
 
@@ -479,7 +479,7 @@ def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
     for histogram in Histograms:
         histogram.SetTitle(histoTitle)
         if arguments.verbose:
-            print "  Drawing hist " + histogram.GetName() + ", with plotting_options = " + plotting_options + ", with mean = " + str(histogram.GetMean()) + ", with color = " + str(histogram.GetLineColor())
+            print("  Drawing hist " + histogram.GetName() + ", with plotting_options = " + plotting_options + ", with mean = " + str(histogram.GetMean()) + ", with color = " + str(histogram.GetLineColor()))
         histogram.Draw(plotting_options)
         histogram.GetXaxis().SetTitle(xAxisLabel)
         histogram.GetYaxis().SetTitle(yAxisLabel)
@@ -489,7 +489,7 @@ def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
             histogram.SetMinimum(yAxisMin)
         if makeRatioPlots or makeDiffPlots:
             histogram.GetXaxis().SetLabelSize(0)
-        if histCounter is 0:
+        if histCounter == 0:
             plotting_options = plotting_options + " SAME"
         histCounter = histCounter + 1
 
@@ -525,12 +525,12 @@ def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
             Reference = Histograms[RefIndex]
 
         for Histogram in Histograms:
-            if Histogram is Reference:
+            if Histogram == Reference:
                 continue
 
             if makeRatioPlots:
                 makeRatio = functools.partial (ratioHistogram,Histogram, Reference)
-                if arguments.ratioRelErrMax is not -1: # it gets initialized to this dummy value of -1
+                if arguments.ratioRelErrMax != -1: # it gets initialized to this dummy value of -1
                     makeRatio =  functools.partial (makeRatio, relErrMax = float(arguments.ratioRelErrMax))
                 if addOneToRatio != -1: # it gets initialized to this dummy value of -1
                     makeRatio = functools.partial (makeRatio, addOne = bool (addOneToRatio))
@@ -589,7 +589,7 @@ def MakeOneDHist(histogramDirectory, histogramName,integrateDir):
     outputFile.cd(histogramDirectory)
     Canvas.Write()
     if arguments.verbose:
-        print "  Finished writing canvas: ", Canvas.GetName()
+        print("  Finished writing canvas: ", Canvas.GetName())
 
     if arguments.savePDFs:
         Canvas.SaveAs("comparison_histograms_pdfs/"+histogramName+".pdf")
@@ -612,7 +612,7 @@ def LoopOverKeys(currentDir, testFile, outputFile):
 
         if (key.GetClassName() == "TDirectoryFile"):
             if arguments.verbose:
-                print "Looping over directory: ", key.GetName()
+                print("Looping over directory: ", key.GetName())
             if currentDir == "":
                 histDir = key.GetName()
             else:
@@ -667,7 +667,7 @@ else:
         if (key.GetClassName() != "TDirectoryFile"):
             continue
         if arguments.verbose:
-            print "Checking key: ", key.GetName()
+            print("Checking key: ", key.GetName())
 
         histogramDirectory = key.GetName()
         outputFile.cd()
@@ -680,4 +680,4 @@ else:
 
 testFile.Close()
 outputFile.Close()
-print "Finished writing " + outputFile.GetName()
+print("Finished writing " + outputFile.GetName())

--- a/Configuration/scripts/makeCutFlows.py
+++ b/Configuration/scripts/makeCutFlows.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import math
@@ -94,7 +94,7 @@ class Table(object):
             return len(self.contents[0])
     def maxColWidth(self, col):
         if col >= len(self.contents):
-            print "ERROR:  Cannot find maximum column width for column index", col, "because the table only contains", len(self.contents), "columns."
+            print("ERROR:  Cannot find maximum column width for column index", col, "because the table only contains", len(self.contents), "columns.")
             return 0
         maxWidth = -1
         for r in range(self.numRows()):
@@ -104,9 +104,9 @@ class Table(object):
 
     def addColumn(self, col):
         if self.numRows() > 0 and len(col) != self.numRows():
-            print "ERROR: Cannot add column with length", len(col), "to table with", self.numRows(), " rows."
-            print "Printing column contents: ", col
-            print "Printing table contents: "
+            print("ERROR: Cannot add column with length", len(col), "to table with", self.numRows(), " rows.")
+            print("Printing column contents: ", col)
+            print("Printing table contents: ")
             self.printToFile()
             return
         newcol = copy.deepcopy(col)
@@ -119,7 +119,7 @@ class Table(object):
                 self.contents.append(newcol)
             return
         if len(col) != self.numCols():
-            print "ERROR: Cannot add row with length", len(row), "to table with", self.numCols(), " columns."
+            print("ERROR: Cannot add row with length", len(row), "to table with", self.numCols(), " columns.")
             return
         else:
             for c in range(self.numCols()):
@@ -176,8 +176,8 @@ class Table(object):
             tableFormat += "|"
             vlinesToPrint.remove(self.numCols()+1)
         if len(vlinesToPrint) != 0:
-            print "WARNING: Found additional vline's that were not printed:"
-            print vlinesToPrint
+            print("WARNING: Found additional vline's that were not printed:")
+            print(vlinesToPrint)
         fout.write("\\begin{table}[htbp] \n")
         fout.write("\\begin{center} \n")
         fout.write("\\begin{tabular}{" + tableFormat + "}\n")
@@ -207,9 +207,9 @@ class Table(object):
             fout.write("\hline \n")
             hlinesToPrint.remove(self.numRows())
         if len(hlinesToPrint) != 0:
-            print "WARNING: Found additional hline's that were not printed:"
-            print hlinesToPrint
-            print "   self.numRows() = ", self.numRows()
+            print("WARNING: Found additional hline's that were not printed:")
+            print(hlinesToPrint)
+            print("   self.numRows() = ", self.numRows())
 
         # Close table:
         fout.write("\\end{tabular} \n")
@@ -228,7 +228,7 @@ class Table(object):
             for c in range(self.numCols()):
                 for r in range(self.numRows()):
                     if replacement in self.contents[c][r]:
-#                        print replacement, "->", replacements[replacement], ":", self.contents[c][r], "->", self.contents[c][r].replace(replacement,replacements[replacement])
+#                        print(replacement, "->", replacements[replacement], ":", self.contents[c][r], "->", self.contents[c][r].replace(replacement,replacements[replacement]))
                         self.contents[c][r] = self.contents[c][r].replace(replacement,replacements[replacement])
 
 
@@ -332,17 +332,17 @@ class CFTable(object):
         table.contents[-1][0] = "\\multicolumn{" + str(len(self.datasets)) + "}{r}{" + self.type + "}"
         table.initializeJustification()
         table.hlines = [1, 2, table.numRows()]
-        #print "Debug:  print all aliases for numRows = ", table.numRows
+        #print("Debug:  print all aliases for numRows = ", table.numRows)
         #for r in range(table.numRows()):
-            #print r, ": ", table.contents[0][r]
+            #print(r, ": ", table.contents[0][r])
         table.makeAllReplacements(replacements)
-        #print "Debug:  print all aliases after replacement 1"
+        #print("Debug:  print all aliases after replacement 1")
         #for r in range(table.numRows()):
-            #print r, ": ", table.contents[0][r]
+            #print(r, ": ", table.contents[0][r])
         #table.makeAllReplacements(secondary_replacements)
-        #print "Debug:  print all aliases after replacement 2"
+        #print("Debug:  print all aliases after replacement 2")
         #for r in range(table.numRows()):
-            #print r, ": ", table.contents[0][r]
+            #print(r, ": ", table.contents[0][r])
         return table
     def printErrors(self, toprint):
         for d in self.datasets:
@@ -356,7 +356,7 @@ class CFTable(object):
 
 def fillTableCuts(table, dataset_file):
     if len(table.cutNames) != 0:
-        print "WARNING: Cuts already defined for table; will not add cuts for channel", table.channel
+        print("WARNING: Cuts already defined for table; will not add cuts for channel", table.channel)
         return
     inputFile = TFile(dataset_file)
     cutFlow = inputFile.Get(table.channel + "/cutFlow")
@@ -376,7 +376,7 @@ def getLumiWt(dataset_file):
             words = filter(None, words) # Remove empty entries.
             lumiWt = float(words[-1].rstrip(".\n"))  # Strip off the end-line and period from the last word in the line.
     if lumiWt <= 0:
-        print "ERROR:  Found invalid lumiWt from file:", mergeLogName
+        print("ERROR:  Found invalid lumiWt from file:", mergeLogName)
         exit(0)
     return lumiWt
 
@@ -384,8 +384,8 @@ def fillTableColumn(table, dataset_file, dataset, hist_name="cutFlow"):
     inputFile = TFile(dataset_file)
     cutFlow = inputFile.Get(table.channel + "/" + hist_name)
     if cutFlow.GetNbinsX() != len(table.cutNames):
-        print "ERROR:  cutFlow.GetNbinsX() = ", cutFlow.GetNbinsX(), " does not equal len(table.cutNames) = ", len(table.cutNames)
-        print "Will skip channel", table.channel, " from file ", dataset_file
+        print("ERROR:  cutFlow.GetNbinsX() = ", cutFlow.GetNbinsX(), " does not equal len(table.cutNames) = ", len(table.cutNames))
+        print("Will skip channel", table.channel, " from file ", dataset_file)
         return
     newcol = CFColumn(dataset)
     newcol.label = getLabel(dataset)
@@ -407,7 +407,7 @@ def makeTableEff(table):
     tableEff = copy.deepcopy(table)
     for c in reversed(range(len(tableEff.datasets))):  # Go backwards to allow removal of columns.
         col = tableEff.datasets[c]
-        if col.dataset is "diff" or col.dataset is "ratio":
+        if col.dataset == "diff" or col.dataset == "ratio":
             # The difference and ratio do not make sense in the efficiency table.
             del tableEff.datasets[c]
             continue
@@ -423,7 +423,7 @@ def makeTableMargEff(table):
     tableMargEff = copy.deepcopy(table)
     for c in reversed(range(len(tableMargEff.datasets))):  # Go backwards to allow removal of columns.
         col = tableMargEff.datasets[c]
-        if col.dataset is "diff" or col.dataset is "ratio":
+        if col.dataset == "diff" or col.dataset == "ratio":
             # The difference and ratio do not make sense in the efficiency table.
             del tableMargEff.datasets[c]
             continue
@@ -440,7 +440,7 @@ def makeTableIndivEff(table):
     tableIndivEff = copy.deepcopy(table)
     for c in reversed(range(len(tableIndivEff.datasets))):  # Go backwards to allow removal of columns.
         col = tableIndivEff.datasets[c]
-        if col.dataset is "diff" or col.dataset is "ratio":
+        if col.dataset == "diff" or col.dataset == "ratio":
             # The difference and ratio do not make sense in the efficiency table.
             del tableIndivEff.datasets[c]
             continue
@@ -464,8 +464,8 @@ def addExtraColumn(table, option):
         sig  = CFCell()
         for d in table.datasets:   # Loop over datasets
             if d.type == "signalMC":
-                if sig.val != 0 and option is "signif":
-                    print "Warning:  table contains more than one signal sample; will calculate signif with only the first."
+                if sig.val != 0 and option == "signif":
+                    print("Warning:  table contains more than one signal sample; will calculate signif with only the first.")
                 else:
                     sig = d.yields[i]
             elif d.type == "bgMC":
@@ -474,15 +474,15 @@ def addExtraColumn(table, option):
                 data += d.yields[i]
         # Perform calculation, and add cell to the column.
         newcell = CFCell()
-        if option is "total":
+        if option == "total":
             newcell = bkgd
-        elif option is "diff":
+        elif option == "diff":
             newcell = data - bkgd
-        elif option is "ratio":
+        elif option == "ratio":
             # Define:  ratio = (data - bkgd) / bkgd = (data / bkgd) - 1.0
             newcell = data / bkgd
             newcell.val -= 1.0
-        elif option is "signif":
+        elif option == "signif":
             x  =  sig.val
             y  = bkgd.val
             dx =  sig.err
@@ -512,7 +512,7 @@ def makePdf(condor_dir,texfile):
     os.system(command)
     os.system(command)
     if (arguments.verbose):
-        print "Finished running: " + command
+        print("Finished running: " + command)
     os.unlink ("%saux" % (texfile.rstrip("tex")))
     os.unlink ("%slog" % (texfile.rstrip("tex")))
 
@@ -542,14 +542,14 @@ def getProcessedDatasets(condor_dir, datasets):
         fileName = condor_dir + "/" + dataset + ".root"
         if not os.path.exists(fileName):
             if (arguments.verbose):
-                print "Couldn't find output file for",dataset,"dataset",fileName,"fileName"
+                print("Couldn't find output file for",dataset,"dataset",fileName,"fileName")
             continue
         testFile = TFile(fileName)
         if not (testFile.IsZombie()):
             processed_datasets.append(dataset)
         if arguments.verbose:
-            print "Opening testFile: ", fileName
-    if len(processed_datasets) is 0:
+            print("Opening testFile: ", fileName)
+    if len(processed_datasets) == 0:
         sys.exit("Can't find any output root files for the given list of datasets")
     return processed_datasets
 
@@ -699,7 +699,7 @@ if arguments.inputFile:
     processed_datasets = []
     labels = { dataset : dataset }
 if arguments.verbose:
-    print "Will process the following channels: ", channels, " in the datasets ", processed_datasets
+    print("Will process the following channels: ", channels, " in the datasets ", processed_datasets)
 
 writeTexFileHeader(texfile)
 labels["total"]  = "total bkgd"
@@ -749,5 +749,4 @@ for channel in channels: # loop over final states, which each have their own dir
 closeTexFile(texfile)
 makePdf(outputDir,texfile)
 
-print "Finished writing cutFlow to " + outputDir + "/" + outputFileName + "{.tex,.pdf}"
-
+print("Finished writing cutFlow to " + outputDir + "/" + outputFileName + "{.tex,.pdf}")

--- a/Configuration/scripts/makeEfficiencyComparisonPlot.py
+++ b/Configuration/scripts/makeEfficiencyComparisonPlot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ### this script has been done to overlaid on the same canva multiple efficency's curves. It uses the asymmetryc errors.
 
@@ -142,7 +142,7 @@ for Histogram in Histograms:
     Histogram.Draw(plotting_options)
 #    Histogram.GetXaxis().SetTitle(xAxisLabel)
     Histogram.GetYaxis().SetTitle("cut efficiency")
-    if counter is 0:
+    if counter == 0:
         if Histogram.InheritsFrom("TGraph"):
             plotting_options = "P"
     counter = counter+1
@@ -161,8 +161,8 @@ Canvas.Write()
 if arguments.plot_savePdf:
     pdfFileName = outputFileName.replace(".root", ".pdf")
     Canvas.SaveAs(pdfFileName)
-    print "Saved file:  " + pdfFileName
+    print("Saved file:  " + pdfFileName)
 
 
 outputFile.Close()
-print "Saved plot in file: " + outputFileName
+print("Saved plot in file: " + outputFileName)

--- a/Configuration/scripts/makeEfficiencyPlots.py
+++ b/Configuration/scripts/makeEfficiencyPlots.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import re
@@ -62,13 +62,13 @@ noUnderFlow = arguments.noUnderFlow
 #### deal with conflicting arguments
 
 if arguments.makeRatioPlots or arguments.makeDiffPlots:
-    if len(input_sources) is not 2:
-        print "You need to have exactly two input sources to produce ratio or difference plots, turning them off"
+    if len(input_sources) != 2:
+        print("You need to have exactly two input sources to produce ratio or difference plots, turning them off")
         arguments.makeRatioPlots = False
         arguments.makeDiffPlots = False
 
 if arguments.makeRatioPlots and arguments.makeDiffPlots:
-    print "You have requested both ratio and difference plots.  Will make just ratio plots instead"
+    print("You have requested both ratio and difference plots.  Will make just ratio plots instead")
     arguments.makeRatioPlots = False
 
 
@@ -239,10 +239,10 @@ def MakeOneHist(dirName, histogramName):
         else:   # Default is to use the same condor directory
             DenHistogramObj = inputFile.Get(source['den_channel'] + "Plotter/" + dirName + "/" + histogramName)
         if not NumHistogramObj:
-            print "WARNING:  Could not find histogram " + source['num_channel'] + "Plotter/" + dirName + "/" + histogramName + " in file " + dataset_file + ".  Will skip it and continue."
+            print("WARNING:  Could not find histogram " + source['num_channel'] + "Plotter/" + dirName + "/" + histogramName + " in file " + dataset_file + ".  Will skip it and continue.")
             return
         if not DenHistogramObj:
-            print "WARNING:  Could not find histogram " + source['den_channel'] + "Plotter/" + dirName + "/" + histogramName + " in file " + dataset_file + ".  Will skip it and continue."
+            print("WARNING:  Could not find histogram " + source['den_channel'] + "Plotter/" + dirName + "/" + histogramName + " in file " + dataset_file + ".  Will skip it and continue.")
             return
 
         Histogram = NumHistogramObj.Clone()
@@ -276,7 +276,7 @@ def MakeOneHist(dirName, histogramName):
         if arguments.rebinFactor:
             RebinFactor = int(arguments.rebinFactor)
             #don't rebin histograms which will have less than 5 bins or any gen-matching histograms
-            if Histogram.GetNbinsX() >= RebinFactor*5 and Histogram.GetTitle().find("GenMatch") is -1 and not Histogram.Class().InheritsFrom("TH2"):
+            if Histogram.GetNbinsX() >= RebinFactor*5 and Histogram.GetTitle().find("GenMatch") == -1 and not Histogram.Class().InheritsFrom("TH2"):
                 Histogram.Rebin(RebinFactor)
                 DenHistogram.Rebin(RebinFactor)
 
@@ -284,7 +284,7 @@ def MakeOneHist(dirName, histogramName):
         unitBeginIndex = xAxisLabel.find("[")
         unitEndIndex = xAxisLabel.find("]")
 
-        if unitBeginIndex is not -1 and unitEndIndex is not -1: #x axis has a unit
+        if unitBeginIndex != -1 and unitEndIndex != -1: #x axis has a unit
             yAxisLabel = "#epsilon_{ " + cutName + "} (" + str(Histogram.GetXaxis().GetBinWidth(1)) + " " + xAxisLabel[unitBeginIndex+1:unitEndIndex] + " width)"
         else:
             yAxisLabel = "#epsilon_{ " + cutName + "} (" + str(Histogram.GetXaxis().GetBinWidth(1)) + " width)"
@@ -316,7 +316,7 @@ def MakeOneHist(dirName, histogramName):
         if not arguments.makeFancy:
             fullTitle = Histogram.GetTitle()
             splitTitle = fullTitle.split(":")
-            #    print splitTitle
+            #    print(splitTitle)
             if len(splitTitle) > 1:
                 histoTitle = splitTitle[1].lstrip(" ")
             else:
@@ -331,7 +331,7 @@ def MakeOneHist(dirName, histogramName):
             Histogram.SetMarkerColor(colors[colorList[colorIndex]])
             Histogram.SetLineColor(colors[colorList[colorIndex]])
             colorIndex = colorIndex + 1
-            if colorIndex is len(colorList):
+            if colorIndex == len(colorList):
                 colorIndex = 0
 
         markerStyle = 20
@@ -445,7 +445,7 @@ def MakeOneHist(dirName, histogramName):
                 histogram.SetMaximum(finalMax)
                 histogram.SetMinimum(yAxisMin)
 
-        if histCounter is 0:
+        if histCounter == 0:
             if histogram.InheritsFrom("TH1"):
                 plotting_options = plotting_options + " SAME"
             elif histogram.InheritsFrom("TEfficiency"):
@@ -473,9 +473,9 @@ def MakeOneHist(dirName, histogramName):
             makeRatio = functools.partial (ratioHistogram,HistogramClones[0],HistogramClones[1])
             if addOneToRatio != -1: # it gets initialized to this dummy value of -1
                 makeRatio = functools.partial (makeRatio, addOne = bool (addOneToRatio))
-            if ratioRelErrMax is not -1: # it gets initialized to this dummy value of -1
+            if ratioRelErrMax != -1: # it gets initialized to this dummy value of -1
                 makeRatio = functools.partial (makeRatio, relErrMax = float (ratioRelErrMax))
-            if dontRebinRatio is True:
+            if dontRebinRatio == True:
                 makeRatio = functools.partial (makeRatio, dontRebinRatio)
             Comparison = makeRatio ()
         elif makeDiffPlots:
@@ -544,11 +544,11 @@ first_input = input_sources[0]
 #### use the first input file as a template and make comparison versions of all its histograms
 testFile = TFile("condor/" + first_input['condor_dir'] + "/" + first_input['dataset'] + ".root")
 if arguments.verbose:
-    print "Opened testFile: ", testFile.GetName()
+    print("Opened testFile: ", testFile.GetName())
 rootDirectory = first_input['num_channel'] + "Plotter"
 testFile.cd(rootDirectory)
 if arguments.verbose:
-    print "Going to rootDirectory: ", rootDirectory
+    print("Going to rootDirectory: ", rootDirectory)
 
 if arguments.savePDFs:
     try:
@@ -560,14 +560,14 @@ if arguments.savePDFs:
 
 for key in gDirectory.GetListOfKeys(): # Loop over directories in same way as in makePlots.py
     if arguments.verbose:
-        print "  Checking key: ", key.GetName()
+        print("  Checking key: ", key.GetName())
 
     if (key.GetClassName() != "TDirectoryFile"):
         continue
 
     level2Directory = rootDirectory + "/" + key.GetName()
     if arguments.verbose:
-        print "  Checking directory: ", level2Directory
+        print("  Checking directory: ", level2Directory)
     outputFile.cd()
     outputFile.mkdir(key.GetName())
     outputFile.cd(key.GetName())
@@ -575,13 +575,13 @@ for key in gDirectory.GetListOfKeys(): # Loop over directories in same way as in
     for key2 in gDirectory.GetListOfKeys():
         if re.match ('TH1', key2.GetClassName()): #found a 1D histogram
             if arguments.verbose:
-                print "    Will make 1D histogram: ", key2.GetName()
+                print("    Will make 1D histogram: ", key2.GetName())
             MakeOneHist(key.GetName(), key2.GetName())
         if arguments.draw2DPlots and re.match ('TH2', key2.GetClassName()):  # make 2D histograms
             if arguments.verbose:
-                print "    Will make 2D histogram: ", key2.GetName()
+                print("    Will make 2D histogram: ", key2.GetName())
             MakeOneHist(key.GetName(), key2.GetName())
 
 testFile.Close()
 outputFile.Close()
-print "Finished writing " + outputFile.GetName()
+print("Finished writing " + outputFile.GetName())

--- a/Configuration/scripts/makePU.py
+++ b/Configuration/scripts/makePU.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os
@@ -34,7 +34,7 @@ for sample in datasets:
     if not (testFile.IsZombie()):
         processed_datasets.append(sample)
 
-if len(processed_datasets) is 0:
+if len(processed_datasets) == 0:
     sys.exit("No datasets have been processed")
 
 #### open first input file and re-make its directory structure in the output file
@@ -55,6 +55,6 @@ for sample in processed_datasets: # loop over different samples as listed in con
         outputFile.cd()
         Histogram.Write (sample)
     else:
-        print rootDirectory+"/pileup does not exist in " + condor_dir + "/" + sample + ".root"
+        print(rootDirectory+"/pileup does not exist in " + condor_dir + "/" + sample + ".root")
         continue
 outputFile.Close()

--- a/Configuration/scripts/makePlots.py
+++ b/Configuration/scripts/makePlots.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import re
@@ -90,26 +90,26 @@ if includeSystematics:
 
 #### deal with conflicting arguments
 if arguments.normalizeToData and arguments.normalizeToUnitArea:
-    print "Conflicting normalizations requsted, will normalize to unit area"
+    print("Conflicting normalizations requsted, will normalize to unit area")
     arguments.normalizeToData = False
 if arguments.normalizeToData and arguments.noStack:
-    print "You have asked to scale non-stacked backgrounds to data.  This is a very strange request.  Will normalize to unit area instead"
+    print("You have asked to scale non-stacked backgrounds to data.  This is a very strange request.  Will normalize to unit area instead")
     arguments.normalizeToData = False
     arguments.normalizeToUnitArea = True
 if arguments.makeRatioPlots and arguments.makeDiffPlots:
-    print "You have requested both ratio and difference plots.  Will make just ratio plots instead"
+    print("You have requested both ratio and difference plots.  Will make just ratio plots instead")
     arguments.makeRatioPlots = False
 if arguments.makeRatioPlots and arguments.noStack:
-    print "You have asked to make a ratio plot and to not stack the backgrounds.  This is a very strange request.  Will skip making the ratio plot."
+    print("You have asked to make a ratio plot and to not stack the backgrounds.  This is a very strange request.  Will skip making the ratio plot.")
     arguments.makeRatioPlots = False
 if arguments.makeDiffPlots and arguments.noStack:
-    print "You have asked to make a difference plot and to not stack the backgrounds.  This is a very strange request.  Will skip making the difference plot."
+    print("You have asked to make a difference plot and to not stack the backgrounds.  This is a very strange request.  Will skip making the difference plot.")
     arguments.makeDiffPlots = False
 if arguments.makeSignificancePlots and arguments.makeRatioPlots:
-    print "You have asked to make a ratio plot and significance plots. This is a very strange request.  Will skip making the ratio plot."
+    print("You have asked to make a ratio plot and significance plots. This is a very strange request.  Will skip making the ratio plot.")
     arguments.makeRatioPlots = False
 if arguments.makeSignificancePlots and arguments.makeDiffPlots:
-    print "You have asked to make a difference plot and significance plots. This is a very strange request.  Will skip making the difference plot."
+    print("You have asked to make a difference plot and significance plots. This is a very strange request.  Will skip making the difference plot.")
     arguments.makeDiffPlots = False
 
 from OSUT3Analysis.Configuration.histogramUtilities import ratioHistogram
@@ -178,7 +178,8 @@ topLeft_y_offset  = 0.04
 
 #set the text for the fancy heading
 #HeaderText = "CMS Preliminary: " + LumiText + " at #sqrt{s} = 8 TeV"
-HeaderText = LumiText + " (13 TeV)"
+#HeaderText = LumiText + " (13 TeV)"
+HeaderText = "(13 TeV)"
 
 #position for header
 header_x_left    = 0.602535
@@ -210,9 +211,9 @@ if arguments.paperConfig:
         noUnderFlow = paperHistogram['noUnderFlow']
 ###############################################
 if not noOverFlow:
-    print "Adding overflow to last bins, in 1D and 2D histograms"
+    print("Adding overflow to last bins, in 1D and 2D histograms")
 if not noUnderFlow:
-    print "Adding underflow to first bins, in 1D and 2D histograms"
+    print("Adding underflow to first bins, in 1D and 2D histograms")
 
 
 ##########################################################################################################################################
@@ -223,7 +224,7 @@ if not noUnderFlow:
 
 def getSystematicError(sample):
     errorSquared = 0.0
-    if types[sample] is "data":
+    if types[sample] == "data":
         return 0.0
 
     # add uncertainty on normalization method
@@ -249,7 +250,7 @@ def getSystematicError(sample):
 
     # add sample-specific uncertainties
     for uncertainty in unique_systematic_uncertainties:
-        if sample is unique_systematic_uncertainties[uncertainty]['dataset']:
+        if sample == unique_systematic_uncertainties[uncertainty]['dataset']:
             error = float(unique_systematic_uncertainties[uncertainty]['value']) -1
             errorSquared = errorSquared + error * error
 
@@ -257,7 +258,7 @@ def getSystematicError(sample):
     for uncertainty in external_systematic_uncertainties:
         input_file_path = os.environ['CMSSW_BASE'] + "/src/" + external_systematics_directory + "systematic_values__" + uncertainty + ".txt"
         if not os.path.exists(input_file_path):
-            print "   skipping",uncertainty,"systematic for the",channel,"channel"
+            print("   skipping",uncertainty,"systematic for the",channel,"channel")
             return 0
 
         input_file = open(input_file_path)
@@ -266,9 +267,9 @@ def getSystematicError(sample):
             dataset = line[0]
             if dataset != sample:
                 continue
-            if len(line) is 2: #just one error
+            if len(line) == 2: #just one error
                 error = float(line[1]) - 1
-            elif len(line) is 3: #asymmetric +- errors (we'll take the bigger one)
+            elif len(line) == 3: #asymmetric +- errors (we'll take the bigger one)
                 minus_error = float(line[1]) - 1
                 plus_error = float(line[2]) - 1
                 if abs(minus_error) > abs(plus_error):
@@ -331,7 +332,7 @@ def signifHistograms(BgSum,SignalMCHistograms):
 def MakeIntegralHist(hist, integrateDir):
     # return the integrated histogram, in the direction specified
     # integrateDir values: "left", "right", "none"
-    if integrateDir is "none":
+    if integrateDir == "none":
         return hist  # do nothing
     integral = 0
     error = 0
@@ -339,7 +340,7 @@ def MakeIntegralHist(hist, integrateDir):
     # always include underflow and overflow
     lowLimit = 0 # underflow bin
     uppLimit = nbins+1 # overflow bin
-    if integrateDir is "left":
+    if integrateDir == "left":
         for i in range(lowLimit, nbins+1):
             integral += hist.GetBinContent(i)
             error = math.sqrt(error*error + hist.GetBinError(i)*hist.GetBinError(i)) # sum errors in quadrature
@@ -348,7 +349,7 @@ def MakeIntegralHist(hist, integrateDir):
             # Then include overflow bin in the last bin
             hist.SetBinContent(nbins, hist.GetBinContent(nbins) + hist.GetBinContent(nbins+1))
             hist.SetBinError  (nbins, math.sqrt(hist.GetBinError(nbins)*hist.GetBinError(nbins) + hist.GetBinError(nbins+1)*hist.GetBinError(nbins+1)))
-    elif integrateDir is "right":
+    elif integrateDir == "right":
         for i in xrange(uppLimit, 0, -1):
             integral += hist.GetBinContent(i)
             error = math.sqrt(error*error + hist.GetBinError(i)*hist.GetBinError(i)) # sum errors in quadrature
@@ -409,7 +410,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
         if histsToBlind:
             for histToBlind in histsToBlind:
                 if histToBlind in histogramName:
-                    print "Blinding data for histogram " + histogramName
+                    print("Blinding data for histogram " + histogramName)
                     blindData = True
     except NameError:
         time.sleep(0.000001) # Do nothing if histsToBlind does not exist
@@ -559,7 +560,8 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
     CMSLabel.SetFillStyle(0)
 
     if makeFancy:
-        LumiLabel = TPaveLabel(topLeft_x_left,topLeft_y_bottom,topLeft_x_right,topLeft_y_top,"CMS Preliminary","NDC")
+        #LumiLabel = TPaveLabel(topLeft_x_left,topLeft_y_bottom,topLeft_x_right,topLeft_y_top,"CMS Preliminary","NDC")
+        LumiLabel = TPaveLabel(topLeft_x_left,topLeft_y_bottom,topLeft_x_right,topLeft_y_top,"CMS #bf{#it{Internal}}","NDC")
         LumiLabel.SetTextFont(62)
         LumiLabel.SetTextSize(0.8)
         LumiLabel.SetTextAlign(12)
@@ -613,9 +615,9 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
     if not arguments.paperConfig:
         outputFile.cd(pathToDir)
     canvasName = histogramName
-    if integrateDir is "left":
+    if integrateDir == "left":
         canvasName += "_CumulativeLeft"
-    if integrateDir is "right":
+    if integrateDir == "right":
         canvasName += "_CumulativeRight"
     Canvas = TCanvas(canvasName,"",4,55,872,850)
     Canvas.SetHighLightColor(2)
@@ -642,7 +644,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
     BgMCHistYieldsDic = {}
 
     if arguments.verbose:
-        print pathToDir+"/"+histogramName
+        print(pathToDir+"/"+histogramName)
 
     for sample in processed_datasets: # loop over different samples as listed in configurationOptions.py
         dataset_file = "%s/%s.root" % (condor_dir,sample)
@@ -650,7 +652,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
         inputFile = TFile(dataset_file)
         HistogramObj = inputFile.Get(pathToDir+"/"+histogramName)
         if not HistogramObj:
-            print "WARNING:  Could not find histogram " + pathToDir + "/" + histogramName + " in file " + dataset_file + ".  Will skip it and continue."
+            print("WARNING:  Could not find histogram " + pathToDir + "/" + histogramName + " in file " + dataset_file + ".  Will skip it and continue.")
             continue
         Histogram = HistogramObj.Clone()
         Histogram.SetDirectory(0)
@@ -694,7 +696,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
         xAxisLabelVar = xAxisLabel
         variableBinYaxisSet = YaxisTitleForVariableBinHist(Histogram)
 
-        if unitBeginIndex is not -1 and unitEndIndex is not -1: #x axis has a unit
+        if unitBeginIndex != -1 and unitEndIndex != -1: #x axis has a unit
             if variableBinYaxisSet['isVariable']:
                     yAxisLabel = "Entries / (Width_{Bin}/" + str(variableBinYaxisSet['smallestBinWidth']) + " " + xAxisLabel[unitBeginIndex+1:unitEndIndex] + ")"
             else:
@@ -709,7 +711,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
             yAxisLabel = yAxisLabel + " (Unit Area Norm.)"
         if normalizeToData:
             yAxisLabel = yAxisLabel + " (Bkgd. Scaled to Data)"
-        if scaleFactor is not 1:
+        if scaleFactor != 1:
             yAxisLabel = yAxisLabel + " (Bkgd. Scaled by " + str(scaleFactor) + ")"
 
         if renamePaperHistY:
@@ -720,9 +722,9 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
             unit = "Efficiency"
         else:
             unit = "Yield"
-        if integrateDir is "left":
+        if integrateDir == "left":
             yAxisLabel = unit + ", " + xAxisLabelVar + "< x (" + str(Histogram.GetXaxis().GetBinWidth(1)) + " bin width)"
-        if integrateDir is "right":
+        if integrateDir == "right":
             yAxisLabel = unit + ", " + xAxisLabelVar + "> x (" + str(Histogram.GetXaxis().GetBinWidth(1)) + " bin width)"
 
         if isProfile:
@@ -748,7 +750,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
             Histogram.SetBinError(1, math.sqrt(math.pow(Histogram.GetBinError(1), 2) + math.pow(Histogram.GetBinError(0), 2))) # Set the errors to be the sum in quadrature
 
         if arguments.verbose:
-            print "Sample = " + sample + ", types[sample] = " + types[sample]
+            print("Sample = " + sample + ", types[sample] = " + types[sample])
         if( types[sample] == "bgMC"):
 
             numBgMCSamples += 1
@@ -871,7 +873,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
 
 
     ### creating the histogram to represent the statistical errors on the stack
-    if numBgMCSamples is not 0 and not noStack and not isProfile:
+    if numBgMCSamples != 0 and not noStack and not isProfile:
         if includeSystematics:
             addSystematicError(BgMCHistograms[0],BgMCUncertainties[0])
         ErrorHisto = BgMCHistograms[0].Clone("errors")
@@ -908,7 +910,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
         #this is better than using #splitline{}{} because with that method, the hist line/marker gets misaligned
         #Split location (here char 113) will need to be changed for each long entry.
         if(len(SignalMCLegendEntries[legendIndex])>100):
-            #print "first 113 char are: "+str(SignalMCLegendEntries[legendIndex][:113])
+            #print("first 113 char are: "+str(SignalMCLegendEntries[legendIndex][:113]))
             firstLineEntry = str(SignalMCLegendEntries[legendIndex][:113])
             secondLineEntry = str(SignalMCLegendEntries[legendIndex][113:])
             SignalMCLegend.AddEntry(Histogram,firstLineEntry,"L")
@@ -919,7 +921,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
 
     ### finding the maximum value of anything going on the canvas, so we know how to set the y-axis
     finalMax = 0
-    if numBgMCSamples is not 0 and not noStack and not isProfile:
+    if numBgMCSamples != 0 and not noStack and not isProfile:
         finalMax = ErrorHisto.GetMaximum() + ErrorHisto.GetBinError(ErrorHisto.GetMaximumBin())
     else:
         for bgMCHist in BgMCHistograms:
@@ -959,12 +961,12 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
     if setLogY:
         gPad.SetLogy()
 
-    if numBgMCSamples is 0 or numDataSamples is not 1 or isProfile:
+    if numBgMCSamples == 0 or numDataSamples != 1 or isProfile:
         makeRatioPlots = False
         makeDiffPlots = False
-    if makeSignifPlots and (numBgMCSamples is 0 or numSignalSamples is 0):
-        print "Error:  you have requested to make significance plots, but you are missing either signal or background samples.  Will skip making the significance plots."
-        print "numBgMCSamples = " + str(numBgMCSamples) + "; numSignalSamples = " + str(numSignalSamples)
+    if makeSignifPlots and (numBgMCSamples == 0 or numSignalSamples == 0):
+        print("Error:  you have requested to make significance plots, but you are missing either signal or background samples.  Will skip making the significance plots.")
+        print("numBgMCSamples = " + str(numBgMCSamples) + "; numSignalSamples = " + str(numSignalSamples))
         makeSignifPlots = False
     if makeRatioPlots or makeDiffPlots or makeSignifPlots:
         Canvas.SetFillStyle(0)
@@ -989,7 +991,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
 
         Canvas.cd(1)
 
-    if numBgMCSamples is not 0: # the first thing to draw to the canvas is a bgMC sample
+    if numBgMCSamples != 0: # the first thing to draw to the canvas is a bgMC sample
 
         if not noStack and not isProfile: # draw stacked background samples
             Stack.SetTitle(histoTitle)
@@ -1037,7 +1039,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
         for dataHist in DataHistograms:
             dataHist.Draw("A E X0 SAME")
 
-    elif numSignalSamples is not 0: # the first thing to draw to the canvas is a signalMC sample
+    elif numSignalSamples != 0: # the first thing to draw to the canvas is a signalMC sample
         SignalMCHistograms[0].SetTitle(histoTitle)
         if not isProfile and not arguments.drawErrorsOnHists:
             SignalMCHistograms[0].Draw("HIST")
@@ -1049,7 +1051,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
         SignalMCHistograms[0].SetMinimum(yAxisMin)
         setXAxisRangeUser(SignalMCHistograms[0])
         for signalMCHist in SignalMCHistograms:
-            if(signalMCHist is not SignalMCHistograms[0]):
+            if(signalMCHist != SignalMCHistograms[0]):
                 if not isProfile and not arguments.drawErrorsOnHists:
                     signalMCHist.Draw("A HIST SAME")
                 else:
@@ -1059,7 +1061,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
 
 
 
-    elif(numDataSamples is not 0): # the first thing to draw to the canvas is a data sample
+    elif(numDataSamples != 0): # the first thing to draw to the canvas is a data sample
         DataHistograms[0].SetTitle(histoTitle)
         DataHistograms[0].Draw("E")
         DataHistograms[0].GetXaxis().SetTitle(xAxisLabel)
@@ -1069,7 +1071,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
             DataHistograms[0].SetMinimum(yAxisMin)
         setXAxisRangeUser(DataHistograms[0])
         for dataHist in DataHistograms:
-            if(dataHist is not DataHistograms[0]):
+            if(dataHist != DataHistograms[0]):
                 dataHist.Draw("A E X0 SAME")
 
 
@@ -1081,7 +1083,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
     y_max = 0.879562
     entry_height = 0.037307
 
-    if(numBgMCSamples is not 0 or numDataSamples is not 0): #then draw the data & bgMC legend
+    if(numBgMCSamples != 0 or numDataSamples != 0): #then draw the data & bgMC legend
 
 
         numExtraEntries = 0 # count the legend title
@@ -1104,7 +1106,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
             BgMCLegend.SetTextSize(0.0364078)
         BgMCLegend.Draw()
 
-    if (numSignalSamples is not 0 and arguments.paperConfig and 'SigLegX1' in paperHistogram): #then draw the signalMC legend to the left of the other one
+    if (numSignalSamples != 0 and arguments.paperConfig and 'SigLegX1' in paperHistogram): #then draw the signalMC legend to the left of the other one
         SignalMCLegend.SetX1NDC(float(paperHistogram['SigLegX1']))
         SignalMCLegend.SetY1NDC(float(paperHistogram['SigLegY1'])) # add one for the title
         SignalMCLegend.SetX2NDC(float(paperHistogram['SigLegX2']))
@@ -1112,7 +1114,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
         if arguments.paperConfig and 'SigTextSize' in paperHistogram:
             SignalMCLegend.SetTextSize(paperHistogram['SigTextSize'])
         SignalMCLegend.Draw()
-    elif (numSignalSamples is not 0):
+    elif (numSignalSamples != 0):
         SignalMCLegend.SetX1NDC(0.157471)
         SignalMCLegend.SetY1NDC(0.821602-entry_height*numSignalSamples) # add one for the title
         SignalMCLegend.SetX2NDC(0.355172)
@@ -1120,7 +1122,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
         SignalMCLegend.SetTextSize(0.0364078)
         SignalMCLegend.Draw()
 
-    if integrateDir is "left":
+    if integrateDir == "left":
         # Move the legend to the other side so it does not overlap with the cumulative histogram.
         BgMCLegend.SetX1NDC(topLeft_x_left + 0.05)
         BgMCLegend.SetX2NDC(topLeft_x_left + 0.05 + x_width)
@@ -1128,7 +1130,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
         BgMCLegend.SetY2NDC(-0.05 + y_max)
         BgMCLegend.Draw()
 
-    elif (numSignalSamples is not 0):
+    elif (numSignalSamples != 0):
         SignalMCLegend.SetX1NDC(x_left)
         SignalMCLegend.SetY1NDC(y_max-entry_height*numSignalSamples)
         SignalMCLegend.SetX2NDC(x_right)
@@ -1253,7 +1255,7 @@ def MakeTwoDHist(pathToDir,histogramName):
         if histsToBlind:
             for histToBlind in histsToBlind:
                 if histToBlind in histogramName:
-                    print "Blinding data for histogram " + histogramName
+                    print("Blinding data for histogram " + histogramName)
                     blindData = True
     except NameError:
         time.sleep(0.000001) # Do nothing if histsToBlind does not exist
@@ -1375,12 +1377,12 @@ def MakeTwoDHist(pathToDir,histogramName):
 
     for sample in processed_datasets: # loop over different samples as listed in configurationOptions.py
         if arguments.verbose:
-            print "Starting to process sample", sample
+            print("Starting to process sample", sample)
         dataset_file = "%s/%s.root" % (condor_dir,sample)
         inputFile = TFile(dataset_file)
         HistogramObj = inputFile.Get(pathToDir+"/"+histogramName)
         if not HistogramObj:
-            print "WARNING:  Could not find histogram " + pathToDir + "/" + histogramName + " in file " + dataset_file + ".  Will skip it and continue."
+            print("WARNING:  Could not find histogram " + pathToDir + "/" + histogramName + " in file " + dataset_file + ".  Will skip it and continue.")
             continue
         Histogram = HistogramObj.Clone()
         Histogram.SetDirectory(0)
@@ -1388,7 +1390,7 @@ def MakeTwoDHist(pathToDir,histogramName):
         if arguments.rebinFactor:
             RebinFactor = int(arguments.rebinFactor)
             #don't rebin histograms which will have less than 5 bins or any gen-matching histograms
-            if Histogram.GetNbinsX() >= RebinFactor*5 and Histogram.GetName().find("GenMatch") is -1:
+            if Histogram.GetNbinsX() >= RebinFactor*5 and Histogram.GetName().find("GenMatch") == -1:
                 Histogram.Rebin(RebinFactor)
         xAxisLabel = Histogram.GetXaxis().GetTitle()
         yAxisLabel = Histogram.GetYaxis().GetTitle()
@@ -1466,24 +1468,24 @@ def MakeTwoDHist(pathToDir,histogramName):
 
     #don't overlay the 2D plots, draw them separately with the colz option
     if arguments.unique2D:
-        if(numDataSamples is not 0):
+        if(numDataSamples != 0):
             DataHistograms[0].SetTitle(histoTitle)
             DataHistograms[0].GetXaxis().SetTitle(xAxisLabel)
             DataHistograms[0].GetYaxis().SetTitle(yAxisLabel)
             DataHistograms[0].Draw("colz")
-        elif(numSignalSamples is not 0):
+        elif(numSignalSamples != 0):
             SignalMCHistograms[0].SetTitle(histoTitle)
             SignalMCHistograms[0].GetXaxis().SetTitle(xAxisLabel)
             SignalMCHistograms[0].GetYaxis().SetTitle(yAxisLabel)
             SignalMCHistograms[0].Draw("colz")
-        elif(numBgMCSamples is not 0):
+        elif(numBgMCSamples != 0):
             BgMCHistograms[0].SetTitle(histoTitle)
             BgMCHistograms[0].GetXaxis().SetTitle(xAxisLabel)
             BgMCHistograms[0].GetYaxis().SetTitle(yAxisLabel)
             BgMCHistograms[0].Draw("colz")
 
     else:
-        if(numBgMCSamples is not 0):
+        if(numBgMCSamples != 0):
             BgMCHistograms[0].SetTitle(histoTitle)
             BgMCHistograms[0].GetXaxis().SetTitle(xAxisLabel)
             BgMCHistograms[0].GetYaxis().SetTitle(yAxisLabel)
@@ -1493,24 +1495,24 @@ def MakeTwoDHist(pathToDir,histogramName):
             for dataHist in DataHistograms:
                 dataHist.Draw("SAME")
 
-        elif(numSignalSamples is not 0):
+        elif(numSignalSamples != 0):
             SignalMCHistograms[0].SetTitle(histoTitle)
             SignalMCHistograms[0].Draw()
             SignalMCHistograms[0].GetXaxis().SetTitle(xAxisLabel)
             SignalMCHistograms[0].GetYaxis().SetTitle(yAxisLabel)
             for signalMCHist in SignalMCHistograms:
-                if(signalMCHist is not SignalMCHistograms[0]):
+                if(signalMCHist != SignalMCHistograms[0]):
                     signalMCHist.Draw("SAME")
             for dataHist in DataHistograms:
                 dataHist.Draw("SAME")
 
-        elif(numDataSamples is not 0):
+        elif(numDataSamples != 0):
             DataHistograms[0].SetTitle(histoTitle)
             DataHistograms[0].GetXaxis().SetTitle(xAxisLabel)
             DataHistograms[0].GetYaxis().SetTitle(yAxisLabel)
             DataHistograms[0].Draw()
             for dataHist in DataHistograms:
-                if(dataHist is not DataHistograms[0]):
+                if(dataHist != DataHistograms[0]):
                     dataHist.Draw("SAME")
 
 
@@ -1559,10 +1561,10 @@ def MakeTwoDHist(pathToDir,histogramName):
 
 
 
-    if(numBgMCSamples is not 0 or numDataSamples is not 0):
+    if(numBgMCSamples != 0 or numDataSamples != 0):
         if not arguments.unique2D:
             BgMCLegend.Draw()
-    if(numSignalSamples is not 0):
+    if(numSignalSamples != 0):
         if not arguments.unique2D:
             SignalMCLegend.Draw()
     if not arguments.paperConfig:
@@ -1616,21 +1618,21 @@ condor_dir = set_condor_output_dir(arguments)
 
 #### check which input datasets have valid output files
 if arguments.verbose:
-    print "Number of datasets: " + str(len(datasets))
-    print datasets
+    print("Number of datasets: " + str(len(datasets)))
+    print(datasets)
 for sample in datasets:
     fileName = condor_dir + "/" + sample + ".root"
     if arguments.verbose:
-        print "Adding fileName: " + fileName
+        print("Adding fileName: " + fileName)
     if not os.path.exists(fileName):
-        print "WARNING: didn't find ",fileName
+        print("WARNING: didn't find ",fileName)
         continue
     testFile = TFile(fileName)
     if testFile.IsZombie() or not testFile.GetNkeys():
         continue
     processed_datasets.append(sample)
 
-if len(processed_datasets) is 0:
+if len(processed_datasets) == 0:
     sys.exit("No datasets have been processed")
 
 if arguments.savePDFs:
@@ -1752,4 +1754,4 @@ for key in inputFile.GetListOfKeys():
 
 
 outputFile.Close()
-print "Finished writing plots to", str(outputDir + "/" + outputFileName)
+print("Finished writing plots to", str(outputDir + "/" + outputFileName))

--- a/Configuration/scripts/makePlots.py
+++ b/Configuration/scripts/makePlots.py
@@ -178,8 +178,7 @@ topLeft_y_offset  = 0.04
 
 #set the text for the fancy heading
 #HeaderText = "CMS Preliminary: " + LumiText + " at #sqrt{s} = 8 TeV"
-#HeaderText = LumiText + " (13 TeV)"
-HeaderText = "(13 TeV)"
+HeaderText = LumiText + " (13 TeV)"
 
 #position for header
 header_x_left    = 0.602535
@@ -560,8 +559,7 @@ def MakeOneDHist(pathToDir,histogramName,integrateDir):
     CMSLabel.SetFillStyle(0)
 
     if makeFancy:
-        #LumiLabel = TPaveLabel(topLeft_x_left,topLeft_y_bottom,topLeft_x_right,topLeft_y_top,"CMS Preliminary","NDC")
-        LumiLabel = TPaveLabel(topLeft_x_left,topLeft_y_bottom,topLeft_x_right,topLeft_y_top,"CMS #bf{#it{Internal}}","NDC")
+        LumiLabel = TPaveLabel(topLeft_x_left,topLeft_y_bottom,topLeft_x_right,topLeft_y_top,"CMS Preliminary","NDC")
         LumiLabel.SetTextFont(62)
         LumiLabel.SetTextSize(0.8)
         LumiLabel.SetTextAlign(12)

--- a/Configuration/scripts/makeSinglePlot.py
+++ b/Configuration/scripts/makeSinglePlot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import re
@@ -135,7 +135,7 @@ for histogram in input_histograms:
 
     fullTitle = Histogram.GetTitle()
     splitTitle = fullTitle.split(":")
-#    print splitTitle
+#    print(splitTitle)
     Histogram.SetTitle(splitTitle[1].lstrip(" "))
 
     Histogram.SetMarkerColor(histogram['color'])
@@ -159,7 +159,7 @@ for histogram in input_histograms:
 
 
 makeRatioPlots = arguments.makeRatioPlots
-if len(Histograms) is not 2:
+if len(Histograms) != 2:
     makeRatioPlots = False
 
 Canvas = TCanvas(re.sub (r".root$", r"", outputFileName))
@@ -191,7 +191,7 @@ for Histogram in Histograms:
     if makeRatioPlots or makeDiffPlots:
         Histogram.GetXaxis().SetLabelSize(0)
 
-    if counter is 0:
+    if counter == 0:
         Histogram.SetMaximum(1.1*finalMax)
         Histogram.SetMinimum(0.0001)
         Histogram.Draw(plotting_options)
@@ -230,8 +230,8 @@ Canvas.Write()
 if arguments.plot_savePdf:
     pdfFileName = outputFileName.replace(".root", ".pdf")
     Canvas.SaveAs(pdfFileName)
-    print "Saved file:  " + pdfFileName
+    print("Saved file:  " + pdfFileName)
 
 
 outputFile.Close()
-print "Saved plot in file: " + outputFileName
+print("Saved plot in file: " + outputFileName)

--- a/Configuration/scripts/makeYieldsTables.py
+++ b/Configuration/scripts/makeYieldsTables.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import re
@@ -64,7 +64,7 @@ newLine = " \n"
 
 def getSystematicError(sample):
     errorSquared = 0.0
-    if types[sample] is "data":
+    if types[sample] == "data":
         return 0.0
 
     # add uncertainty on normalization method
@@ -92,7 +92,7 @@ def getSystematicError(sample):
     for uncertainty in external_systematic_uncertainties:
         input_file_path = os.environ['CMSSW_BASE'] + "/src/" + external_systematics_directory + "systematic_values__" + uncertainty + ".txt"
         if not os.path.exists(input_file_path):
-            print "   skipping",uncertainty,"systematic for the",channel,"channel"
+            print("   skipping",uncertainty,"systematic for the",channel,"channel")
             return 0
 
         input_file = open(input_file_path)
@@ -101,9 +101,9 @@ def getSystematicError(sample):
             dataset = line[0]
             if dataset != sample:
                 continue
-            if len(line) is 2: #just one error
+            if len(line) == 2: #just one error
                 error = float(line[1]) - 1
-            elif len(line) is 3: #asymmetric +- errors (we'll take the bigger one)
+            elif len(line) == 3: #asymmetric +- errors (we'll take the bigger one)
                 minus_error = float(line[1]) - 1
                 plus_error = float(line[2]) - 1
                 if abs(minus_error) > abs(plus_error):
@@ -129,8 +129,8 @@ for dataset in datasets:
         processed_datasets.append(dataset)
 
 #### exit if no datasets found
-if len(processed_datasets) is 0:
-    print datasets
+if len(processed_datasets) == 0:
+    print(datasets)
     sys.exit("Can't find any output root files for the given list of datasets")
 
 
@@ -171,7 +171,7 @@ for sample in processed_datasets:
         if not arguments.inputHistogram:
             cutFlowHistogram = inputFile.Get(channel+"/cutFlow")
             if not cutFlowHistogram:
-                print "WARNING: didn't find cutflow for ", sample, "dataset in", channel, "channel"
+                print("WARNING: didn't find cutflow for ", sample, "dataset in", channel, "channel")
                 continue
             yield_ = cutFlowHistogram.GetBinContent(cutFlowHistogram.GetNbinsX())
             statError_ = cutFlowHistogram.GetBinError(cutFlowHistogram.GetNbinsX())
@@ -180,7 +180,7 @@ for sample in processed_datasets:
             newChannel = channel.replace("CutFlow","")
             inputHistogram = inputFile.Get(newChannel + "/" + arguments.inputHistogram)
             if not inputHistogram:
-                print "WARNING: didn't find input histogram for ", sample, "dataset in", newChannel, "channel"
+                print("WARNING: didn't find input histogram for ", sample, "dataset in", newChannel, "channel")
                 continue
             statError_ = Double(0.0)
             yield_ = inputHistogram.IntegralAndError(0, inputHistogram.GetNbinsX()+1, statError_)
@@ -193,14 +193,14 @@ for sample in processed_datasets:
         else:
             sysError_ = 0.0
         roundedNumbersDictionary = roundingNumbers(yield_,statError_,sysError_)
-        if types[sample] is "data":
+        if types[sample] == "data":
             yields[sample][channel] = str(int(yield_))
         else:
             yields[sample][channel] = str(roundedNumbersDictionary['central_value'])
         stat_errors[sample][channel] = str(roundedNumbersDictionary['stat_error'])
         sys_errors[sample][channel] = str(roundedNumbersDictionary['syst_error'])
 
-        if types[sample] is "bgMC":
+        if types[sample] == "bgMC":
             bgMCSum[channel] = bgMCSum[channel] + yield_
             bgMCStatErrSquared[channel] = bgMCStatErrSquared[channel] + statError_*statError_
             bgMCSysErrSquared[channel] = bgMCSysErrSquared[channel] + sysError_*sysError_
@@ -226,7 +226,7 @@ for channel in channels:
     #write a line for each background sample
     bgMCcounter = 0
     for sample in processed_datasets_channels[channel]:
-        if types[sample] is not "bgMC":
+        if types[sample] != "bgMC":
             continue
 
         bgMCcounter = bgMCcounter + 1
@@ -239,7 +239,7 @@ for channel in channels:
         fout.write(line)
 
     #write a line with the sum of the backgrounds
-    if bgMCcounter is not 0:
+    if bgMCcounter != 0:
         roundedNumbersDictionary = roundingNumbers(bgMCSum[channel], math.sqrt(bgMCStatErrSquared[channel]),math.sqrt(bgMCSysErrSquared[channel]))
         bgMCSum_ = str(roundedNumbersDictionary['central_value'])
         bgMCStatErr_ = str(roundedNumbersDictionary['stat_error'])
@@ -252,7 +252,7 @@ for channel in channels:
 
     #write a line for each data sample
     for sample in processed_datasets_channels[channel]:
-        if types[sample] is not "data":
+        if types[sample] != "data":
             continue
 
         label =  "Observation"
@@ -262,7 +262,7 @@ for channel in channels:
     #write a line for each signal sample
     signalCounter = 0
     for sample in processed_datasets_channels[channel]:
-        if types[sample] is not "signalMC":
+        if types[sample] != "signalMC":
             continue
         signalCounter += 1
         rawlabel = labels[sample]
@@ -292,7 +292,4 @@ for channel in channels:
         #os.system("rm %s" % outputFile)
         os.unlink ("%saux" % (outputFile.rstrip("tex")))
         os.unlink ("%slog" % (outputFile.rstrip("tex")))
-        print "Finished writing cutFlow to " + outputFile + " and compiling pdf"
-
-
-
+        print("Finished writing cutFlow to " + outputFile + " and compiling pdf")

--- a/Configuration/scripts/mergeOut.py
+++ b/Configuration/scripts/mergeOut.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from optparse import OptionParser
 from OSUT3Analysis.Configuration.processingUtilities import *
@@ -36,7 +36,7 @@ from OSUT3Analysis.Configuration.mergeUtilities import *
 ###############################################################################
 CondorDir = ''
 if arguments.condorDir == "":
-    print "No working directory is given, aborting."
+    print("No working directory is given, aborting.")
     sys.exit()
 else:
     CondorDir = os.getcwd() + '/condor/' + arguments.condorDir
@@ -59,16 +59,16 @@ if arguments.localConfig:
     split_datasets = split_composite_datasets(datasets, composite_dataset_definitions)
     IntLumi = intLumi
     if arguments.Dataset:
-        print "ERROR:  The -d and -l options cannot be used simultaneously."
+        print("ERROR:  The -d and -l options cannot be used simultaneously.")
         exit(0)
 
 if not arguments.localConfig:
     if arguments.Dataset == "":
-        print "There are no datasets to merge!"
+        print("There are no datasets to merge!")
     else:
         split_datasets.append(arguments.Dataset)
 
-if arguments.IntLumi is not "":
+if arguments.IntLumi != "":
     IntLumi = float(arguments.IntLumi)
 
 # Remove duplicates
@@ -80,40 +80,40 @@ if "optional_dict_ntupleEff" not in locals () and "optional_dict_ntupleEff" not 
 
 currentCondorSubArgumentsSet = {}
 if arguments.verbose:
-    print "List of datasets: ", split_datasets
+    print("List of datasets: ", split_datasets)
 if not arguments.compositeOnly and not arguments.UseCondor:
     for dataSet in split_datasets:
         mergeOneDataset(dataSet, IntLumi, CondorDir, OutputDir, optional_dict_ntupleEff, verbose = arguments.verbose, skipMerging = arguments.skipMerging)
 
 if arguments.UseCondor:
     # Make necessary files for condor and submit condor jobs.
-    print '......................Using Condor!...........................'
+    print('......................Using Condor!...........................')
     currentCondorSubArgumentsSet = copy.deepcopy(CondorSubArgumentsSet)
     GetCompleteOrderedArgumentsSet(InputCondorArguments, currentCondorSubArgumentsSet)
     MakeSubmissionScriptForMerging(CondorDir, currentCondorSubArgumentsSet, split_datasets)
     MakeMergingConfigForCondor(CondorDir, OutputDir, split_datasets, IntLumi, optional_dict_ntupleEff)
     os.chdir(CondorDir)
     if arguments.NotToExecute:
-        print 'Configuration files created in ' + str(CondorDir) + ' directory but no jobs submitted.\n'
+        print('Configuration files created in ' + str(CondorDir) + ' directory but no jobs submitted.\n')
     else:
         os.system('condor_submit condorMerging.sub')
 else:
     os.chdir(CondorDir)
     for dataSet_component in composite_datasets:
-        print "................Merging composite dataset " + dataSet_component + " ................"
+        print("................Merging composite dataset " + dataSet_component + " ................")
         memberList = []
         for dataset in composite_dataset_definitions[dataSet_component]:
             if not os.path.exists(dataset + '.root'):
-                print dataset + '.root does not exist, component dataset ' + dataSet_component + ' wont be complete!'
+                print(dataset + '.root does not exist, component dataset ' + dataSet_component + ' wont be complete!')
                 continue
             memberList.append(dataset + '.root')
         InputFileString = " ".join (memberList)
         os.system('mergeTFileServiceHistograms -i ' + InputFileString + ' -o ' + OutputDir + "/" + dataSet_component + '.root')
-        print 'Finish merging composite dataset ' + dataSet_component
-        print "...............................................................\n"
+        print('Finish merging composite dataset ' + dataSet_component)
+        print("...............................................................\n")
 
 if arguments.UseCondor:
-    print "After all condor merging jobs have finished, rerun mergeOut.py with the -C option to merge composite datasets."
+    print("After all condor merging jobs have finished, rerun mergeOut.py with the -C option to merge composite datasets.")
 elif not arguments.compositeOnly:
-    print "Next time, consider using the -c option to send the merging jobs to the condor queue."
-print "Finished mergeOut.py."
+    print("Next time, consider using the -c option to send the merging jobs to the condor queue.")
+print("Finished mergeOut.py.")

--- a/Configuration/scripts/mergeOutputHadd.py
+++ b/Configuration/scripts/mergeOutputHadd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Script to merge the output of root files that do not contain cutflow histograms.
 # This is much simpler than mergeOutput.py:  it only runs hadd for the histograms in the specified datasets.
@@ -54,10 +54,10 @@ for dataset in datasets:
     numberOfInputFiles = len(files)
     for i in range(0,numberOfInputFiles):
         inputFiles.append(path + "/" + files[i])
-    print "Number of input files is: " + str(numberOfInputFiles)
+    print("Number of input files is: " + str(numberOfInputFiles))
     mergeEvery = 500
     numberOfPartialFiles = int(math.ceil(1.0*numberOfInputFiles/mergeEvery))
-    print "Number of Partial Files is: " + str(numberOfPartialFiles)
+    print("Number of Partial Files is: " + str(numberOfPartialFiles))
     outputFiles = []
     for i in range(0,numberOfPartialFiles):
         partialListOfInputFiles = inputFiles[(i*mergeEvery):((i+1)*mergeEvery)]
@@ -69,8 +69,8 @@ for dataset in datasets:
     rmCommand = "rm partial*.root"
     subprocess.call(rmCommand,shell=True)
 
-print "Merge complete"
+print("Merge complete")
 if missing_directories:
-    print "The following directories were not found and the corresponding datasets were skipped:"
+    print("The following directories were not found and the corresponding datasets were skipped:")
     for path in missing_directories:
-        print path
+        print(path)

--- a/Configuration/scripts/mergePdf.py
+++ b/Configuration/scripts/mergePdf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Merge several pdf's into one
 # Usage:
@@ -8,7 +8,7 @@ import os
 import sys
 
 if len(sys.argv) < 3:
-    print "Error:  Must specify as arguments the output merged file and source files."
+    print("Error:  Must specify as arguments the output merged file and source files.")
     exit(0)
 
 command = "gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile="
@@ -20,8 +20,7 @@ for i in range(2,len(sys.argv)):
 #    sources.append(sys.argv[i])
     command += " " + sys.argv[i]
 
-print "command = ", command
+print("command = ", command)
 
 os.system(command)
-print "Finished merging files to ", merged
-
+print("Finished merging files to ", merged)

--- a/Configuration/scripts/mergeSkims.py
+++ b/Configuration/scripts/mergeSkims.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Script to merge skim output files into a single file.
 
@@ -25,7 +25,7 @@ parser.add_option("-v", "--verbose", dest="verbose", action="store_true", defaul
 ###############################################################################
 CondorDir = ''
 if arguments.condorDir == "":
-    print "No working directory is given, aborting."
+    print("No working directory is given, aborting.")
     sys.exit()
 else:
     condorDir = os.getcwd() + '/condor/' + arguments.condorDir
@@ -42,7 +42,7 @@ if arguments.localConfig:
 elif arguments.dataset != "":
     split_datasets.append(arguments.dataset)
 else:
-    print "There are no datasets to merge!"
+    print("There are no datasets to merge!")
 
 
 ###############################################################################
@@ -51,7 +51,7 @@ else:
 for dataset in split_datasets:
     directory = condorDir + '/' + dataset
     if not os.path.exists(directory):
-        print directory + " does not exist, will skip it and continue!"
+        print(directory + " does not exist, will skip it and continue!")
         continue
     os.chdir(directory)
 
@@ -68,8 +68,7 @@ for dataset in split_datasets:
         command = command[:-1]  # Remove trailing comma
         command += '" outputFile="' + channel + 'merged/skimMerged.root"'
         if arguments.verbose:
-            print "command = ", command
+            print("command = ", command)
         os.makedirs (directory + "/" + channel + "merged")
         os.system(command)
-        print "Created condor/" + arguments.condorDir + "/" + dataset + "/" + channel + "merged/skimMerged.root"
-
+        print("Created condor/" + arguments.condorDir + "/" + dataset + "/" + channel + "merged/skimMerged.root")

--- a/Configuration/scripts/pickEvents.py
+++ b/Configuration/scripts/pickEvents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import re
 from OSUT3Analysis.Configuration.configurationOptions import *
@@ -35,7 +35,7 @@ RedirectorDic = {'Infn':'xrootd.ba.infn.it','FNAL':'cmsxrootd.fnal.gov','Global'
 def createEventList():
     files = os.popen('ls skim*root -1 2>/dev/null').read().split('\n')
     files.extend (os.popen('ls emptySkim*root -1 2>/dev/null').read().split('\n'))
-    print "Files = ", files
+    print("Files = ", files)
     eventList = ""
     nEventsTot = 0
     for f in files:
@@ -44,15 +44,15 @@ def createEventList():
         nEvents = -1
         logFileUtil = os.popen('edmFileUtil    -f ' + f).read().split(' ')  # First get number of events
         if arguments.verbose:
-            print "Debug: logFileUtil = ", logFileUtil
+            print("Debug: logFileUtil = ", logFileUtil)
         for i in range(len(logFileUtil)-1, -1, -1):  # Iterate backwards over the words in the output.
             if "events" in logFileUtil[i]:
                 nEvents = int(logFileUtil[i-1])  # The number of events comes immediately before the word "events"
         if arguments.verbose:
-            print "Debug:  nEvents = ", nEvents, "file = ", f, " nEventsTot = ", nEventsTot, ", maxEvents = ", arguments.maxEvents
+            print("Debug:  nEvents = ", nEvents, "file = ", f, " nEventsTot = ", nEventsTot, ", maxEvents = ", arguments.maxEvents)
         if nEvents < 0:
-            print "ERROR: Failed to find valid number of events for file: ", f
-            print "Will exit prematurely."
+            print("ERROR: Failed to find valid number of events for file: ", f)
+            print("Will exit prematurely.")
             exit(0)
         if nEventsTot > int(arguments.maxEvents) and int(arguments.maxEvents) > 0:
             break
@@ -65,7 +65,7 @@ def createEventList():
             words = filter(None, words) # Remove empty elements
             # Content of lines corresponding to a valid event is in the format:
             # Run           Lumi          Event    TTree Entry
-            # print "Debug:  checking line=", line, "words=", words
+            # print("Debug:  checking line=", line, "words=", words)
             if len(words) == 4:
                 run  = words[0]
                 lumi = words[1]
@@ -73,9 +73,9 @@ def createEventList():
                 eventList += run + ":" + lumi + ":" + evt + "\n"
                 nFoundEvts += 1
                 if arguments.verbose:
-                    print "Debug:  filling words for line: ", line, ", run = ", run, "lumi = ", lumi
+                    print("Debug:  filling words for line: ", line, ", run = ", run, "lumi = ", lumi)
         if int(arguments.maxEvents) < 0 and nFoundEvts != nEvents:
-            print "ERROR:  Number of found events = ", nFoundEvts, " does not match number of expected events = ", nEvents, ".  Please investigate."
+            print("ERROR:  Number of found events = ", nFoundEvts, " does not match number of expected events = ", nEvents, ".  Please investigate.")
             exit(0)
         nEventsTot += nEvents
     fout = open("pickevents.txt", "w")
@@ -91,34 +91,34 @@ def runEdmPickEvents(dataset):
         datasetName = datasetName.replace(orig, new)
     if arguments.parent:
         query = 'das_client.py --query="parent dataset=' + datasetName + ' instance=prod/phys03" --limit=0'
-        print "Executing query:  ", query
+        print("Executing query:  ", query)
         datasets = os.popen(query).read().split('\n')
         datasetName = datasets[0]
-        print "Will use dataset: ", datasetName
+        print("Will use dataset: ", datasetName)
     cmd = 'edmPickEvents.py "' + datasetName + '" pickevents.txt --printInteractive > pickevents.src'
     if arguments.verbose:
-        print "Running command: ", cmd
+        print("Running command: ", cmd)
     os.system(cmd)
     redirector = RedirectorDic[arguments.Redirector]
     # Replace "/store/" with, e.g., root://cmsxrootd.fnal.gov///store/
     os.system('sed -i "s_/store/_root://' + redirector + '///store/_g" pickevents.src')
     if arguments.noExecute:
-        print "Created command file: " + os.getcwd() + "/pickevents.src"
+        print("Created command file: " + os.getcwd() + "/pickevents.src")
     else:
         os.system("source pickevents.src")
-        print "Created and executed command file: " + os.getcwd() + "/pickevents.src"
+        print("Created and executed command file: " + os.getcwd() + "/pickevents.src")
 
 
 def doOneDirectory(directory):
     if not os.path.exists(directory):
-        print directory + " does not exist, will skip it and continue!"
+        print(directory + " does not exist, will skip it and continue!")
         return
     os.chdir(directory)
     createEventList()
     if not arguments.eventsOnly:
         runEdmPickEvents(dataset)
     else:
-        print "Created event list: " + os.getcwd() + "/pickevents.txt"
+        print("Created event list: " + os.getcwd() + "/pickevents.txt")
 
 
 
@@ -127,7 +127,7 @@ def doOneDirectory(directory):
 ###############################################################################
 CondorDir = ''
 if arguments.condorDir == "":
-    print "No working directory is given, aborting."
+    print("No working directory is given, aborting.")
     sys.exit()
 else:
     condorDir = os.getcwd() + '/condor/' + arguments.condorDir
@@ -142,7 +142,7 @@ if arguments.localConfig:
     composite_datasets = get_composite_datasets(datasets, composite_dataset_definitions)
     split_datasets   = split_composite_datasets(datasets, composite_dataset_definitions)
 else:
-    print "There are no datasets specified!"
+    print("There are no datasets specified!")
     exit(0)
 
 
@@ -155,4 +155,3 @@ for dataset in split_datasets:
     p = Process(target=doOneDirectory, args=(directory,))
     p.start()
     p.join()
-

--- a/Configuration/scripts/rewtHist.py
+++ b/Configuration/scripts/rewtHist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # rewtHist.py
 # Reweights a specified histogram for a list of datasets by the weights specified in a weight histogram.
@@ -53,23 +53,23 @@ condor_dir = set_condor_output_dir(arguments)
 def rewtOneHist(dataset, hwts):
     fileName = condor_dir + "/" + dataset + ".root"
     if not os.path.exists(fileName):
-        print "WARNING: didn't find ",fileName
+        print("WARNING: didn't find ",fileName)
         return
-    print "About to reweight histogram in " + fileName
+    print("About to reweight histogram in " + fileName)
     inFile = TFile(fileName, "UPDATE")
     if inFile.IsZombie() or not inFile.GetNkeys():
         return
     inFile.cd()
     h = inFile.Get(str(arguments.histToBeReWeighted)).Clone()
     if not h:
-        print "  Could not find hist named " + arguments.histToBeReWeighted + " in " + inFile.GetName()
+        print("  Could not find hist named " + arguments.histToBeReWeighted + " in " + inFile.GetName())
         return
     h.SetDirectory(0)
     newName = h.GetName() + str(arguments.suffixRename)
     h.SetName(newName)
     dir = arguments.histToBeReWeighted
     dir = dir[:dir.rfind("/")]
-    print "Will write hist to directory " + dir
+    print("Will write hist to directory " + dir)
     inFile.cd(dir)
     tdir = inFile.GetDirectory(dir)
     tdir.Delete(newName + ";*")
@@ -87,7 +87,7 @@ def rewtOneHist(dataset, hwts):
 ########################################################################################
 ########################################################################################
 
-print "Will take weights from hist " + str(arguments.weightsHist) + " in " + str(arguments.fileWithWtHist)
+print("Will take weights from hist " + str(arguments.weightsHist) + " in " + str(arguments.fileWithWtHist))
 
 fileWithWtHist = TFile(str(arguments.fileWithWtHist))
 hwts = fileWithWtHist.Get(arguments.weightsHist)
@@ -100,9 +100,4 @@ for dataset in datasets:
     rewtOneHist(dataset, hwts)
 
 
-print "Finished rewtHist.py successfully."
-
-
-
-
-
+print("Finished rewtHist.py successfully.")

--- a/ControlRegions/test/doubleElectronOptions.py
+++ b/ControlRegions/test/doubleElectronOptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 config_file = "doubleElectronAnalyzer_cfg.py"
 intLumi = 19709.  # DoubleElectron

--- a/ControlRegions/test/doubleMuOptions.py
+++ b/ControlRegions/test/doubleMuOptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 config_file = "doubleMuAnalyzer_cfg.py"
 intLumi = 19040.  # DoubleMu
@@ -35,4 +35,3 @@ datasets = [
     'QCD_MuEnriched',
 
 ]
-

--- a/ControlRegions/test/muEGOptions.py
+++ b/ControlRegions/test/muEGOptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 config_file = "muEGAnalyzer_cfg.py"
 intLumi = 19487.  # MuEG
@@ -35,4 +35,3 @@ datasets = [
 ##     'QCD_MuEnriched',
 
 ]
-

--- a/ControlRegions/test/singleElectronOptions.py
+++ b/ControlRegions/test/singleElectronOptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 config_file = "singleElectronAnalyzer_cfg.py"
 #intLumi = 19183. # Full SingleElectron
@@ -36,4 +36,3 @@ datasets = [
     'QCD_ElectronEnriched',
 
 ]
-

--- a/ControlRegions/test/singleMuOptions.py
+++ b/ControlRegions/test/singleMuOptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 config_file = "singleMuAnalyzer_cfg.py"
 #intLumi = 19417.  # Full SingleMu
@@ -36,4 +36,3 @@ datasets = [
     'QCD_MuEnriched',
 
 ]
-

--- a/ControlRegions/test/zToMuMuOptions.py
+++ b/ControlRegions/test/zToMuMuOptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 config_file = "zToMuMuAnalyzer_cfg.py"
 intLumi = 19040.  # DoubleMu
@@ -18,4 +18,3 @@ datasets = [
     'DYToMuMu_20',
 
 ]
-

--- a/DBTools/python/condorSubArgumentsSet.py
+++ b/DBTools/python/condorSubArgumentsSet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import socket
 

--- a/DBTools/python/osusub_cfg.py
+++ b/DBTools/python/osusub_cfg.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import math
 # For jobs with input datasets, normal cases: cmsRun config_cfg.py True 671 $(Process) /DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v3/MINIAODSIM DYJetsToLL_50_MiniAOD
@@ -6,7 +7,7 @@ if len (sys.argv) == 7 and sys.argv[2] == "True":
   Label = str(sys.argv[6])
   jobNumber = int (sys.argv[4])
   if int (sys.argv[3]) != 0 and sys.argv[5] != "NULL":
-    exec("import datasetInfo_" + Label +"_cfg as datasetInfo")
+    exec("import datasetInfo_" + Label +"_cfg as datasetInfo", globals(), globals())
     filesPerJob = int (math.floor (len (datasetInfo.listOfFiles) / nJobs))
     residualLength = int(len(datasetInfo.listOfFiles)%nJobs)
     if jobNumber < residualLength:
@@ -32,7 +33,7 @@ def getSiblings (fileName, dataset):
     from dbs.apis.dbsClient import DbsApi
     from CRABClient.ClientUtilities import DBSURLS
   except ImportError:
-    print "getSiblings() relies on CRAB. Please set up the environment for CRAB before using."
+    print("getSiblings() relies on CRAB. Please set up the environment for CRAB before using.")
     sys.exit (1)
 
   dbsurl_global = DBSURLS["reader"].get ("global", "global")

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import getpass
 import os
@@ -157,7 +157,7 @@ def getLatestJsonFile():
 
     else:
         if len(arguments.JSONType.split('_')) < 2:
-            print "Argument for -J is wrong, it needs to be in a format similar to \"R_Silver\""
+            print("Argument for -J is wrong, it needs to be in a format similar to \"R_Silver\"")
             sys.exit(1)
 
         if re.search('16$', arguments.JSONType):
@@ -239,9 +239,9 @@ def getLatestJsonFile():
             runRange = 0
 
             if len(jsonFileFiltered) == 0:
-                print "#######################################################"
-                print A_BRIGHT_RED + "Warning!!!!!!!!!!!Could not find wanted JSON file" + A_RESET
-                print "#######################################################"
+                print("#######################################################")
+                print(A_BRIGHT_RED + "Warning!!!!!!!!!!!Could not find wanted JSON file" + A_RESET)
+                print("#######################################################")
 
             for json in jsonFileFiltered:
                 nameSplit = json.split('_')
@@ -315,9 +315,9 @@ def getLatestJsonFile():
                                 jsonFileFiltered.append(fileName)
 
             if len(jsonFileFiltered) == 0:
-                print "#######################################################"
-                print A_BRIGHT_RED + "Warning!!!!!!!!!!!Could not find wanted JSON file" + A_RESET
-                print "#######################################################"
+                print("#######################################################")
+                print(A_BRIGHT_RED + "Warning!!!!!!!!!!!Could not find wanted JSON file" + A_RESET)
+                print("#######################################################")
 
             ultimateJson = jsonFileFiltered[-1]
             subprocess.call('wget https://cms-service-dqmdc.web.cern.ch/CAF/certification/' + collisionType + '/13TeV/' + rerecoDir + '/' + ultimateJson + ' -O ' + tmpDir + "/" + ultimateJson, shell = True)
@@ -338,9 +338,9 @@ def MakeSkimDirectory(SkimDir, lpcCAF):
                 msg = subprocess.check_output(['xrd', 'cmseos.fnal.gov', 'mkdir', os.path.realpath(SkimDir)])
                 return True
             except subprocess.CalledProcessError as e:
-                print 'Creating directory "' + str(SkimDir) + '" failed with error:'
-                print e
-                print 'Aborting.'
+                print('Creating directory "' + str(SkimDir) + '" failed with error:')
+                print(e)
+                print('Aborting.')
                 sys.exit(1)
     else:
         if os.path.exists(SkimDir):
@@ -361,8 +361,8 @@ def WriteTextToFile(textBody, filePath, lpcCAF):
         try:
             msg = subprocess.check_output(['xrdcp', tmpFilePath, 'root://cmseos.fnal.gov/' + os.path.realpath(filePath)])
         except subprocess.CalledProcessError as e:
-            print 'Failed to copy', tmpFilePath, 'to root://cmseos.fnal.gov/' + os.path.realpath(filePath), 'with error:'
-            print e
+            print('Failed to copy', tmpFilePath, 'to root://cmseos.fnal.gov/' + os.path.realpath(filePath), 'with error:')
+            print(e)
         shutil.rmtree(tmpDir)
     else:
         f = open(filePath, 'w')
@@ -431,14 +431,14 @@ def GetCommandLineString():
 def GetListOfRootFiles(Path):
     fileList = os.popen('ls ' + Path + '/*.root').read().split('\n')  # remove '\n' from each word
     for f in fileList:
-        if len(f) is 0:
+        if len(f) == 0:
             fileList.remove(f)   # remove empty filename
     return fileList
 
 def GetListOfRemoteRootFiles(Path):
     fileList = []
     if not len(Path.split('//')) == 3 or not Path.startswith('root://'):
-        print 'Remote directories must be of the form \"root://<redirector>//store/...\"'
+        print('Remote directories must be of the form \"root://<redirector>//store/...\"')
         return fileList
     thisRedirector = Path.split('//')[0] + '//' + Path.split('//')[1] + '/'
     thisRemotePath = '/' + Path.split('//')[2]
@@ -460,18 +460,18 @@ def MakeCondorSubmitScript(Dataset,NumberOfJobs,Directory,Label, SkimChannelName
     directoriesToTransfer = []
     SubmitFile.write("# Command line arguments:\n# " + GetCommandLineString() + "\n\n\n")
     for argument in sorted(currentCondorSubArgumentsSet):
-        if currentCondorSubArgumentsSet[argument].has_key('Executable') and currentCondorSubArgumentsSet[argument]['Executable'] == "":
+        if 'Executable' in currentCondorSubArgumentsSet[argument] and currentCondorSubArgumentsSet[argument]['Executable'] == "":
             SubmitFile.write('Executable = condor.sh\n')
-        elif currentCondorSubArgumentsSet[argument].has_key('Arguments') and currentCondorSubArgumentsSet[argument]['Arguments'] == "":
+        elif 'Arguments' in currentCondorSubArgumentsSet[argument] and currentCondorSubArgumentsSet[argument]['Arguments'] == "":
             SubmitFile.write('Arguments = config_cfg.py True ' + str(NumberOfJobs) + ' $(Process) ' + Dataset + ' ' + Label + '\n\n')
-        elif currentCondorSubArgumentsSet[argument].has_key('Transfer_Input_files') and currentCondorSubArgumentsSet[argument]['Transfer_Input_files'] == "":
+        elif 'Transfer_Input_files' in currentCondorSubArgumentsSet[argument] and currentCondorSubArgumentsSet[argument]['Transfer_Input_files'] == "":
             FilesToTransfer = os.environ["CMSSW_VERSION"] + '.tar.gz,condor.sh,config_cfg.py,userConfig_' + Label + '_cfg.py'
             if Dataset != '':
                 FilesToTransfer += ',datasetInfo_' + Label + '_cfg.py'
             if UseGridProxy:
                 if rutgers:
                     shutil.copy (proxy, Directory + "/" + os.path.basename (proxy))
-                    os.chmod (Directory + "/" + os.path.basename (proxy), 0644)
+                    os.chmod (Directory + "/" + os.path.basename (proxy), 0o644)
                     FilesToTransfer += ',' + os.path.basename (proxy)
                 else:
                     FilesToTransfer += ',' + proxy
@@ -481,7 +481,7 @@ def MakeCondorSubmitScript(Dataset,NumberOfJobs,Directory,Label, SkimChannelName
             SubmitFile.write('Transfer_Input_files = ' + FilesToTransfer + '\n')
             if UseGridProxy and not rutgers:
                 SubmitFile.write('x509userproxy = ' + proxy + '\n')
-        elif currentCondorSubArgumentsSet[argument].has_key('Transfer_Output_files') and currentCondorSubArgumentsSet[argument]['Transfer_Output_files'] == "":
+        elif 'Transfer_Output_files' in currentCondorSubArgumentsSet[argument] and currentCondorSubArgumentsSet[argument]['Transfer_Output_files'] == "":
             SubmitFile.write ('Transfer_Output_files = ')
             if os.path.realpath (Directory).startswith (("/data/users/", "/mnt/hadoop/se/store/", "/eos/uscms/store/", "/cms/")):
                 filesToTransfer.append ("hist_${Process}.root")
@@ -493,12 +493,12 @@ def MakeCondorSubmitScript(Dataset,NumberOfJobs,Directory,Label, SkimChannelName
                 else:
                     SubmitFile.write (SkimChannelNames[i] + ",")
             SubmitFile.write ("\n")
-        elif currentCondorSubArgumentsSet[argument].has_key('Requirements') and arguments.Requirements:
+        elif 'Requirements' in currentCondorSubArgumentsSet[argument] and arguments.Requirements:
             SubmitFile.write('Requirements = ' + arguments.Requirements + '\n')
-        elif currentCondorSubArgumentsSet[argument].has_key('Queue'):
+        elif 'Queue' in currentCondorSubArgumentsSet[argument]:
             SubmitFile.write('Queue ' + str(NumberOfJobs) +'\n')
         else:
-            SubmitFile.write(currentCondorSubArgumentsSet[argument].keys()[0] + ' = ' + currentCondorSubArgumentsSet[argument].values()[0] + '\n')
+            SubmitFile.write(list(currentCondorSubArgumentsSet[argument].keys())[0] + ' = ' + list(currentCondorSubArgumentsSet[argument].values())[0] + '\n')
     SubmitFile.close()
 
     SubmitScript = open (Directory + "/condor.sh", "w")
@@ -582,7 +582,7 @@ def MakeCondorSubmitScript(Dataset,NumberOfJobs,Directory,Label, SkimChannelName
     SubmitScript.write ("[ $i -eq 10 ] && exit 999\n")
     SubmitScript.write ("exit 0\n")
     SubmitScript.close ()
-    os.chmod (Directory + "/condor.sh", 0755)
+    os.chmod (Directory + "/condor.sh", 0o755)
 
 def MakeCondorSubmitRelease(Directory):
     # list of directories copied from $CMSSW_BASE; note that src/ is a special
@@ -613,12 +613,12 @@ def MakeCondorSubmitRelease(Directory):
 
     recopy = not hasattr (MakeCondorSubmitRelease, "madeCondorSubmitRelease")
     if recopy and os.path.isfile (os.environ["CMSSW_VERSION"] + ".tar.gz"):
-        print "Release " + os.environ["CMSSW_VERSION"] + " already exists for remote execution."
+        print("Release " + os.environ["CMSSW_VERSION"] + " already exists for remote execution.")
         recopy = raw_input ("Would you like to recopy the release? (y/N): ")
         recopy = (len (recopy) > 0 and recopy[0].upper () == "Y")
 
     if recopy:
-        print "Setting up " + os.environ["CMSSW_VERSION"] + " for remote execution..."
+        print("Setting up " + os.environ["CMSSW_VERSION"] + " for remote execution...")
         while os.path.isfile (os.environ["CMSSW_VERSION"] + ".tar.gz"):
             try:
                 os.unlink (os.environ["CMSSW_VERSION"] + ".tar.gz")
@@ -814,7 +814,8 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
     InitializeAAA = ""
     if UseAAA:
         if FileType == 'OSUT3Ntuple' or FileType == 'Dataset':
-            if not hasattr (Dataset, "__iter__"):
+            y = getattr(Dataset, "__iter__", None)
+            if y is not None:
                 AcquireAwesomeAAA(Dataset, datasetInfoName, 'AAAFileList.txt', datasetRead, crossSection, False)
             else:
                 append = False
@@ -831,10 +832,10 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
             Dataset = "condor/" + Dataset
             isInCondorDir = True
         if arguments.inputDirectory and not os.path.exists( re.sub (r"\*\/", r"", arguments.inputDirectory) ):
-            print "The directory you provided does not exist: ", arguments.inputDirectory
+            print("The directory you provided does not exist: ", arguments.inputDirectory)
             sys.exit(1)
         if not arguments.inputDirectory and not os.path.exists(Dataset):
-            print "The directory you provided does not exist: ", Dataset
+            print("The directory you provided does not exist: ", Dataset)
             sys.exit(1)
         #Get the list of the root files in the directory and modify it to have the standard format.
         secondaryCollectionModifications = []
@@ -871,7 +872,7 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
         fnew.close()
     if FileType == 'UserList':
         if not os.path.exists(Dataset):
-            print "The list you provided does not exist."
+            print("The list you provided does not exist.")
             sys.exit(1)
         #Get the list of the files to datasetInfo_cfg.py and modify it to have the standard format.
         secondaryCollectionModifications = []
@@ -915,7 +916,7 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
             else:
                 prefix = 'root://cms-0.mps.ohio-state.edu:1094/'
             if RunOverSkim:
-                print "You have specified a skim as input.  Will obtain cross sections for dataset", Label, "from the database."
+                print("You have specified a skim as input.  Will obtain cross sections for dataset", Label, "from the database.")
             #Use MySQLModule, a perl script to get the information of the given dataset from T3 DB and save it in datasetInfo_cfg.py.
             # Currently MySQLModule doesn't work at the LPC
             if not lpcCAF:
@@ -945,7 +946,7 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
             SkimDirectory = arguments.SkimDirectory + '/' + Label + '/' + arguments.SkimChannel
             inputFiles = GetListOfRemoteRootFiles(SkimDirectory)
             if inputFiles is None:
-                print "Reading from the remote directory failed for remote dataset " + Label + ". Does it exist? Will skip it and continue."
+                print("Reading from the remote directory failed for remote dataset " + Label + ". Does it exist? Will skip it and continue.")
                 datasetRead['numberOfFiles'] = 0
                 return datasetRead
             numInputFiles = len(inputFiles)
@@ -954,31 +955,31 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
             try:
                 subprocess.call('xrdcp ' + SkimDirectory + '/' + os.path.basename(datasetInfoName) + ' ' + datasetInfoName, shell = True)
             except subprocess.CalledProcessError:
-                print "Could not copy info file " + datasetInfoName + " from remote directory. Will skip this dataset and continue."
+                print("Could not copy info file " + datasetInfoName + " from remote directory. Will skip this dataset and continue.")
                 datasetRead['numberOfFiles'] = 0
                 return datasetRead
             try:
                 subprocess.call('xrdcp ' + SkimDirectory + '/OriginalNumberOfEvents.txt' + ' ' + Directory + '/OriginalNumberOfEvents.txt', shell = True)
             except subprocess.CalledProcessError:
-                print "Could not copy OriginalNumberOfEvents.txt from remote directory. Will skip this dataset and continue."
+                print("Could not copy OriginalNumberOfEvents.txt from remote directory. Will skip this dataset and continue.")
                 datasetRead['numberOfFiles'] = 0
                 return datasetRead
             try:
                 subprocess.call('xrdcp ' + SkimDirectory + '/SkimNumberOfEvents.txt' + ' ' + Directory + '/SkimNumberOfEvents.txt', shell = True)
             except subprocess.CalledProcessError:
-                print "Could not copy SkimNumberOfEvents.txt from remote directory. Will skip this dataset and continue."
+                print("Could not copy SkimNumberOfEvents.txt from remote directory. Will skip this dataset and continue.")
                 datasetRead['numberOfFiles'] = 0
                 return datasetRead
             # Modidy the datasetInfo file copied so that it can be used by the jobs running over skims. Also update the crossSection here.
             SkimModifier(Label, Directory, crossSection, True)
             if not numInputFiles:
-                print "No input skim files found for remote dataset " + Label + ". Will skip it and continue"
+                print("No input skim files found for remote dataset " + Label + ". Will skip it and continue")
                 datasetRead['numberOfFiles'] = numInputFiles
                 return datasetRead
         elif RunOverSkim:
             numInputFiles = len(glob.glob(Condor + arguments.SkimDirectory + '/' + Label + '/' + arguments.SkimChannel + "/*.root"))
             if not numInputFiles:
-                print "No input skim files found for dataset " + Label + ".  Will skip it and continue"
+                print("No input skim files found for dataset " + Label + ".  Will skip it and continue")
                 datasetRead['numberOfFiles'] = numInputFiles
                 return datasetRead
             SkimDirectory = Condor + str(arguments.SkimDirectory) + '/' + str(Label) + '/'
@@ -990,7 +991,7 @@ def MakeFileList(Dataset, FileType, Directory, Label, UseAAA, crossSection):
             InitializeAAA = ""
 
         sys.path.append(Directory)
-        exec('import datasetInfo_' + Label +'_cfg as datasetInfo')
+        exec('import datasetInfo_' + Label +'_cfg as datasetInfo', globals())
         if not UseAAA and InitializeAAA == "" and not RunOverSkim:
             status = datasetInfo.status
             continueForNonPresentDataset = True
@@ -1022,8 +1023,8 @@ def MakeBatchJobFile(WorkDir, Queue, NumberOfJobs):
     LxBatchRunFile.write('eval `scram runtime -sh`\n')
     LxBatchRunFile.write('cmsRun config_cfg.py True ' + NumberOfJobs + ' \$1 NULL NULL\n')
     LxBatchRunFile.close()
-    os.chmod (currentDir + '/' + WorkDir + '/lxbatchRun.sh', 0755)
-    os.chmod (currentDir + '/' + WorkDir + '/lxbatchSub.sh', 0755)
+    os.chmod (currentDir + '/' + WorkDir + '/lxbatchRun.sh', 0o755)
+    os.chmod (currentDir + '/' + WorkDir + '/lxbatchSub.sh', 0o755)
 
 ###############################################################################
 #        Function to find all the skim channels from the userConfig.          #
@@ -1119,7 +1120,7 @@ def getOriginalFiles (files, tempdir, isFirstFile = True, skimDirs = []):
     originalFiles = set ()
     for f in files:
         originalFile = getOriginalFile (f, tempdir, isFirstFile, skimDirs)
-        if len (originalFile) is not 0:
+        if len (originalFile) != 0:
             originalFiles.update (originalFile)
 
     return originalFiles
@@ -1141,9 +1142,9 @@ def getOriginalFile (f, tempdir, isFirstFile = True, skimDirs = []):
     try:
         skimDirFile = open (os.path.dirname (f) + "/SkimDirectory.txt", "r")
     except IOError:
-        print "ERROR:  Could not open skim directory file."
-        print "Expected name is", (os.path.dirname (f) + "/SkimDirectory.txt")
-        print "This should not be."
+        print("ERROR:  Could not open skim directory file.")
+        print("Expected name is", (os.path.dirname (f) + "/SkimDirectory.txt"))
+        print("This should not be.")
         sys.exit(1)
     skimDir = skimDirFile.readline ().rstrip ("\n")
     skimDirFile.close ()
@@ -1153,7 +1154,7 @@ def getOriginalFile (f, tempdir, isFirstFile = True, skimDirs = []):
     skimDirs.append (skimDir)
 
     datasetInfoFile = re.sub (r"(.*)\.py$", r"\1", copyDatasetInfoToTempFile (glob.glob (skimDir + "/datasetInfo_*_cfg.py")[0], tempdir))
-    exec("import " + datasetInfoFile + " as skimDatasetInfo")
+    exec("import " + datasetInfoFile + " as skimDatasetInfo", globals(), globals())
 
     return getOriginalFiles (skimDatasetInfo.listOfFiles, tempdir, False, skimDirs)
 
@@ -1194,23 +1195,23 @@ sys.path.append(os.getcwd())
 CondorDir = ''
 Condor = os.getcwd() + '/condor/'
 if not os.path.exists(Condor):
-    print "The directory ", Condor, " does not exist.  Aborting."
+    print("The directory ", Condor, " does not exist.  Aborting.")
     sys.exit(1)
 if arguments.condorDir == "":
-    print "No working directory is given, aborting."
+    print("No working directory is given, aborting.")
     sys.exit(1)
 else:
-    CondorDir = Condor + arguments.condorDir
+    CondorDir = Condor + str(arguments.condorDir)
 #Check whether the directory specified already exists and warn the user if so.
 if not os.path.exists(CondorDir):
     os.mkdir (CondorDir)
 else:
     if arguments.FileType == "OSUT3Ntuple" or arguments.Resubmit:
         # Ok to proceed, since the working directory will be "CondorDir/dataset"
-        print 'Directory "' + str(CondorDir) + '" already exists in your condor directory. Will proceed with job submission.'
+        print('Directory "' + str(CondorDir) + '" already exists in your condor directory. Will proceed with job submission.')
     else:
         # Do not proceed because the working directory is CondorDir, and we do not want to overwrite existing files.
-        print "Directory", CondorDir, " already exists.  Please remove it before proceeding."
+        print("Directory", CondorDir, " already exists.  Please remove it before proceeding.")
         sys.exit(1)
 
 HadoopDir = ''
@@ -1221,32 +1222,32 @@ if arguments.skimToHadoop:
         try:
             msg = subprocess.check_output(['xrd', 'cmseos.fnal.gov', 'existdir', os.path.realpath(arguments.skimToHadoop)])
         except:
-            print 'The directory', arguments.skimToHadoop, 'does not exist. Aborting.'
+            print('The directory', arguments.skimToHadoop, 'does not exist. Aborting.')
             sys.exit(1)
         HadoopDir = arguments.skimToHadoop + '/' + arguments.condorDir
         # if needed, create the job directory
         try:
             msg = subprocess.check_output(['xrd', 'cmseos.fnal.gov', 'existdir', os.path.realpath(HadoopDir)])
-            print 'Directory "' + str(HadoopDir) + '" already exists. Will proceed with job submission.'
+            print('Directory "' + str(HadoopDir) + '" already exists. Will proceed with job submission.')
         except:
             try:
                 msg = subprocess.check_output(['xrd', 'cmseos.fnal.gov', 'mkdir', os.path.realpath(HadoopDir)])
             except subprocess.CalledProcessError as e:
-                print 'Creating directory "' + str(HadoopDir) + '" failed with error:'
-                print e
-                print 'Aborting.'
+                print('Creating directory "' + str(HadoopDir) + '" failed with error:')
+                print(e)
+                print('Aborting.')
                 sys.exit(1)
     else:
         # check if the directory exists
         if not os.path.exists(arguments.skimToHadoop):
-            print "The directory ", arguments.skimToHadoop, " does not exist.  Aborting."
+            print("The directory ", arguments.skimToHadoop, " does not exist.  Aborting.")
             sys.exit(1)
         HadoopDir = arguments.skimToHadoop + '/' + arguments.condorDir
         # if needed, create the job directory
         if not os.path.exists(HadoopDir):
             os.makedirs(HadoopDir)
         else:
-            print 'Directory "' + str(HadoopDir) + '" already exists. Will proceed with job submission.'
+            print('Directory "' + str(HadoopDir) + '" already exists. Will proceed with job submission.')
     HadoopDir = os.path.abspath(HadoopDir)
 
 RunOverSkim = False
@@ -1255,7 +1256,7 @@ if arguments.SkimDirectory != "" and arguments.SkimChannel != "":
 elif arguments.SkimDirectory == "" and arguments.SkimChannel == "":
     RunOverSkim = False
 else:
-    print "Both skim directory and skim channel should be provided."
+    print("Both skim directory and skim channel should be provided.")
 
 RunOverRemoteSkim = RunOverSkim and 'root://' in arguments.SkimDirectory
 
@@ -1266,26 +1267,26 @@ split_datasets = []
 
 
 if arguments.localConfig:
-    exec("from " + re.sub (r".py$", r"", arguments.localConfig) + " import *")
+    exec("from " + re.sub (r".py$", r"", arguments.localConfig) + " import *", globals(), globals())
     split_datasets = split_composite_datasets(datasets, composite_dataset_definitions)
 
 #Check whether the necessary options are correctly given if no local config is given.
 if not arguments.localConfig:
     if not arguments.NumberOfJobs > 0:
-        print "Invalid number of jobs, aborting."
+        print("Invalid number of jobs, aborting.")
         sys.exit(1)
     if arguments.Config == "":
-        print "No cmsRun executable is given, aborting."
+        print("No cmsRun executable is given, aborting.")
         sys.exit(1)
     if arguments.Dataset == "":
-        print A_BRIGHT_RED + "Warning, you are running batch jobs witout using input sources." + A_RESET
+        print(A_BRIGHT_RED + "Warning, you are running batch jobs witout using input sources." + A_RESET)
     else:
         split_datasets.append(arguments.Dataset)
 
 if lpcCAF and "el6" in platform.release ():
   print
-  print A_BRIGHT_RED + "Warning! You are working in SL6 on the LPC. Job submission is currently"
-  print                "         problematic in SLF6, and you are encouraged to switch to SL7." + A_RESET
+  print(A_BRIGHT_RED + "Warning! You are working in SL6 on the LPC. Job submission is currently")
+  print(               "         problematic in SLF6, and you are encouraged to switch to SL7." + A_RESET)
   print
 
 UseAAA = False
@@ -1302,16 +1303,16 @@ userId = os.getuid()
 proxy = '/tmp/x509up_u' + str(userId) if "X509_USER_PROXY" not in os.environ else os.environ["X509_USER_PROXY"]
 
 if arguments.Redirector != "":
-    if not RedirectorDic.has_key(arguments.Redirector):
-        print A_BRIGHT_RED + "Warning! Invalid redirector provided!! Quit!!" + A_RESET
+    if not arguments.Redirector in RedirectorDic:
+        print(A_BRIGHT_RED + "Warning! Invalid redirector provided!! Quit!!" + A_RESET)
         sys.exit(1)
 
 if lpcCAF and not arguments.skimToHadoop:
     print
-    print A_BRIGHT_RED + "Warning! You are working on the LPC, but have not provided a \"Hadoop\" directory"
-    print                "         for your skim with \"-H\". Your skim files will be written directly to"
-    print                "         your condor directory, which may threaten the quota on your home"
-    print                "         directory. Consider using -H with eos!" + A_RESET
+    print(A_BRIGHT_RED + "Warning! You are working on the LPC, but have not provided a \"Hadoop\" directory")
+    print(               "         for your skim with \"-H\". Your skim files will be written directly to")
+    print(               "         your condor directory, which may threaten the quota on your home")
+    print(               "         directory. Consider using -H with eos!" + A_RESET)
     print
 
 ###############################################################################
@@ -1331,7 +1332,7 @@ if not arguments.Resubmit:
         Config =  arguments.Config
         if arguments.localConfig:
             Config = config_file
-        exec('import ' + re.sub (r"(.*)\.py$", r"\1", Config) + ' as temPset')
+        exec('import ' + re.sub (r"(.*)\.py$", r"\1", Config) + ' as temPset', globals(), globals())
 
         for dataset in split_datasets:
             currentCondorSubArgumentsSet = copy.deepcopy(CondorSubArgumentsSet)
@@ -1352,39 +1353,39 @@ if not arguments.Resubmit:
             GetCompleteOrderedArgumentsSet(InputCondorArguments, currentCondorSubArgumentsSet)
 
             if arguments.FileType == 'OSUT3Ntuple':
-                if dataset_names.has_key(dataset):
+                if dataset in dataset_names:
                     DatasetName = dataset_names[dataset]
                 else:
-                    print str(dataset) + ' has not been registered on T3. Will try to find it on DAS.'
+                    print(str(dataset) + ' has not been registered on T3. Will try to find it on DAS.')
                 WorkDir = CondorDir + '/' + SpecialStringModifier(dataset,['/'],[['-','_']])
                 SkimDir = HadoopDir + '/' + SpecialStringModifier(dataset,['/'],[['-','_']]) if HadoopDir else ''
                 if os.path.exists(WorkDir):
-                    print 'Directory "' + str(WorkDir) + '" already exists.  Please remove it and resubmit.'
+                    print('Directory "' + str(WorkDir) + '" already exists.  Please remove it and resubmit.')
                     continue
                 else:
                     os.mkdir (WorkDir)
                 if SkimDir:
                     if not MakeSkimDirectory(SkimDir, lpcCAF):
-                        print 'Directory "' + str(SkimDir) + '" already exists. Please remove it and resubmit. For now dataset "' + str(dataset) + '" will be skipped.'
+                        print('Directory "' + str(SkimDir) + '" already exists. Please remove it and resubmit. For now dataset "' + str(dataset) + '" will be skipped.')
                         continue
             elif arguments.FileType == 'UserList':
                 WorkDir = CondorDir + '/' + SpecialStringModifier(dataset,['/'],[['-','_']])
                 SkimDir = HadoopDir + '/' + SpecialStringModifier(dataset,['/'],[['-','_']]) if HadoopDir else ''
                 if os.path.exists(WorkDir):
-                    print 'Directory "' + str(WorkDir) + '" already exists.  Please remove it and resubmit.'
+                    print('Directory "' + str(WorkDir) + '" already exists.  Please remove it and resubmit.')
                     continue
                 else:
                     os.mkdir (WorkDir)
                 if SkimDir:
                     if not MakeSkimDirectory(SkimDir, lpcCAF):
-                        print 'Directory "' + str(SkimDir) + '" already exists. Please remove it and resubmit. For now dataset "' + str(dataset) + '" will be skipped.'
+                        print('Directory "' + str(SkimDir) + '" already exists. Please remove it and resubmit. For now dataset "' + str(dataset) + '" will be skipped.')
                         continue
             else:
                 WorkDir = CondorDir
                 SkimDir = HadoopDir
             dataset = SpecialStringModifier(dataset, ['/','.'], [['-','_']])
             crossSection = -1
-            if crossSections.has_key(dataset):
+            if dataset in crossSections:
                 crossSection = crossSections[dataset]
             elif arguments.crossSection != "":
                 crossSection = arguments.crossSection
@@ -1429,22 +1430,22 @@ if not arguments.Resubmit:
             if not arguments.NotToExecute:
                 os.chdir(os.path.realpath(WorkDir))
                 if RealMaxEvents > 0 :
-                    print 'Submitting ' + str(NumberOfJobs) +  ' jobs to run on ' + str(RealMaxEvents)  + ' events in ' + str(DatasetRead['numberOfFiles']) + ' files for ' + str(dataset) + ' dataset...\n'
+                    print('Submitting ' + str(NumberOfJobs) +  ' jobs to run on ' + str(RealMaxEvents)  + ' events in ' + str(DatasetRead['numberOfFiles']) + ' files for ' + str(dataset) + ' dataset...\n')
                 else:
-                    print 'Submitting ' + str(NumberOfJobs) +  ' jobs to run on all events in ' + str(DatasetRead['numberOfFiles'])  +' files for ' + str(dataset) + ' dataset...\n'
+                    print('Submitting ' + str(NumberOfJobs) +  ' jobs to run on all events in ' + str(DatasetRead['numberOfFiles'])  +' files for ' + str(dataset) + ' dataset...\n')
                 if lxbatch:
                     os.syetem('./lxbatchSub.sh')
                 else:
                     os.symlink ("../" + os.environ["CMSSW_VERSION"] + ".tar.gz", os.environ["CMSSW_VERSION"] + ".tar.gz")
                     cmd = "LD_LIBRARY_PATH= condor_submit condor.sub"
                     if os.path.isfile (os.path.basename (proxy)):
-                        os.chmod (os.path.basename (proxy), 0644)
+                        os.chmod (os.path.basename (proxy), 0o644)
                     subprocess.call(cmd, shell = True)
                     if os.path.isfile (os.path.basename (proxy)):
-                        os.chmod (os.path.basename (proxy), 0600)
+                        os.chmod (os.path.basename (proxy), 0o600)
                 os.chdir(SubmissionDir)
             else:
-                print 'Configuration files created for ' + str(dataset) + ' dataset but no jobs submitted.\n'
+                print('Configuration files created for ' + str(dataset) + ' dataset but no jobs submitted.\n')
                 os.chdir(SubmissionDir)
     #If there are no input datasets specified and the user still continues.
     else:
@@ -1453,7 +1454,7 @@ if not arguments.Resubmit:
         MaxEvents = -1
         Label = arguments.Label
         if arguments.MaxEvents < 0:
-            print "Maximum number of events is negative and no input dataset is specified, Aborting!"
+            print("Maximum number of events is negative and no input dataset is specified, Aborting!")
             sys.exit(1)
         else:
             MaxEvents = int(arguments.MaxEvents)
@@ -1468,7 +1469,7 @@ if not arguments.Resubmit:
             GetCompleteOrderedArgumentsSet(InputCondorArguments, currentCondorSubArgumentsSet)
         userConfig = 'userConfig_' + Label + '_cfg.py'
         shutil.copy (Config, WorkDir + "/" + userConfig)
-        exec('import ' + re.sub (r"(.*)\.py$", r"\1", Config) + ' as temPset')
+        exec('import ' + re.sub (r"(.*)\.py$", r"\1", Config) + ' as temPset', globals(), globals())
 
         MakeSpecificConfig('', WorkDir, SkimDir, Label, SkimChannelNames, '', temPset, lpcCAF)
 
@@ -1479,20 +1480,20 @@ if not arguments.Resubmit:
             MakeCondorSubmitRelease(WorkDir)
         if not arguments.NotToExecute:
             os.chdir(os.path.realpath(WorkDir))
-            print 'Submitting ' + str(NumberOfJobs) +  ' jobs to run ' + str(RealMaxEvents)  + ' events for ' + str(Config) + '...\n'
+            print('Submitting ' + str(NumberOfJobs) +  ' jobs to run ' + str(RealMaxEvents)  + ' events for ' + str(Config) + '...\n')
             if lxbatch:
                 os.syetem('./lxbatchSub.sh')
             else:
                 os.symlink ("../" + os.environ["CMSSW_VERSION"] + ".tar.gz", os.environ["CMSSW_VERSION"] + ".tar.gz")
                 cmd = "LD_LIBRARY_PATH= condor_submit condor.sub"
                 if os.path.isfile (os.path.basename (proxy)):
-                    os.chmod (os.path.basename (proxy), 0644)
+                    os.chmod (os.path.basename (proxy), 0o644)
                 subprocess.call(cmd, shell = True)
                 if os.path.isfile (os.path.basename (proxy)):
-                    os.chmod (os.path.basename (proxy), 0600)
+                    os.chmod (os.path.basename (proxy), 0o600)
             os.chdir(SubmissionDir)
         else:
-            print 'Configuration files created for ' + str(Config) + '  but no jobs submitted.\n'
+            print('Configuration files created for ' + str(Config) + '  but no jobs submitted.\n')
 else:
     if split_datasets:
         SubmissionDir = os.getcwd()
@@ -1501,7 +1502,7 @@ else:
             if os.path.isfile (WorkDir + "/" + os.path.basename (proxy)) and os.path.isfile (proxy):
                 os.unlink (WorkDir + "/" + os.path.basename (proxy))
                 shutil.copy (proxy, WorkDir + "/" + os.path.basename (proxy))
-                os.chmod (WorkDir + "/" + os.path.basename (proxy), 0644)
+                os.chmod (WorkDir + "/" + os.path.basename (proxy), 0o644)
             if os.path.exists(WorkDir + '/condor_resubmit.sh'):
                 os.chdir(WorkDir)
                 subprocess.call ('./condor_resubmit.sh', shell = True)
@@ -1510,7 +1511,7 @@ else:
                 os.chdir(os.path.realpath(WorkDir))
                 #If a redirector is defined, switch to the new redirector.
                 if arguments.Redirector != "" :
-                    if RedirectorDic.has_key(arguments.Redirector):
+                    if arguments.Redirector in RedirectorDic:
                         originalRedirector = ""
                         datasetInfoFileName = os.popen("ls datasetInfo_*_cfg.py").read().split('\n')[0]
                         datasetInfoFile = open(str(datasetInfoFileName),'r')
@@ -1519,11 +1520,11 @@ else:
                                originalRedirector = line.split('/')[2]
                                break
                         subprocess.call('sed -i \'s/' + str(originalRedirector) + '/' + str(RedirectorDic[arguments.Redirector]) + '/g\' '  +  str(datasetInfoFileName), shell = True)
-                print '################ Resubmit failed jobs for ' + str(dataset) + ' dataset #############'
+                print('################ Resubmit failed jobs for ' + str(dataset) + ' dataset #############')
                 cmd = "LD_LIBRARY_PATH= condor_submit condor_resubmit.sub"
                 if os.path.isfile (os.path.basename (proxy)):
-                    os.chmod (os.path.basename (proxy), 0644)
+                    os.chmod (os.path.basename (proxy), 0o644)
                 subprocess.call(cmd, shell = True)
                 if os.path.isfile (os.path.basename (proxy)):
-                    os.chmod (os.path.basename (proxy), 0600)
+                    os.chmod (os.path.basename (proxy), 0o600)
                 os.chdir(SubmissionDir)

--- a/ExampleAnalysis/test/comparisonPlot_cfg.py
+++ b/ExampleAnalysis/test/comparisonPlot_cfg.py
@@ -1,14 +1,14 @@
-#! /usr/bn/env python
-intLumi = 16146.2 # 2016G,H only 
+#! /usr/bn/env python3
+intLumi = 16146.2 # 2016G,H only
 
 ###################
 # 'color' options #
 ###################
 ## 'black'
-## 'red'  
+## 'red'
 ## 'green'
 ## 'purple'
-## 'blue'  
+## 'blue'
 ## 'yellow'
 ## default: cycle through list
 

--- a/ExampleAnalysis/test/eMuOptions.py
+++ b/ExampleAnalysis/test/eMuOptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from OSUT3Analysis.Configuration.configurationOptions import *
 from OSUT3Analysis.Configuration.processingUtilities import *
@@ -101,4 +101,3 @@ options['labels'] = labels
 
 #add_stops (options, [200,300,400,500,600,700,800,900], [0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0,20.0,30.0,40.0,50.0,60.0,70.0,80.0,90.0,100.0,200.0,300.0,400.0,500.0,600.0,700.0,800.0,900.0,1000.0],[100])
 add_stops (options, [500], [1.0,10.0,100.0],[100])
-

--- a/ExampleAnalysis/test/protoBatchConfig.py
+++ b/ExampleAnalysis/test/protoBatchConfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # to be run with osusub.py (see https://twiki.cern.ch/twiki/bin/view/CMS/OSUT3AnalysisTutorial)
 

--- a/ExampleAnalysis/test/protoPuConfig.py
+++ b/ExampleAnalysis/test/protoPuConfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # to be run with osusub.py (see https://twiki.cern.ch/twiki/bin/view/CMS/OSUT3AnalysisTutorial)
 


### PR DESCRIPTION
STILL IN PROGRESS, DON'T TRY TO MERGE YET

When updating to CMSSW_12_1_X, there was an update to move to python3 (from python2) as well. The main changes that need to happen for python3 are:
- print statement syntax moved to `print()` rather than simply `print `
- `is` and `is not` sometimes give warnings that you should change them to `==` and `!=`, respectively
- integers can't start with a 0, so you have to do e.g. `0o644` when you mean the `0644` for chmod
- instead of `dictionary.has_key('keyname')` we need to use `'keyname' in dictionary`
- you have to explicitly ask for dictionary keys, values, or items as a list (https://stackoverflow.com/questions/16819222/how-to-return-dictionary-keys-as-a-list-in-python)

The ROOT version was also updated, such that ROOT Doubles are no longer a thing. I changed them all to python doubles.

All of these changes have been implemented in this PR.