### PR TITLE
Changes to allow MiniAOD only processing

### DIFF
--- a/AnaTools/interface/DataFormat.h
+++ b/AnaTools/interface/DataFormat.h
@@ -4,21 +4,24 @@
 // bit 0: datatier flag (0=AOD, 1=MINIAOD)
 // bit 1: 2017 flag (0=not 2017, 1=2017 -- only relevant for MINIAOD in 2017)
 // bit 2: custom flag (0=not custom, 1=custom)
+// bit 3: 2022 flag (0=not 2022, 1=2022)
+// bit 4: only flag (0=not only MiniAOD, 1=only MiniAOD)
 
-#define AOD                  0b0000 // 0
-#define MINI_AOD             0b0001 // 1
-#define AOD_2017             0b0010 // 2 (unused)
-#define MINI_AOD_2017        0b0011 // 3
-#define AOD_CUSTOM           0b0100 // 4
-#define MINI_AOD_CUSTOM      0b0101 // 5
-#define AOD_2017_CUSTOM      0b0110 // 6 (unused)
-#define MINI_AOD_2017_CUSTOM 0b0111 // 7
-#define AOD_2022             0b1000 // 8
-#define MINI_AOD_2022        0b1001 // 9 
-#define AOD_2022_CUSTOM      0b1100 // 12
-#define MINI_AOD_2022_CUSTOM 0b1101 // 13
+#define AOD                       0b00000 // 0
+#define MINI_AOD                  0b00001 // 1
+#define AOD_2017                  0b00010 // 2 (unused)
+#define MINI_AOD_2017             0b00011 // 3
+#define AOD_CUSTOM                0b00100 // 4
+#define MINI_AOD_CUSTOM           0b00101 // 5
+#define AOD_2017_CUSTOM           0b00110 // 6 (unused)
+#define MINI_AOD_2017_CUSTOM      0b00111 // 7
+#define AOD_2022                  0b01000 // 8
+#define MINI_AOD_2022             0b01001 // 9
+#define AOD_2022_CUSTOM           0b01100 // 12
+#define MINI_AOD_2022_CUSTOM      0b01101 // 13
+#define MINI_AOD_ONLY_2022_CUSTOM 0b11101 // 15
 
-#define DATA_FORMAT MINI_AOD_2022_CUSTOM
+#define DATA_FORMAT MINI_AOD_ONLY_2022_CUSTOM
 
 #define DATA_FORMAT_FROM_MINIAOD (DATA_FORMAT & 0b1) == 1
 #define DATA_FORMAT_FROM_AOD (DATA_FORMAT & 0b1) == 0
@@ -26,7 +29,7 @@
 #define DATA_FORMAT_IS_CUSTOM ((DATA_FORMAT >> 2) & 0b1) == 1
 #define DATA_FORMAT_IS_2022 ((DATA_FORMAT >> 3) & 0b1) == 1
 
-#define DATA_FORMAT_IS_VALID (DATA_FORMAT == AOD || DATA_FORMAT == MINI_AOD || DATA_FORMAT == AOD_2017 || DATA_FORMAT == MINI_AOD_2017 || DATA_FORMAT == AOD_CUSTOM || DATA_FORMAT == MINI_AOD_CUSTOM || DATA_FORMAT == AOD_2017_CUSTOM || DATA_FORMAT == MINI_AOD_2017_CUSTOM || DATA_FORMAT == MINI_AOD_2022 || DATA_FORMAT == MINI_AOD_2022_CUSTOM)
+#define DATA_FORMAT_IS_VALID (DATA_FORMAT == AOD || DATA_FORMAT == MINI_AOD || DATA_FORMAT == AOD_2017 || DATA_FORMAT == MINI_AOD_2017 || DATA_FORMAT == AOD_CUSTOM || DATA_FORMAT == MINI_AOD_CUSTOM || DATA_FORMAT == AOD_2017_CUSTOM || DATA_FORMAT == MINI_AOD_2017_CUSTOM || DATA_FORMAT == MINI_AOD_2022 || DATA_FORMAT == MINI_AOD_2022_CUSTOM || DATA_FORMAT == MINI_AOD_ONLY_2022 || DATA_FORMAT == MINI_AOD_ONLY_2022_CUSTOM)
 
 #define INVALID_TYPE void *
 

--- a/AnaTools/python/osuAnalysis_cfi.py
+++ b/AnaTools/python/osuAnalysis_cfi.py
@@ -5,7 +5,7 @@ import copy
 ##### Define the datatier being used ####
 #########################################
 
-dataFormat = "MINI_AOD_2022_CUSTOM"
+dataFormat = "MINI_AOD_ONLY_2022_CUSTOM"
 
 ###########################################################
 ##### Set up the standard input collections in miniAOD ####

--- a/AnaTools/scripts/setupFramework.py
+++ b/AnaTools/scripts/setupFramework.py
@@ -28,7 +28,7 @@ A_BRIGHT_WHITE    =  "\033[1;37m"
 
 A_RESET           =  "\033[0m"
 
