### PR TITLE
Update getSiblings

### DIFF
--- a/DBTools/scripts/getLumiBlock.py
+++ b/DBTools/scripts/getLumiBlock.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+from FWCore.PythonUtilities.LumiList   import LumiList
+from DataFormats.FWLite import Lumis, Handle
+import optparse
+import json
+import sys
+import os
+
+filenames = [
+    '/data/users/borzari/condor/SignalMC/Run3/step3/1000cm/700GeV/AMSB_chargino_M_700GeV_CTau_1000cm_TuneCP5_PSweights_13p6TeV_madgraph5_pythia8/hist_641.root',
+    '/data/users/borzari/condor/SignalMC/Run3/step3/1000cm/700GeV/AMSB_chargino_M_700GeV_CTau_1000cm_TuneCP5_PSweights_13p6TeV_madgraph5_pythia8/hist_642.root'
+    ]
+
+def getLumiBlocks(filelist, saveFile):
+
+    json_dict = {}
+
+    if os.path.exists(os.getcwd() + '/' + saveFile + '.json'):
+        f_in = open(saveFile + '.json', 'r')
+        json_dict = json.load(f_in)
+        f_in.close()
+
+    runLumisDict = {}
+    lumis = Lumis (filelist)
+    for i, (lumi, filename), in enumerate(zip(lumis, filelist)):
+
+        '''if i%100 == 0:
+            os.system('cat /proc/sys/fs/file-nr')'''
+
+        print("Getting lumis for file {0}".format(filename))
+        runLumisDict[filename] = [lumi.aux().run(), lumi.aux().id().luminosityBlock()]
+
+    combined_dict = dict(runLumisDict, **json_dict)
+    json_dict = json.dumps(combined_dict)
+    f_out = open(saveFile + '.json', 'w')
+    f_out.write(json_dict)
+    f_out.close()
+
+    del lumis
+
+
+if __name__ == '__main__':
+
+    if len(sys.argv) < 4:
+        print("Need to give json file name and list of files to get lumi blocks from")
+        sys.exit(1)
+
+    getLumiBlocks(sys.argv[2:], sys.argv[1])

--- a/DBTools/scripts/getSiblings.py
+++ b/DBTools/scripts/getSiblings.py
@@ -2,62 +2,139 @@ import os
 import sys
 import json
 import argparse
+import psutil
 from OSUT3Analysis.DBTools.osusub_cfg import getRun3SkimSiblings
+from FWCore.PythonUtilities.LumiList   import LumiList
+from DataFormats.FWLite import Lumis, Handle
+from multiprocessing import Process, Queue
+import subprocess
 
 
-try:
-    from dbs.apis.dbsClient import DbsApi
-    #from CRABClient.ClientUtilities import DBSURLS
-except ImportError:
-    print("getSiblings() relies on CRAB. Please set up the environment for CRAB before using.")
-    sys.exit (1)
+def getDBSSiblings(output_json):
 
-parser = argparse.ArgumentParser()
-parser.add_argument("-i", "--inputDataset", type=str, help="Input dataset to get siblings of")
-parser.add_argument("-s", "--siblingDataset", type=str, help="Sibling dataset to get sibling files from")
-parser.add_argument("-u", "--user", action="store_true", help="Use this option to use a user created dataset")
-parser.add_argument("-n", "--nameList", type=str, help="Name of the json file to output")
+    file_dict = {}
+    dataset_in = ''
+    dataset_sib = ''
 
