### PR TITLE
Changing host name to cms-in

### DIFF
--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -1371,7 +1371,7 @@ def copyDatasetInfoToTempFile (f, tempdir):
 #    Get the host name to determine whether you are using lxplus or OSU T3.   #
 ###############################################################################
 hostname = socket.getfqdn()
-remoteAccessT3 = ('interactive' not in hostname)
+remoteAccessT3 = ('cms-in' not in hostname)
 lxbatch = ('cern.ch' in hostname)
 lpcCAF = ('fnal.gov' in hostname)
 rutgers = ('rutgers.edu' in hostname or arguments.forceRutgersMode)


### PR DESCRIPTION
Whenever the computers are reset the host name changes from `interactive-0-X` to `cms-inX`. Instead of renaming the host everytime, this is changing the remoteAccessT3 variable to be in agreement with the default name and not cause issues with the path of files when the `UserDir` dataset option is used.