### PR TITLE
Removing isCRAB option

### DIFF
--- a/AnaTools/plugins/ISRWeightProducer.cc
+++ b/AnaTools/plugins/ISRWeightProducer.cc
@@ -7,7 +7,7 @@ ISRWeightProducer::ISRWeightProducer (const edm::ParameterSet &cfg) :
   pdgIds_                  (cfg.getParameter<vector<int> >    ("pdgIds")),
   motherIdsToReject_       (cfg.getParameter<vector<int> >    ("motherIdsToReject")),
   requireLastNotFirstCopy_ (cfg.getParameter<bool>            ("requireLastNotFirstCopy")),
-  weightFile_              (cfg.getParameter<string>          ("weightFile")),
+  weightFile_              (cfg.getParameter<edm::FileInPath>          ("weightFile").fullPath()),
   weightHist_              (cfg.getParameter<vector<string> > ("weightHist")),
   weights_                 ({})
 {

--- a/AnaTools/plugins/ObjectScalingFactorProducer.cc
+++ b/AnaTools/plugins/ObjectScalingFactorProducer.cc
@@ -7,10 +7,10 @@ ObjectScalingFactorProducer::ObjectScalingFactorProducer(const edm::ParameterSet
 {
 
   if (cfg.exists ("electronFile"))
-    electronFile_ = cfg.getParameter<string>("electronFile");
+    electronFile_ = cfg.getParameter<edm::FileInPath>("electronFile").fullPath();
 
   if (cfg.exists ("muonFile"))
-    muonFile_ = cfg.getParameter<string>("muonFile");
+    muonFile_ = cfg.getParameter<edm::FileInPath>("muonFile").fullPath();
 
   if (cfg.exists ("trackFile"))
     trackFile_ = cfg.getParameter<string>("trackFile");

--- a/AnaTools/plugins/PUScalingFactorProducer.cc
+++ b/AnaTools/plugins/PUScalingFactorProducer.cc
@@ -3,7 +3,7 @@
 
 PUScalingFactorProducer::PUScalingFactorProducer(const edm::ParameterSet &cfg) :
    EventVariableProducer(cfg),
-   PU_               (cfg.getParameter<string>("PU")),
+   PU_               (cfg.getParameter<edm::FileInPath>("PU").fullPath()),
    dataset_          (cfg.getParameter<string>("dataset")),
    target_           (cfg.getParameter<string>("target")),
    targetUp_         ((cfg.exists("targetUp"))   ? cfg.getParameter<string>("targetUp")   : ""),

--- a/Collections/plugins/OSUGenericJetProducer.cc
+++ b/Collections/plugins/OSUGenericJetProducer.cc
@@ -10,8 +10,8 @@ OSUGenericJetProducer<T>::OSUGenericJetProducer (const edm::ParameterSet &cfg) :
   collections_ (cfg.getParameter<edm::ParameterSet> ("collections")),
   rho_         (cfg.getParameter<edm::InputTag>  ("rho")),
   jetCorrectionPayloadName_ (cfg.getParameter<string> ("jetCorrectionPayload")),
-  jetResolutionPayload_ (cfg.getParameter<string> ("jetResolutionPayload")),
-  jetResSFPayload_      (cfg.getParameter<string> ("jetResSFPayload")),
+  jetResolutionPayload_ (cfg.getParameter<edm::FileInPath> ("jetResolutionPayload").fullPath()),
+  jetResSFPayload_      (cfg.getParameter<edm::FileInPath> ("jetResSFPayload").fullPath()),
   jetResFromGlobalTag_  (cfg.getParameter<bool> ("jetResFromGlobalTag")),
   jetResNewPrescription_ (cfg.getParameter<bool> ("jetResNewPrescription")),
 

--- a/Collections/plugins/OSUGenericTrackProducer.cc
+++ b/Collections/plugins/OSUGenericTrackProducer.cc
@@ -23,8 +23,6 @@ OSUGenericTrackProducer<T>::OSUGenericTrackProducer (const edm::ParameterSet &cf
   ecalStatusToken_ (esConsumes<edm::Transition::BeginRun>()),
   trackerTopologyToken_ (esConsumes<edm::Transition::BeginRun>()),
 
-  graphPath_(cfg.getParameter<std::string>("graphPath")),
-  graphPathDS_(cfg.getParameter<std::string>("graphPathDS")),
   inputTensorName_(cfg.getParameter<std::string>("inputTensorName")),
   outputTensorName_(cfg.getParameter<std::string>("outputTensorName")),
   inputTensorNameDS_(cfg.getParameter<std::string>("inputTensorNameDS")),
@@ -178,13 +176,13 @@ OSUGenericTrackProducer<T>::initializeGlobalCache(const edm::ParameterSet& confi
   std::unique_ptr<CacheData> cache = std::make_unique<CacheData>();
 
   // load the graph def and save it
-  std::string graphPath = config.getParameter<std::string>("graphPath");
+  std::string graphPath = config.getParameter<edm::FileInPath>("graphPath").fullPath();
   if (!graphPath.empty()) {
     graphPath = edm::FileInPath(graphPath.c_str()).fullPath();
     cache->graphDef = tensorflow::loadGraphDef(graphPath);
   }
 
-  std::string graphPathDS = config.getParameter<std::string>("graphPathDS");
+  std::string graphPathDS = config.getParameter<edm::FileInPath>("graphPathDS").fullPath();
   if (!graphPathDS.empty()) {
     graphPathDS = edm::FileInPath(graphPathDS.c_str()).fullPath();
     cache->graphDefDS = tensorflow::loadGraphDef(graphPathDS);

--- a/Collections/plugins/OSUGenericTrackProducer.h
+++ b/Collections/plugins/OSUGenericTrackProducer.h
@@ -271,9 +271,6 @@ template<class T>
     std::pair<std::array<double, 3>, std::array<double, 3>> getClosestVertices(const std::vector<VertexInfo>, float track_vz, float track_vx, float track_vy) const;
     int getDetectorIndex(const int) const;
 
-    std::string graphPath_;
-    std::string graphPathDS_;
-
     std::string inputTensorName_;
     std::string outputTensorName_;
     std::string inputTensorNameDS_;

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -137,8 +137,8 @@ copyConfiguration (collectionProducer.genjets, collectionProducer.genMatchables)
 
 collectionProducer.jets = cms.EDProducer ("OSUJetProducer",
     rho = cms.InputTag("fixedGridRhoFastjetAll", "", ""),
-    jetResolutionPayload = cms.string(os.environ['CMSSW_BASE'] + "/src/OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_PtResolution_AK4PFchs.txt"),
-    jetResSFPayload = cms.string(os.environ['CMSSW_BASE'] + "/src/OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_SF_AK4PFchs.txt"),
+    jetResolutionPayload = cms.FileInPath("OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_PtResolution_AK4PFchs.txt"),
+    jetResSFPayload = cms.FileInPath("OSUT3Analysis/Collections/data/Fall15_25nsV2_MC_SF_AK4PFchs.txt"),
     jetResFromGlobalTag = cms.bool(False),
     jetResNewPrescription = cms.bool(False),
 )
@@ -282,12 +282,6 @@ collectionProducer.taus = cms.EDProducer ("OSUTauProducer",
 copyConfiguration (collectionProducer.taus, collectionProducer.genMatchables)
 
 #-------------------------------------------------------------------------------
-dataDir = os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Collections/data/'
-fakeGraphFile = "graph_oct25.pb"
-deepSetsGraphFile = "graph.pb"
-fakePath = os.path.join(dataDir, fakeGraphFile)
-deepSetsPath = os.path.join(dataDir, deepSetsGraphFile)
-
 collectionProducer.tracks = cms.EDProducer ("OSUTrackProducer",
     fiducialMaps = cms.PSet (
         electrons = cms.VPSet (
@@ -368,11 +362,11 @@ collectionProducer.tracks = cms.EDProducer ("OSUTrackProducer",
     minTrackPt       = cms.double(20.0),
     maxRelTrackIso   = cms.double(-1.0),
 
-    graphPath = cms.string(fakePath),
+    graphPath = cms.FileInPath('OSUT3Analysis/Collections/data/graph_oct25.pb'),
     inputTensorName = cms.string("Input_input"),
     outputTensorName = cms.string("sequential/Output_xyz/Sigmoid"),
 
-    graphPathDS = cms.string(deepSetsPath),
+    graphPathDS = cms.FileInPath('OSUT3Analysis/Collections/data/graph.pb'),
     inputTensorNameDS = cms.string("input"),
     inputTrackTensorNameDS = cms.string("input_track"),
     outputTensorNameDS = cms.string("model_1/output_xyz/Softmax")

--- a/Configuration/python/PUScalingFactorProducer_cff.py
+++ b/Configuration/python/PUScalingFactorProducer_cff.py
@@ -3,7 +3,7 @@ import os
 
 PUScalingFactorProducer = cms.EDFilter ("PUScalingFactorProducer",
     # this should be set in the user's config file if a different pileup file is being used
-    PU       =  cms.string(os.environ['CMSSW_BASE'] + '/src/OSUT3Analysis/Configuration/data/pu.root'),
+    PU       =  cms.FileInPath('OSUT3Analysis/Configuration/data/pu.root'),
 
     # this should always be set in the user's config file
     target   =  cms.string("data"),

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -528,12 +528,6 @@ def add_channels (process,
         #in the outputCommands
         ########################################################################
         for collection in dir(collectionProducer):
-            if collection == "jets" and isCRAB:
-                collectionProducer.jets.jetResolutionPayload = cms.string("Fall15_25nsV2_MC_PtResolution_AK4PFchs.txt")
-                collectionProducer.jets.jetResSFPayload = cms.string("Fall15_25nsV2_MC_SF_AK4PFchs.txt")
-            if collection == "tracks" and isCRAB:
-                collectionProducer.tracks.graphPath = cms.string('OSUT3Analysis/Collections/data/graph_oct25.pb')
-                collectionProducer.tracks.graphPathDS = cms.string('OSUT3Analysis/Collections/data/graph.pb')
             if isinstance(getattr(collectionProducer,collection) ,FWCore.ParameterSet.Modules.EDProducer) or isinstance(getattr(collectionProducer,collection) ,FWCore.ParameterSet.Modules.EDFilter):
                 dic = vars(getattr(collectionProducer,collection))
                 for p in dic:
@@ -728,9 +722,6 @@ def add_channels (process,
         ########################################################################
         if len(scalingfactorproducers):
             for module in scalingfactorproducers:
-                if isCRAB:
-                    module["electronFile"] = cms.string('electronSFs.root')
-                    module["muonFile"] = cms.string('muonSFs.root')
                 # Here we try to add the original producer as specified in the config files.
                 objectProducer = cms.EDFilter (str(module['name']),
                                         # Use filteredCollections, the ones selected by the objectSelectors
@@ -862,11 +853,6 @@ def add_channels (process,
             skimFilePrefix = "emptySkim"
             outputCommands.append ("drop *")
 
-        if hasattr(process, 'EventJetVarProducer'):
-            if isCRAB: process.EventJetVarProducer.isCRAB = cms.bool(True)
-            else: process.EventJetVarProducer.isCRAB = cms.bool(False)
-
-
         outFileName = ""
         if not isCRAB: outFileName = channelName + "/" + skimFilePrefix + suffix + ".root"
         else: outFileName = skimFilePrefix + "_" + channelName + ".root"
@@ -879,11 +865,10 @@ def add_channels (process,
             SelectEvents = cms.untracked.PSet (SelectEvents = SelectEvents),
             outputCommands = cms.untracked.vstring (outputCommands),
             dropMetaData = cms.untracked.string ("ALL"),
-        )
-        if isCRAB:
-            poolOutputModule.dataset = cms.untracked.PSet(
+            dataset = cms.untracked.PSet(
                 filterName = cms.untracked.string(channelName)
-            )
+            ),
+        )
         add_channels.endPath += poolOutputModule
         setattr (process, channelName + "PoolOutputModule", poolOutputModule)
         ########################################################################

--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -231,8 +231,7 @@ def add_channels (process,
                   skim = None,
                   branchSets = None,
                   ignoreSkimmedCollections = False,
-                  forceNonEmptySkim = False,
-                  isCRAB = False):
+                  forceNonEmptySkim = False):
     if skim != None:
         print("# The \"skim\" parameter of add_channels is obsolete and will soon be deprecated.")
         print("# Please remove from your config files.")
@@ -398,8 +397,7 @@ def add_channels (process,
         if not hasattr (add_channels, "originalName"):
             add_channels.originalName = str(process.TFileService.fileName.pythonValue()).replace("'", "")  # Remove quotes.
             outputName = add_channels.originalName
-            if not isCRAB: suffix = "_" + str(channels[0].name.pythonValue()).replace("'", "") + "_" + get_date_time_stamp()
-            else: suffix = "_" + str(channels[0].name.pythonValue()).replace("'", "")
+            suffix = "_" + str(channels[0].name.pythonValue()).replace("'", "") + "_" + get_date_time_stamp()
             outputName = outputName.replace(".root", suffix + ".root")
             process.TFileService.fileName = cms.string(outputName)
             if os.path.islink (add_channels.originalName):
@@ -853,9 +851,11 @@ def add_channels (process,
             skimFilePrefix = "emptySkim"
             outputCommands.append ("drop *")
 
-        outFileName = ""
-        if not isCRAB: outFileName = channelName + "/" + skimFilePrefix + suffix + ".root"
-        else: outFileName = skimFilePrefix + "_" + channelName + ".root"
+        # channelName folders ARE NOT created locally, to accommodate running stuff with CRAB
+        # Running jobs with osusub is unchanged so that other utilities don't break
+        outFileName = channelName + "/" + skimFilePrefix + suffix + ".root"
+        if not osusub.batchMode: outFileName = skimFilePrefix + "_" + channelName + "_" + get_date_time_stamp() + ".root"
+        print(outFileName)
 
         poolOutputModule = cms.OutputModule ("PoolOutputModule",
             overrideInputFileSplitLevels = cms.untracked.bool (True),


### PR DESCRIPTION
This PR changes the paths of files in modules to accept the format `Package/Sub-Package/data/filename` using the `edm::FileInPath` type. This removes the need to send extra input files to CRAB and to use the `isCRAB` option in the `customize.py` and `processingUtilities.py` files.

It also changed the names of `hist_*` and `skim_*` files to completely remove the `isCRAB` option from `processingUtilities.py`.

Tested locally, with osusub and with CRAB several times with different cases, and everything worked as expected.