### PR TITLE
Run3 devel update

### DIFF
--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -6,7 +6,8 @@ import importlib
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_"):
     samples = importlib.import_module("DisappTrks.StandardAnalysis.miniAOD_124X_Samples")
     dataset_names = getattr(samples, "dataset_names")
-    print(dataset_names)
+    run3_skim_sibling_datasets = getattr(samples, "run3_skim_sibling_datasets")
+
 
 config_file = "standardConfig_cfg.py"
 

--- a/DBTools/python/osusub_cfg.py
+++ b/DBTools/python/osusub_cfg.py
@@ -166,7 +166,7 @@ def getRun3SkimSiblings (fileName, dataset, inputUser=False):
   return list (miniaodSubset.intersection (miniaod))
 
 def skimListExists(dataset):
-  if os.path.exists('/store/user/mcarrigan/skim_lists/' + dataset + '.json'):
+  if os.path.exists(os.environ.get("CMSSW_BASE") + '/DisappTrks/Skims/data/' + dataset + '.json'):
     print("Skim list for {0} exists".format(dataset))
     return True
   else:

--- a/DBTools/python/osusub_cfg.py
+++ b/DBTools/python/osusub_cfg.py
@@ -166,7 +166,7 @@ def getRun3SkimSiblings (fileName, dataset, inputUser=False):
   return list (miniaodSubset.intersection (miniaod))
 
 def skimListExists(dataset):
-  if os.path.exists(os.environ.get("CMSSW_BASE") + '/DisappTrks/Skims/data/' + dataset + '.json'):
+  if os.path.exists(os.environ.get("CMSSW_BASE") + '/src/DisappTrks/Skims/data/' + dataset + '.json'):
     print("Skim list for {0} exists".format(dataset))
     return True
   else:

--- a/DBTools/scripts/getSiblings.py
+++ b/DBTools/scripts/getSiblings.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import json
+import argparse
+from OSUT3Analysis.DBTools.osusub_cfg import getRun3SkimSiblings
+
+
+try:
+    from dbs.apis.dbsClient import DbsApi
+    #from CRABClient.ClientUtilities import DBSURLS
+except ImportError:
+    print("getSiblings() relies on CRAB. Please set up the environment for CRAB before using.")
+    sys.exit (1)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-i", "--inputDataset", type=str, help="Input dataset to get siblings of")
+parser.add_argument("-s", "--siblingDataset", type=str, help="Sibling dataset to get sibling files from")
+parser.add_argument("-u", "--user", action="store_true", help="Use this option to use a user created dataset")
+parser.add_argument("-n", "--nameList", type=str, help="Name of the json file to output")
+
+file_dict = {}
+dataset_in = ''
+dataset_sib = ''
+
+args = parser.parse_args()
+
+dbs3api_in = DbsApi (url = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader')
+dbs3api_out = DbsApi (url = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader')
+
+if args.user:
+    dbs3api_in = DbsApi (url = 'https://cmsweb.cern.ch/dbs/prod/phys03/DBSReader')
+if args.inputDataset:
+    dataset_in = args.inputDataset
+else:
+    print("Need to specify the input dataset")
+    sys.exit(2)
+if args.siblingDataset:
+    dataset_sib = args.siblingDataset
+else:
+    print("Need to specify the sibling dataset")
+    sys.exit(2)
+if args.nameList:
+    dictName = args.nameList
+else:
+    dictName = dataset_in.split('/')[1] + '_' + dataset_in.split('/')[2].split('-')[0].replace('Run', '')
+
+print("Output JSON file will be called {0}".format(dictName))
+
+input_files = dbs3api_in.listFiles (dataset = dataset_in)
+
+for ifile, filename in enumerate(input_files):
+    print('Input File: ' + filename['logical_file_name'])
+    this_file = filename['logical_file_name']
+    siblings = getRun3SkimSiblings(this_file, dataset_sib, args.user)
+    file_dict[this_file] = siblings
+    print('Siblings: ')
+    for sib in siblings:
+        print('\t', sib)
+
+json_dict = json.dumps(file_dict)
+f_out = open(dictName + '.json', 'w')
+f_out.write(json_dict)
+f_out.close()

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -843,11 +843,14 @@ def MakeSpecificConfig(Dataset, Directory, SkimDirectory, Label, SkimChannelName
     if not RunOverSkim and ("run3_skim_sibling_datasets" in locals() or "run3_skim_sibling_datasets" in globals()) and labeled_era in run3_skim_sibling_datasets:
         ConfigFile.write("\nsiblings = []\n")
         ConfigFile.write("if osusub.batchMode:\n")
-        ConfigFile.write("  try:\n")
+        #ConfigFile.write("  try:\n")
+        ConfigFile.write("  if osusub.skimListExists('" + labeled_era + "'):\n")
+        ConfigFile.write("    siblings.extend(osusub.getSiblingList('/store/user/mcarrigan/skim_lists/" + labeled_era + ".json', osusub.runList, '" + run3_skim_sibling_datasets[labeled_era] + "'))\n")
+        ConfigFile.write("  else:\n")
         ConfigFile.write("    for fileName in osusub.runList:\n")
         ConfigFile.write("      siblings.extend (osusub.getRun3SkimSiblings (fileName, \"" + run3_skim_sibling_datasets[labeled_era] + "\"))\n")
-        ConfigFile.write("  except:\n")
-        ConfigFile.write("    print( \"No valid grid proxy. Not adding sibling files.\")\n" )
+        #ConfigFile.write("  except:\n")
+        #ConfigFile.write("    print( \"No valid grid proxy. Not adding sibling files.\")\n" )
         ConfigFile.write("pset.process.source.secondaryFileNames.extend(siblings)\n\n")
 
     ConfigFile.write('process = pset.process\n')


### PR DESCRIPTION
PR includes many updates to run osusub in CMSSW_12_4_X using skimmed AOD and miniAOD datasets. 

File Configuration/python/configurationOptions.py now imports the skim siblings "run3_skim_sibling_datasets" along with "dataset_names" from DisappTrks/StandardAnalysis/python/miniAOD_124X_Samples.py. Here the primary dataset is the AOD skim and the sibling dataset is miniAOD. This ensures that only events passing the skim are run over.

File DBTools/scripts/getSiblings.py has been added to create a python dictionary of files in an AOD skim dataset and find the corresponding miniAOD siblings. These files are saved in the DisappTrk/Skims/data folder (see PR https://github.com/OSU-CMS/DisappTrks/pull/14). File osusub_cfg.py is then configured to look for the json for a given dataset. If no json file is found it will default to finding all run3 skim siblings. Finding the siblings can take a long time (ex. for short test jobs all sibling files are still searched for). The json file is used instead to save time.

Also included are bug fixes to osusub.py. These include

1. loading the correct libraries in cmssw for a "patch version" (ex. CMSSW_12_4_11_patch3) where some libraries are stored in a different directory compared to a non patch version. 
2. changing the "Label" used to get the run3_skim_sibling_datasets to include the year and era. 