### PR TITLE
changes in JER get() method under CMSSW_12_4_X

### DIFF
--- a/Collections/plugins/OSUGenericJetProducer.h
+++ b/Collections/plugins/OSUGenericJetProducer.h
@@ -15,6 +15,13 @@
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectionUncertainty.h"
 
+#if DATA_FORMAT_FROM_MINIAOD
+#include "JetMETCorrections/Modules/interface/JetResolution.h"
+#include "CondFormats/DataRecord/interface/JetResolutionRcd.h"
+#include "CondFormats/DataRecord/interface/JetResolutionScaleFactorRcd.h"
+#include "TRandom3.h"
+#endif
+
 template<class T>
 class OSUGenericJetProducer : public edm::EDProducer
 {
@@ -48,6 +55,11 @@ class OSUGenericJetProducer : public edm::EDProducer
   edm::EDGetTokenT<vector<TYPE(genjets)> > genjetsToken_;
   edm::EDGetTokenT<double> rhoToken_;
   edm::EDGetTokenT<vector<TYPE(primaryvertexs)> > primaryvertexsToken_;
+
+  #if CMSSW_VERSION_CODE >= CMSSW_VERSION(12,4,0)
+  JME::JetResolution::Token  jetResolutionToken_;
+  JME::JetResolutionScaleFactor::Token jetResolutionSFToken_;
+  #endif
 
   edm::ParameterSet  cfg_;
   ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The get() method for JetEnergyResolution(ScaleFactors) are modified in CMSSW_12_4_X.