### PR TITLE
Changing jet res and electron d0, dz cuts for run 3

### DIFF
--- a/Collections/plugins/OSUGenericJetProducer.cc
+++ b/Collections/plugins/OSUGenericJetProducer.cc
@@ -273,7 +273,8 @@ OSUGenericJetProducer<T>::produce (edm::Event &event, const edm::EventSetup &set
                                    jetEnergyResolutionSFs.getScaleFactor(jetResParams, Variation::UP),
                                    jetEnergyResolutionSFs.getScaleFactor(jetResParams, Variation::DOWN));
 
-      // https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution#Smearing_procedures
+      // https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution#Smearing_procedures for Run 2
+      // https://cms-jerc.web.cern.ch/JER/ for Run 3
       if(hasGenJets) {
         bool isMatchedToGenJet = false;
         for (const auto &genjet : *genjets) {
@@ -281,7 +282,8 @@ OSUGenericJetProducer<T>::produce (edm::Event &event, const edm::EventSetup &set
           double dPt = jet.pt() - genjet.pt();
 
           if(jetResNewPrescription_) {
-            // https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_25/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L237
+            // https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_25/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L237 for Run 2
+            // https://github.com/cms-sw/cmssw/blob/CMSSW_13_0_13/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L260 for Run 3
             if(dR < 0.2 && fabs(dPt) < 3.0 * jet.pt() * jet.jer()) {
               // smearFactor = 1 + (jet.jerSF() - 1.) * dPt / jet.pt();
               jet.set_smearedPt(    max(0.0, jet.pt() + (jet.jerSF()     - 1.) * dPt));

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -149,6 +149,7 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_8_0_") or os.environ["CMSSW_VE
 
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_13_0_"):
     collectionProducer.jets.jetCorrectionPayload = cms.string("AK4PFchs")
+    collectionProducer.jets.jetResNewPrescription = cms.bool(True)
 
 copyConfiguration (collectionProducer.jets, collectionProducer.genMatchables)
 
@@ -312,6 +313,14 @@ collectionProducer.tracks = cms.EDProducer ("OSUTrackProducer",
     EERecHits          =  cms.InputTag  ("reducedEcalRecHitsEE"),
     HBHERecHits        =  cms.InputTag  ("reducedHcalRecHits", "hbhereco"),
 
+    # ONLY UNCOMMENT THIS IF USING MINIAOD ONLY EVENTS PROCESSING AND NOT USING
+    # DEEPSETS; DEEPSETS USE THE OLD COLLECTIONS ABOVE TO GET THE CALO IMAGE
+    # WHEN USING MINIAOD ONLY THE ECALO CUT CAN BE CHANGED TO THE CALO JET BASED
+    # CALCULATION
+    # EBRecHits          =  cms.InputTag  ("reducedEgamma", "reducedEBRecHits"),
+    # EERecHits          =  cms.InputTag  ("reducedEgamma", "reducedEERecHits"),
+    # HBHERecHits        =  cms.InputTag  ("slimmedHcalRecHits", "reducedHcalRecHits"),
+
     rhoTag             =  cms.InputTag  ("fixedGridRhoFastjetAll"),
     rhoCaloTag         =  cms.InputTag  ("fixedGridRhoFastjetAllCalo"),
     rhoCentralCaloTag  =  cms.InputTag  ("fixedGridRhoFastjetCentralCalo"),
@@ -403,9 +412,10 @@ if osusub.batchMode and types[osusub.datasetLabel] == "data":
         collectionProducer.tracks.fiducialMaps.muons[0].era = cms.string (osusub.datasetLabel[osusub.datasetLabel.find('_201'):])
 
 # For 94X/102X which use electron VIDs, define the vertexing requirements for veto electrons
-if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_"):
+if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_13_0_"):
     # Cut values are ordered by ID, as: veto, loose, medium, tight
     # https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Working_points_for_92X_and_later
+    # https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun3#Working_points_for_Run3_v1_ID_tr
     collectionProducer.tracks.eleVtx_d0Cuts_barrel = cms.vdouble(0.05, 0.05, 0.05, 0.05)
     collectionProducer.tracks.eleVtx_dzCuts_barrel = cms.vdouble(0.10, 0.10, 0.10, 0.10)
     collectionProducer.tracks.eleVtx_d0Cuts_endcap = cms.vdouble(0.10, 0.10, 0.10, 0.10)


### PR DESCRIPTION
This PR sets `jetResNewPrescription` as true also for Run 3 jets to use the recommendation from the JME POG.

It also changes the electron cut based d0 and dz selections to use the recommendation from the EGM POG.