### PR TITLE
Changing jet ID selections to use common utils and datasets legends

### DIFF
--- a/Collections/plugins/OSUGenericTrackProducer.cc
+++ b/Collections/plugins/OSUGenericTrackProducer.cc
@@ -1321,9 +1321,9 @@ OSUGenericTrackProducer<T>::getTrackInfo(const T &track,
   info.dRMinJet = -1;
   for(const auto &jet : jets) {
     if(jet.pt() > 30 &&
-        fabs(jet.eta()) < 4.5 &&
-        (((jet.neutralHadronEnergyFraction()<0.90 && jet.neutralEmEnergyFraction()<0.90 && (jet.chargedMultiplicity() + jet.neutralMultiplicity())>1 && jet.muonEnergyFraction()<0.8) && ((fabs(jet.eta())<=2.4 && jet.chargedHadronEnergyFraction()>0 && jet.chargedMultiplicity()>0 && jet.chargedEmEnergyFraction()<0.90) || fabs(jet.eta())>2.4) && fabs(jet.eta())<=3.0)
-          || (jet.neutralEmEnergyFraction()<0.90 && jet.neutralMultiplicity()>10 && fabs(jet.eta())>3.0))) {
+       fabs(jet.eta()) < 4.5 &&
+       anatools::jetPassesTightLepVeto(jet) // This automatically uses the correct jet ID criteria
+      ) {
       double dR = deltaR(track, jet);
       if(info.dRMinJet < 0 || dR < info.dRMinJet) info.dRMinJet = dR;
     }

--- a/Collections/src/TrackBase.cc
+++ b/Collections/src/TrackBase.cc
@@ -1,4 +1,5 @@
 #include "OSUT3Analysis/Collections/interface/TrackBase.h"
+#include "OSUT3Analysis/AnaTools/interface/CommonUtils.h" // Needed to include anatools::jetPassesTightLepVeto; doesn't work if added in TrackBase.h
 
 #if IS_VALID(tracks)
 
@@ -189,8 +190,8 @@ osu::TrackBase::TrackBase (const TYPE(tracks) &track,
 #else
       if(jet.pt() > 30 &&
          fabs(jet.eta()) < 4.5 &&
-         (((jet.neutralHadronEnergyFraction()<0.90 && jet.neutralEmEnergyFraction()<0.90 && (jet.chargedMultiplicity() + jet.neutralMultiplicity())>1 && jet.muonEnergyFraction()<0.8) && ((fabs(jet.eta())<=2.4 && jet.chargedHadronEnergyFraction()>0 && jet.chargedMultiplicity()>0 && jet.chargedEmEnergyFraction()<0.90) || fabs(jet.eta())>2.4) && fabs(jet.eta())<=3.0)
-            || (jet.neutralEmEnergyFraction()<0.90 && jet.neutralMultiplicity()>10 && fabs(jet.eta())>3.0)))
+         anatools::jetPassesTightLepVeto(jet) // This automatically uses the correct jet ID criteria
+        )
 #endif
       {
         double dR = deltaR(*this, jet);

--- a/Configuration/python/configurationOptions.py
+++ b/Configuration/python/configurationOptions.py
@@ -8749,8 +8749,8 @@ labels = {
 
   #Run3 2022EE
   'WToLNu_4Jets_2022EE' : "W#rightarrowl#nu",
-  'DYto2L_4jets_M10to50_2022EE' : "Z#rightarrowll M(5to50)",
-  'DYJetsToLL_M50_2022EE' : "Z#rightarrowll M(10to50)",
+  'DYto2L_4jets_M10to50_2022EE' : "Z#rightarrowll M(10to50)",
+  'DYJetsToLL_M50_2022EE' : "Z#rightarrowll M(50)",
   'TbarBtoLminusNuB_2022EE' : "#bar{t}b#rightarrowl#nub",
   'TBbartoLplusNuBbar_2022EE' : "t#bar{b}#rightarrowl#nu#bar{b}",
   'TbarQtoLNu_2022EE' : "#bar{t}q#rightarrowl#nu",


### PR DESCRIPTION
This PR changes every place the jet ID criteria was added by hand, to use the method defined in `OSUT3Analysis/AnaTools/interface/CommonUtils.h`.

It also adds some changes to some datasets legends in `configurationOptions.py`.