-file_dict = {}
-dataset_in = ''
-dataset_sib = ''
+    dbs3api_in = DbsApi (url = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader')
+    dbs3api_out = DbsApi (url = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader')
 
-args = parser.parse_args()
+    if args.user:
+        dbs3api_in = DbsApi (url = 'https://cmsweb.cern.ch/dbs/prod/phys03/DBSReader')
+    if args.inputDataset:
+        dataset_in = args.inputDataset
+    else:
+        print("Need to specify the input dataset")
+        sys.exit(2)
+    if args.siblingDataset:
+        dataset_sib = args.siblingDataset
+    else:
+        print("Need to specify the sibling dataset")
+        sys.exit(2)
+    if args.nameList:
+        dictName = args.nameList
+    else:
+        dictName = dataset_in.split('/')[1] + '_' + dataset_in.split('/')[2].split('-')[0].replace('Run', '')
 
-dbs3api_in = DbsApi (url = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader')
-dbs3api_out = DbsApi (url = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader')
+    print("Output JSON file will be called {0}".format(dictName))
 
-if args.user:
-    dbs3api_in = DbsApi (url = 'https://cmsweb.cern.ch/dbs/prod/phys03/DBSReader')
-if args.inputDataset:
-    dataset_in = args.inputDataset
-else:
-    print("Need to specify the input dataset")
-    sys.exit(2)
-if args.siblingDataset:
-    dataset_sib = args.siblingDataset
-else:
-    print("Need to specify the sibling dataset")
-    sys.exit(2)
-if args.nameList:
-    dictName = args.nameList
-else:
-    dictName = dataset_in.split('/')[1] + '_' + dataset_in.split('/')[2].split('-')[0].replace('Run', '')
+    input_files = dbs3api_in.listFiles (dataset = dataset_in, detail=True)
+    print(input_files)
 
-print("Output JSON file will be called {0}".format(dictName))
+    for ifile, filename in enumerate(input_files):
+        if(filename['is_file_valid']): print('Input File: ' + filename['logical_file_name'])
+        this_file = filename['logical_file_name']
+        siblings = getRun3SkimSiblings(this_file, dataset_sib, args.user)
+        file_dict[this_file] = siblings
+        print('Siblings: ')
+        for sib in siblings:
+            print('\t', sib)
 
-input_files = dbs3api_in.listFiles (dataset = dataset_in)
+    json_dict = json.dumps(file_dict)
+    f_out = open(output_json, 'w')
+    f_out.write(json_dict)
+    f_out.close()
 
-for ifile, filename in enumerate(input_files):
-    print('Input File: ' + filename['logical_file_name'])
-    this_file = filename['logical_file_name']
-    siblings = getRun3SkimSiblings(this_file, dataset_sib, args.user)
-    file_dict[this_file] = siblings
-    print('Siblings: ')
-    for sib in siblings:
-        print('\t', sib)
+def getLocalSiblings(output_json):
 
-json_dict = json.dumps(file_dict)
-f_out = open(dictName + '.json', 'w')
-f_out.write(json_dict)
-f_out.close()
+    inputFileList = []
+    siblingFileList = []
+
+    for filename in os.listdir(args.inputDataset):
+        if not filename.endswith('root'): continue
+        inputFileList.append(args.inputDataset + filename)
+
+    for filename in os.listdir(args.siblingDataset):
+        if not filename.endswith('root'): continue
+        siblingFileList.append(args.siblingDataset + filename)
+
+    subList = []
+
+    #this is run as a subprocess because the CMSSW Lumi class used does not close root files
+    #this results in too many files open error / going over memory usage
+    for ifile, filename in enumerate(inputFileList):
+        subList.append(filename)
+        if ifile % 100 == 0 and ifile > 0:
+            os.system('cat /proc/sys/fs/file-nr')
+            inputLumiBlocks = subprocess.run(['python3 getLumiBlock.py input '+ ' '.join(subList)], shell=True)
+            subList = []
+    inputLumiBlocks = subprocess.run(['python3 getLumiBlock.py input '+ ' '.join(subList)], shell=True)
+
+
+    subList = []
+    for ifile, filename in enumerate(siblingFileList):
+        subList.append(filename)
+        if ifile % 100 == 0 and ifile > 0:
+            os.system('cat /proc/sys/fs/file-nr')
+            inputLumiBlocks = subprocess.run(['python3 getLumiBlock.py sibling '+ ' '.join(subList)], shell=True)
+            subList = []
+    inputLumiBlocks = subprocess.run(['python3 getLumiBlock.py sibling '+ ' '.join(subList)], shell=True)
+
+
+    input_fin = open('input.json', 'r')
+    sib_fin = open('sibling.json', 'r')
+    inputLumiBlocks = json.load(input_fin)
+
+    siblingLumiBlocks = json.load(sib_fin)
+
+    dict_out = {}
+
+    for filename, [run, lumi] in inputLumiBlocks.items():
+        for sibname, [sibRun, sibLumi] in siblingLumiBlocks.items():
+            if run == sibRun and lumi == sibLumi:
+                if filename in dict_out:
+                    dict_out[filename] = dict_out[filename].append(sibname)
+                else:
+                    dict_out[filename] = [sibname]
+        if not filename in dict_out:
+            print("File {0} has no matching run/lumi in the sibling dataset".format(filename))
+
+    f_out = open(output_json, 'w')
+    json_dict = json.dumps(dict_out)
+    f_out.write(json_dict)
+    f_out.close()
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--inputDataset", type=str, help="Input dataset to get siblings of")
+    parser.add_argument("-s", "--siblingDataset", type=str, help="Sibling dataset to get sibling files from")
+    parser.add_argument("-u", "--user", action="store_true", help="Use this option to use a user created dataset")
+    parser.add_argument("-n", "--nameList", type=str, help="Name of the json file to output")
+    parser.add_argument("-l", "--local", action="store_true", help="If input data is user created on the T3")
+
+    args = parser.parse_args()
+
+    output_json = 'output.json'
+    if args.nameList: output_json = args.nameList + '.json'
+
+    if not args.local:
+        try:
+            from dbs.apis.dbsClient import DbsApi
+        except ImportError:
+            print("getSiblings() relies on CRAB. Please set up the environment for CRAB before using.")
+            sys.exit (1)
+        getDBSSiblings(output_json)
+    else:
+        getLocalSiblings(output_json)


### PR DESCRIPTION
Update of getSiblings script to allow for usage with locally produced datasets. These local datasets have no parent/children info so run and lumi block number are used to match siblings instead. The option -l is used to indicate the dataset is local. There is also a new file getLumiBlock that uses the cmssw Lumi class to get the lumi blocks of files. This is derived from the edm tool edmLumisInFile. This class does not close root files after opening them which can result in a too many files open error (1024 on T3). The file open quota should not be changed on the T3 because we will hit a memory usage limit instead and begin using too much swap memory. Instead the subprocess package is used to get the lumi blocks of 100 files at a time and upon the end of the process the files are closed. 