### PR TITLE
Fixing max events

### DIFF
--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -1617,7 +1617,7 @@ if not arguments.Resubmit:
             if float(arguments.NumberOfFilesPerJob) > 0:
                 NumberOfJobs = int(math.ceil(NumberOfFiles/float(arguments.NumberOfFilesPerJob)))
             if MaxEvents > 0:
-                EventsPerJob = int(math.ceil(int(arguments.MaxEvents)/NumberOfJobs))
+                EventsPerJob = int(math.ceil(int(MaxEvents)/NumberOfJobs))
             if RunOverSkim:
                 NumberOfEvents = int(DatasetRead['numberOfEvents'])
                 if arguments.NumberOfEventsPerJob > 0:

--- a/DBTools/scripts/osusub.py
+++ b/DBTools/scripts/osusub.py
@@ -1536,7 +1536,8 @@ if not arguments.Resubmit:
                      DatasetName = dataset_names[dataset]
                 else:
                      DatasetName = dataset
-                MaxEvents = maxEvents[dataset]
+                if MaxEvents < 0:
+                    MaxEvents = maxEvents[dataset]  # If user has specified MaxEvents, use that value.
 
             GetCompleteOrderedArgumentsSet(InputCondorArguments, currentCondorSubArgumentsSet)
 


### PR DESCRIPTION
This PR changes how the MaxEvents number is being used by `osusub.py`.

Before, only if the number of max events in `configurationOptions.py` was positive that the number of EventsPerJob would be correctly assigned as the number of MaxEvents divided by the NumberOfJobs.

In the case where the number of max events in `configurationOptions.py` was negative, regardless of using the `-m` option, the assigned number of EventsPerJob would take into account the maximum number of events (the -1 value in `configurationOptions.py`) in a given dataset.

The changes are made such that whenever the user inputs some non-negative value into `-m`, it gets the user input (regardless of the `configurationOption.py` value), and if `-m` is negative (including the default option), it gets the `configurationOption.py` value (regardless of the `configurationOption.py` value).

Tested all the cases successfully:
- `-m` > 0 and `configurationOption.py` > 0 (uses `-m`)
- `-m` > 0 and `configurationOption.py` < 0 (uses `-m`)
- `-m` < 0 and `configurationOption.py` > 0 (uses `configurationOption.py`)
- `-m` < 0 and `configurationOption.py` < 0 (uses `configurationOption.py`)