-supported_formats = ["AOD", "MINI_AOD", "MINI_AOD_2017", "MINI_AOD_2022"]
+supported_formats = ["AOD", "MINI_AOD", "MINI_AOD_2017", "MINI_AOD_2022", "MINI_AOD_ONLY_2022"]
 
 parser = OptionParser()
 parser.add_option("-f", "--format", dest="data_format",

--- a/Collections/interface/DisappearingTrack.h
+++ b/Collections/interface/DisappearingTrack.h
@@ -80,7 +80,7 @@ namespace osu {
       enum RhoType { All, Calo, CentralCalo };
       enum CaloType { Sum, EM, Had };
 
-#if DATA_FORMAT != MINI_AOD_2022_CUSTOM
+#if DATA_FORMAT != MINI_AOD_2022_CUSTOM && DATA_FORMAT != MINI_AOD_ONLY_2022_CUSTOM
       const edm::Ref<vector<CandidateTrack> > matchedCandidateTrack () const { return matchedCandidateTrack_; };
       const double dRToMatchedCandidateTrack () const { return (IS_INVALID(dRToMatchedCandidateTrack_)) ? MAX_DR : dRToMatchedCandidateTrack_; };
 #endif
@@ -359,7 +359,7 @@ namespace osu {
       void set_additionalPFIsolations(const edm::Handle<vector<pat::PackedCandidate> > &, const edm::Handle<vector<pat::PackedCandidate> > &);
       void set_caloValues(); //mcarrigan
 
-#if DATA_FORMAT != MINI_AOD_2022_CUSTOM
+#if DATA_FORMAT != MINI_AOD_2022_CUSTOM && DATA_FORMAT != MINI_AOD_ONLY_2022_CUSTOM
       edm::Ref<vector<CandidateTrack> > matchedCandidateTrack_;
       double dRToMatchedCandidateTrack_;
       double maxDeltaR_candidateTrackMatching_;

--- a/Collections/interface/TrackBase.h
+++ b/Collections/interface/TrackBase.h
@@ -143,7 +143,7 @@ namespace osu
       void PrintTrackHitCategoryPatterns(const reco::HitPattern::HitCategory category) const;
       void PrintTrackHitPatternInfo() const;
 
-#if DATA_FORMAT != MINI_AOD_2017 && DATA_FORMAT != MINI_AOD_2022_CUSTOM
+#if DATA_FORMAT != MINI_AOD_2017 && DATA_FORMAT != MINI_AOD_2022_CUSTOM && DATA_FORMAT != MINI_AOD_ONLY_2022_CUSTOM
       const double innerP() const;
       const double outerP() const;
       const double fbrem() const;

--- a/Collections/src/DisappearingTrack.cc
+++ b/Collections/src/DisappearingTrack.cc
@@ -491,7 +491,7 @@ osu::DisappearingTrack::DisappearingTrack (const TYPE(tracks) &track,
   set_primaryPFIsolations(pfCandidates);
   set_additionalPFIsolations(pfCandidates, lostTracks);
 
-#if DATA_FORMAT != MINI_AOD_2022_CUSTOM
+#if DATA_FORMAT != MINI_AOD_2022_CUSTOM && DATA_FORMAT != MINI_AOD_ONLY_2022_CUSTOM
   // if the tracks collection itself is CandidateTracks, don't bother with matching this to itself
   if(cfg.getParameter<edm::ParameterSet>("collections").getParameter<edm::InputTag>("tracks").label() != "candidateTrackProducer") {
     maxDeltaR_candidateTrackMatching_ = cfg.getParameter<double> ("maxDeltaRForCandidateTrackMatching");
@@ -519,7 +519,7 @@ osu::DisappearingTrack::~DisappearingTrack ()
   eleVtx_dzCuts_endcap_.clear();
 }
 
-#if DATA_FORMAT != MINI_AOD_2022_CUSTOM
+#if DATA_FORMAT != MINI_AOD_2022_CUSTOM && DATA_FORMAT != MINI_AOD_ONLY_2022_CUSTOM
 const edm::Ref<vector<CandidateTrack> > &
 osu::DisappearingTrack::findMatchedCandidateTrack (const edm::Handle<vector<CandidateTrack> > &candidateTracks, edm::Ref<vector<CandidateTrack> > &matchedCandidateTrack, double &dRToMatchedCandidateTrack) const
 {

--- a/Collections/src/TrackBase.cc
+++ b/Collections/src/TrackBase.cc
@@ -963,7 +963,7 @@ osu::TrackBase::lastLayerWithValidHit () const
 }
 
 /******************************************************************************/
-#if DATA_FORMAT != MINI_AOD_2017 && DATA_FORMAT != MINI_AOD_2022_CUSTOM
+#if DATA_FORMAT != MINI_AOD_2017 && DATA_FORMAT != MINI_AOD_2022_CUSTOM && DATA_FORMAT != MINI_AOD_ONLY_2022_CUSTOM
 const double
 osu::TrackBase::innerP () const
 {
@@ -1006,7 +1006,7 @@ osu::TrackBase::bremEnergy () const
 const bool
 osu::TrackBase::isBadGsfTrack (const reco::GsfTrack &track) const
 {
-#if DATA_FORMAT == MINI_AOD_2017 || DATA_FORMAT == MINI_AOD_2022_CUSTOM
+#if DATA_FORMAT == MINI_AOD_2017 || DATA_FORMAT == MINI_AOD_2022_CUSTOM || DATA_FORMAT == MINI_AOD_ONLY_2022_CUSTOM
   return true;
 #else
 
@@ -1295,7 +1295,7 @@ osu::TrackBase::inTOBCrack () const
 {
 #if DATA_FORMAT == MINI_AOD_2017
   double fabsLambda = fabs(M_PI_2 - this->theta());
-#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM
+#elif DATA_FORMAT == MINI_AOD_2022_CUSTOM || DATA_FORMAT == MINI_AOD_ONLY_2022_CUSTOM
   double fabsLambda = fabs(M_PI_2 - this->theta());
 #else
   double fabsLambda = fabs(this->lambda());

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 import OSUT3Analysis.DBTools.osusub_cfg as osusub
 from OSUT3Analysis.Configuration.configurationOptions import *
+from OSUT3Analysis.AnaTools.osuAnalysis_cfi import dataFormat
 import copy
 import os
 
@@ -313,14 +314,6 @@ collectionProducer.tracks = cms.EDProducer ("OSUTrackProducer",
     EERecHits          =  cms.InputTag  ("reducedEcalRecHitsEE"),
     HBHERecHits        =  cms.InputTag  ("reducedHcalRecHits", "hbhereco"),
 
-    # ONLY UNCOMMENT THIS IF USING MINIAOD ONLY EVENTS PROCESSING AND NOT USING
-    # DEEPSETS; DEEPSETS USE THE OLD COLLECTIONS ABOVE TO GET THE CALO IMAGE
-    # WHEN USING MINIAOD ONLY THE ECALO CUT CAN BE CHANGED TO THE CALO JET BASED
-    # CALCULATION
-    # EBRecHits          =  cms.InputTag  ("reducedEgamma", "reducedEBRecHits"),
-    # EERecHits          =  cms.InputTag  ("reducedEgamma", "reducedEERecHits"),
-    # HBHERecHits        =  cms.InputTag  ("slimmedHcalRecHits", "reducedHcalRecHits"),
-
     rhoTag             =  cms.InputTag  ("fixedGridRhoFastjetAll"),
     rhoCaloTag         =  cms.InputTag  ("fixedGridRhoFastjetAllCalo"),
     rhoCentralCaloTag  =  cms.InputTag  ("fixedGridRhoFastjetCentralCalo"),
@@ -410,6 +403,9 @@ if osusub.batchMode and types[osusub.datasetLabel] == "data":
     if "_201" in osusub.datasetLabel:
         collectionProducer.tracks.fiducialMaps.electrons[0].era = cms.string (osusub.datasetLabel[osusub.datasetLabel.find('_201'):])
         collectionProducer.tracks.fiducialMaps.muons[0].era = cms.string (osusub.datasetLabel[osusub.datasetLabel.find('_201'):])
+    if "_202" in osusub.datasetLabel:
+        collectionProducer.tracks.fiducialMaps.electrons[0].era = cms.string (osusub.datasetLabel[osusub.datasetLabel.find('_202'):])
+        collectionProducer.tracks.fiducialMaps.muons[0].era = cms.string (osusub.datasetLabel[osusub.datasetLabel.find('_202'):])
 
 # For 94X/102X which use electron VIDs, define the vertexing requirements for veto electrons
 if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_10_2_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_12_4_") or os.environ["CMSSW_VERSION"].startswith ("CMSSW_13_0_"):
@@ -420,6 +416,11 @@ if os.environ["CMSSW_VERSION"].startswith ("CMSSW_9_4_") or os.environ["CMSSW_VE
     collectionProducer.tracks.eleVtx_dzCuts_barrel = cms.vdouble(0.10, 0.10, 0.10, 0.10)
     collectionProducer.tracks.eleVtx_d0Cuts_endcap = cms.vdouble(0.10, 0.10, 0.10, 0.10)
     collectionProducer.tracks.eleVtx_dzCuts_endcap = cms.vdouble(0.20, 0.20, 0.20, 0.20)
+
+if dataFormat == 'MINI_AOD_ONLY_2022_CUSTOM':
+    collectionProducer.tracks.EBRecHits   =  cms.InputTag  ("reducedEgamma", "reducedEBRecHits")
+    collectionProducer.tracks.EERecHits   =  cms.InputTag  ("reducedEgamma", "reducedEERecHits")
+    collectionProducer.tracks.HBHERecHits =  cms.InputTag  ("slimmedHcalRecHits", "reducedHcalRecHits")
 
 copyConfiguration (collectionProducer.tracks, collectionProducer.genMatchables)
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds changes to allow for the processing of data using the MiniAOD datasets only.

Checked for differences when processing with the MiniAOD+AOD skims and found none.