### PR TITLE
Changes for Run 3

### DIFF
--- a/Collections/interface/Tau.h
+++ b/Collections/interface/Tau.h
@@ -50,9 +50,11 @@ namespace osu
 
         const bool match_HLT_LooseIsoPFTau50_Trk30_eta2p1_v () const;
         const bool match_HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v () const;
+        const bool match_HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v () const;
 
         void set_match_HLT_LooseIsoPFTau50_Trk30_eta2p1_v (const bool);
         void set_match_HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v (const bool);
+        void set_match_HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v (const bool);
 
       private:
 
@@ -78,6 +80,7 @@ namespace osu
 
         bool match_HLT_LooseIsoPFTau50_Trk30_eta2p1_v_;
         bool match_HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v_;
+        bool match_HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v_;
     };
 }
 

--- a/Collections/plugins/OSUGenericTrackProducer.cc
+++ b/Collections/plugins/OSUGenericTrackProducer.cc
@@ -1176,15 +1176,28 @@ OSUGenericTrackProducer<T>::getTagMuons(const edm::Event &event,
     iso = muon.pfIsolationR04().sumChargedHadronPt + max(0.0, iso);
     if(iso / muon.pt() >= 0.15) continue;
 
+#if DATA_FORMAT_IS_2017
     if(!anatools::isMatchedToTriggerObject(event,
                                            triggers,
                                            muon,
                                            trigObjs,
                                            (is2017_ ? "hltIterL3MuonCandidates::HLT" : "hltHighPtTkMuonCands::HLT"),
-                                           (is2017_ ? "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07" : "hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08"))) {
+                                           (is2017_ ? "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07" : "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07"))) {
       continue; // cutMuonMatchToTrigObj
     }
-    
+
+#elif DATA_FORMAT_IS_2022
+    if(!anatools::isMatchedToTriggerObject(event,
+                                           triggers,
+                                           muon,
+                                           trigObjs,
+                                           "hltIterL3MuonCandidates::HLT",
+                                           "hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered")) {
+      continue; // cutMuonMatchToTrigObj
+    }
+
+#endif
+
     tagMuons.push_back(muon);
   }
 

--- a/Collections/plugins/OSUGenericTrackProducer.cc
+++ b/Collections/plugins/OSUGenericTrackProducer.cc
@@ -1125,7 +1125,8 @@ OSUGenericTrackProducer<T>::getTagElectrons(const edm::Event &event,
     }
 
     if(fabs(electron.eta()) >= 2.1) continue;
-    if(!electron.electronID(is2017_ ? "cutBasedElectronID-Fall17-94X-V1-tight" : "cutBasedElectronID-Fall17-94X-V2-tight")) continue;
+    // if(!electron.electronID(is2017_ ? "cutBasedElectronID-Fall17-94X-V1-tight" : "cutBasedElectronID-Fall17-94X-V2-tight")) continue;
+    if(!electron.electronID("cutBasedElectronID-RunIIIWinter22-V1-tight")) continue;
     
     if(fabs(electron.superCluster()->eta()) <= 1.479) {
       if(fabs(electron.gsfTrack()->dxy(vertex.position())) >= 0.05) continue;

--- a/Collections/plugins/OSUGenericTrackProducer.cc
+++ b/Collections/plugins/OSUGenericTrackProducer.cc
@@ -1167,7 +1167,7 @@ OSUGenericTrackProducer<T>::getTagMuons(const edm::Event &event,
                                            muon,
                                            trigObjs,
                                            (is2017_ ? "hltIterL3MuonCandidates::HLT" : "hltHighPtTkMuonCands::HLT"),
-                                           (is2017_ ? "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07" : "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07"))) {
+                                           (is2017_ ? "hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07" : "hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08"))) {
       continue; // cutMuonMatchToTrigObj
     }
     
@@ -1200,14 +1200,14 @@ OSUGenericTrackProducer<T>::getTrackInfo(const T &track,
   //apply track pt cut
   if(minTrackPt_ > 0 && track.pt() <= minTrackPt_) return info;
 
-  info.trackIso = 0.0;
-  for(const auto &t : *tracks) {
-    const auto theptinv2 = 1 / pow(track.pt(),2);
-    float dz_track = (track.vz() - t.vz()) - ((track.vx() - t.vx()) * track.px() + (track.vy() - t.vy()) * track.py()) * track.pz() * theptinv2;
-    if(fabs(dz_track) > 3.0 * hypot(track.dzError(), t.dzError())) continue;
-    double dR = deltaR(track, t);
-    if(dR < 0.3 && dR > 1.0e-12) info.trackIso += t.pt();
-  }
+  info.trackIso = track.pfIsolationDR03().chargedHadronIso();
+  // for(const auto &t : *tracks) {
+  //   const auto theptinv2 = 1 / pow(track.pt(),2);
+  //   float dz_track = (track.vz() - t.vz()) - ((track.vx() - t.vx()) * track.px() + (track.vy() - t.vy()) * track.py()) * track.pz() * theptinv2;
+  //   if(fabs(dz_track) > 3.0 * hypot(track.dzError(), t.dzError())) continue;
+  //   double dR = deltaR(track, t);
+  //   if(dR < 0.3 && dR > 1.0e-12) info.trackIso += t.pt();
+  // }
 
   // apply relative track isolation cut
   if(maxRelTrackIso_ > 0 && info.trackIso / track.pt() >= maxRelTrackIso_) return info;
@@ -1370,17 +1370,29 @@ OSUGenericTrackProducer<T>::getTrackInfo(const T &track,
 
   info.deltaRToClosestTauHad = -1;
   for(const auto &tau : taus) {
-    if(tau.isTauIDAvailable("againstElectronLooseMVA5")) {
-      if(tau.tauID("decayModeFinding") <= 0.5 ||
-          tau.tauID("againstElectronLooseMVA5") <= 0.5 ||
-          tau.tauID("againstMuonLoose3") <= 0.5) {
+    // if(tau.isTauIDAvailable("againstElectronLooseMVA5")) {
+    //   if(tau.tauID("decayModeFinding") <= 0.5 ||
+    //       tau.tauID("againstElectronLooseMVA5") <= 0.5 ||
+    //       tau.tauID("againstMuonLoose3") <= 0.5) {
+    //     continue;
+    //   }
+    // }
+    // else if(tau.isTauIDAvailable("againstElectronLooseMVA6")) {
+    //   if(tau.tauID("decayModeFinding") <= 0.5 ||
+    //       tau.tauID("againstElectronLooseMVA6") <= 0.5 ||
+    //       tau.tauID("againstMuonLoose3") <= 0.5) {
+    //     continue;
+    //   }
+    // }
+    if(tau.isTauIDAvailable("byVVVLooseDeepTau2018v2p5VSe")) {
+      if(tau.tauID("decayModeFindingNewDMs") <= 0.5 ||
+          tau.tauID("byVVVLooseDeepTau2018v2p5VSe") <= 0.5) {
         continue;
       }
     }
-    else if(tau.isTauIDAvailable("againstElectronLooseMVA6")) {
-      if(tau.tauID("decayModeFinding") <= 0.5 ||
-          tau.tauID("againstElectronLooseMVA6") <= 0.5 ||
-          tau.tauID("againstMuonLoose3") <= 0.5) {
+    else if(tau.isTauIDAvailable("byVLooseDeepTau2018v2p5VSmu")) {
+      if(tau.tauID("decayModeFindingNewDMs") <= 0.5 ||
+          tau.tauID("byVLooseDeepTau2018v2p5VSmu") <= 0.5) {
         continue;
       }
     }

--- a/Collections/plugins/OSUGenericTrackProducer.cc
+++ b/Collections/plugins/OSUGenericTrackProducer.cc
@@ -111,6 +111,8 @@ OSUGenericTrackProducer<T>::OSUGenericTrackProducer (const edm::ParameterSet &cf
   // disappearing track ntuples.
   tracksToken_ = consumes<vector<reco::Track> > (edm::InputTag ("generalTracks", "", "RECO"));
 
+  muonTriggerFilter_ = cfg.getParameter<std::string> ("muonTriggerFilter");
+
   //caloGeometryToken_  = esConsumes();
   //ecalStatusToken_    = esConsumes();
 
@@ -1187,12 +1189,13 @@ OSUGenericTrackProducer<T>::getTagMuons(const edm::Event &event,
     }
 
 #elif DATA_FORMAT_IS_2022
+
     if(!anatools::isMatchedToTriggerObject(event,
                                            triggers,
                                            muon,
                                            trigObjs,
                                            "hltIterL3MuonCandidates::HLT",
-                                           "hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered")) {
+                                           muonTriggerFilter_)) {
       continue; // cutMuonMatchToTrigObj
     }
 

--- a/Collections/plugins/OSUGenericTrackProducer.cc
+++ b/Collections/plugins/OSUGenericTrackProducer.cc
@@ -1397,35 +1397,56 @@ OSUGenericTrackProducer<T>::getTrackInfo(const T &track,
 
   info.deltaRToClosestTauHad = -1;
   for(const auto &tau : taus) {
-    // if(tau.isTauIDAvailable("againstElectronLooseMVA5")) {
-    //   if(tau.tauID("decayModeFinding") <= 0.5 ||
-    //       tau.tauID("againstElectronLooseMVA5") <= 0.5 ||
-    //       tau.tauID("againstMuonLoose3") <= 0.5) {
-    //     continue;
-    //   }
-    // }
-    // else if(tau.isTauIDAvailable("againstElectronLooseMVA6")) {
-    //   if(tau.tauID("decayModeFinding") <= 0.5 ||
-    //       tau.tauID("againstElectronLooseMVA6") <= 0.5 ||
-    //       tau.tauID("againstMuonLoose3") <= 0.5) {
-    //     continue;
-    //   }
-    // }
+
+#if DATA_FORMAT_IS_2017
+    if(tau.isTauIDAvailable("againstElectronLooseMVA5")) {
+      if(tau.tauID("decayModeFinding") <= 0.5 ||
+          tau.tauID("againstElectronLooseMVA5") <= 0.5 ||
+          tau.tauID("againstMuonLoose3") <= 0.5) {
+        continue;
+      }
+    }
+    else if(tau.isTauIDAvailable("againstElectronLooseMVA6")) {
+      if(tau.tauID("decayModeFinding") <= 0.5 ||
+          tau.tauID("againstElectronLooseMVA6") <= 0.5 ||
+          tau.tauID("againstMuonLoose3") <= 0.5) {
+        continue;
+      }
+    }
+
+#elif DATA_FORMAT_IS_2022
     if(tau.isTauIDAvailable("byVVVLooseDeepTau2018v2p5VSe")) {
       if(tau.tauID("decayModeFindingNewDMs") <= 0.5 ||
           tau.tauID("byVVVLooseDeepTau2018v2p5VSe") <= 0.5) {
         continue;
       }
     }
-    else if(tau.isTauIDAvailable("byVLooseDeepTau2018v2p5VSmu")) {
+    else if(tau.isTauIDAvailable("byVVVLooseDeepTau2017v2p1VSe")) {
       if(tau.tauID("decayModeFindingNewDMs") <= 0.5 ||
-          tau.tauID("byVLooseDeepTau2018v2p5VSmu") <= 0.5) {
+          tau.tauID("byVVVLooseDeepTau2017v2p1VSe") <= 0.5) {
         continue;
       }
     }
     else {
       continue;
     }
+    if(tau.isTauIDAvailable("byVLooseDeepTau2018v2p5VSmu")) {
+      if(tau.tauID("decayModeFindingNewDMs") <= 0.5 ||
+          tau.tauID("byVLooseDeepTau2018v2p5VSmu") <= 0.5) {
+        continue;
+      }
+    }
+    else if(tau.isTauIDAvailable("byVLooseDeepTau2017v2p1VSmu")) {
+      if(tau.tauID("decayModeFindingNewDMs") <= 0.5 ||
+          tau.tauID("byVLooseDeepTau2017v2p1VSmu") <= 0.5) {
+        continue;
+      }
+    }
+    else {
+      continue;
+    }
+
+#endif
 
     double thisDR = deltaR(tau, track);
     if(info.deltaRToClosestTauHad < 0 || thisDR < info.deltaRToClosestTauHad) info.deltaRToClosestTauHad = thisDR;

--- a/Collections/plugins/OSUGenericTrackProducer.cc
+++ b/Collections/plugins/OSUGenericTrackProducer.cc
@@ -1415,6 +1415,8 @@ OSUGenericTrackProducer<T>::getTrackInfo(const T &track,
     }
 
 #elif DATA_FORMAT_IS_2022
+    // The Tau IDs is done like this so that the 2018v2p5 algorithm has priority over the 2017v2p1, which is the recommendation from the Tau POG
+    // The 2018v2p5 doesn't exist in the PromptReco files, but exist in the rereco MiniAOD
     if(tau.isTauIDAvailable("byVVVLooseDeepTau2018v2p5VSe")) {
       if(tau.tauID("decayModeFindingNewDMs") <= 0.5 ||
           tau.tauID("byVVVLooseDeepTau2018v2p5VSe") <= 0.5) {

--- a/Collections/plugins/OSUGenericTrackProducer.h
+++ b/Collections/plugins/OSUGenericTrackProducer.h
@@ -322,6 +322,8 @@ template<class T>
     double PhiRange_ = 0.25;
     int maxHits_ = 100;
 
+    std::string muonTriggerFilter_;
+
 };
 
 #endif

--- a/Collections/plugins/OSUGenericTrackProducer.h
+++ b/Collections/plugins/OSUGenericTrackProducer.h
@@ -228,7 +228,8 @@ template<class T>
                                         const edm::TriggerResults &,
                                         const vector<pat::TriggerObjectStandAlone> &,
                                         const reco::Vertex &,
-                                        const edm::View<pat::Electron> &);
+                                        const edm::View<pat::Electron> &,
+                                        const edm::Handle<edm::ValueMap<bool>> &);
 
     vector<pat::Muon> getTagMuons(const edm::Event &,
                                 const edm::TriggerResults &,

--- a/Collections/plugins/OSUTauProducer.cc
+++ b/Collections/plugins/OSUTauProducer.cc
@@ -53,6 +53,7 @@ OSUTauProducer::produce (edm::Event &event, const edm::EventSetup &setup)
       if(trigobjs.isValid()) {
         tau.set_match_HLT_LooseIsoPFTau50_Trk30_eta2p1_v (anatools::isMatchedToTriggerObject (event, *triggers, object, *trigobjs, "hltSelectedPFTausTrackPt30AbsOrRelIsolation::HLT", "hltPFTau50TrackPt30LooseAbsOrRelIso"));
         tau.set_match_HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v (anatools::isMatchedToTriggerObject (event, *triggers, object, *trigobjs, "hltSelectedPFTausTrackPt30MediumAbsOrRelIsolation1Prong::HLT", "hltPFTau50TrackPt30MediumAbsOrRelIso1Prong"));
+        tau.set_match_HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v (anatools::isMatchedToTriggerObject (event, *triggers, object, *trigobjs, "hltHpsSinglePFTau20MediumDitauWPDeepTauNoMatchForVBFIsoTau::HLT", "hltHpsOverlapFilterIsoMu24MediumDeepTauPFTau20")); // Not sure if this works; need to check
       }
 #endif
     }

--- a/Collections/src/DisappearingTrack.cc
+++ b/Collections/src/DisappearingTrack.cc
@@ -683,18 +683,40 @@ osu::DisappearingTrack::set_minDeltaRToTaus(const edm::Handle<vector<TYPE(taus)>
 
     if(dR < deltaRToClosestTau_ || deltaRToClosestTau_ < 0.0) deltaRToClosestTau_ = dR;
 
-    // passesDecayModeReconstruction = (tau.isTauIDAvailable("decayModeFinding") && tau.tauID("decayModeFinding") > 0.5);
+#if DATA_FORMAT_IS_2017
+    passesDecayModeReconstruction = (tau.isTauIDAvailable("decayModeFinding") && tau.tauID("decayModeFinding") > 0.5);
 
-    // passesLightFlavorRejection = (tau.isTauIDAvailable("againstElectronLooseMVA5") && tau.tauID("againstElectronLooseMVA5") > 0.5);
-    // passesLightFlavorRejection = passesLightFlavorRejection || (tau.isTauIDAvailable("againstElectronLooseMVA6") && tau.tauID("againstElectronLooseMVA6") > 0.5);
-    // passesLightFlavorRejection = passesLightFlavorRejection && (tau.isTauIDAvailable("againstMuonLoose3") && tau.tauID("againstMuonLoose3") > 0.5);
+    passesLightFlavorRejection = (tau.isTauIDAvailable("againstElectronLooseMVA5") && tau.tauID("againstElectronLooseMVA5") > 0.5);
+    passesLightFlavorRejection = passesLightFlavorRejection || (tau.isTauIDAvailable("againstElectronLooseMVA6") && tau.tauID("againstElectronLooseMVA6") > 0.5);
+    passesLightFlavorRejection = passesLightFlavorRejection && (tau.isTauIDAvailable("againstMuonLoose3") && tau.tauID("againstMuonLoose3") > 0.5);
 
+#elif DATA_FORMAT_IS_2022
     passesDecayModeReconstruction = tau.isTauIDAvailable("decayModeFindingNewDMs") && (tau.tauID("decayModeFindingNewDMs"));
 
-    passesLightFlavorRejection = ((tau.isTauIDAvailable("byVVVLooseDeepTau2018v2p5VSe") && tau.tauID("byVVVLooseDeepTau2018v2p5VSe")) ||
-                                  (tau.isTauIDAvailable("byVVVLooseDeepTau2017v2p1VSe") && tau.tauID("byVVVLooseDeepTau2017v2p1VSe"))) &&
-                                 ((tau.isTauIDAvailable("byVVVLooseDeepTau2018v2p5VSe") && tau.tauID("byVLooseDeepTau2018v2p5VSmu")) ||
-                                  (tau.isTauIDAvailable("byVLooseDeepTau2017v2p1VSmu") && tau.tauID("byVLooseDeepTau2017v2p1VSmu")));
+    passesLightFlavorRejection = true;
+
+    // The Tau IDs is done like this so that the 2018v2p5 algorithm has priority over the 2017v2p1, which is the recommendation from the Tau POG
+    // The 2018v2p5 doesn't exist in t > 0.5he PromptReco files, but exist in the rereco MiniAOD
+    if(tau.isTauIDAvailable("byVVVLooseDeepTau2018v2p5VSe")) {
+      passesLightFlavorRejection = passesLightFlavorRejection && (tau.tauID("byVVVLooseDeepTau2018v2p5VSe") > 0.5);
+    }
+    else if(tau.isTauIDAvailable("byVVVLooseDeepTau2017v2p1VSe")) {
+      passesLightFlavorRejection = passesLightFlavorRejection && (tau.tauID("byVVVLooseDeepTau2017v2p1VSe") > 0.5);
+    }
+    else {
+      passesLightFlavorRejection = passesLightFlavorRejection && false;
+    }
+
+    if(tau.isTauIDAvailable("byVLooseDeepTau2018v2p5VSmu")) {
+      passesLightFlavorRejection = passesLightFlavorRejection && (tau.tauID("byVLooseDeepTau2018v2p5VSmu") > 0.5);
+    }
+    else if(tau.isTauIDAvailable("byVLooseDeepTau2017v2p1VSmu")) {
+      passesLightFlavorRejection = passesLightFlavorRejection && (tau.tauID("byVLooseDeepTau2017v2p1VSmu") > 0.5);
+    }
+    else {
+      passesLightFlavorRejection = passesLightFlavorRejection && false;
+    }
+#endif
 
     if(passesDecayModeReconstruction && passesLightFlavorRejection && (dR < deltaRToClosestTauHad_  || deltaRToClosestTauHad_  < 0.0)) {
       deltaRToClosestTauHad_ = dR;

--- a/Collections/src/DisappearingTrack.cc
+++ b/Collections/src/DisappearingTrack.cc
@@ -691,7 +691,10 @@ osu::DisappearingTrack::set_minDeltaRToTaus(const edm::Handle<vector<TYPE(taus)>
 
     passesDecayModeReconstruction = tau.isTauIDAvailable("decayModeFindingNewDMs") && (tau.tauID("decayModeFindingNewDMs"));
 
-    passesLightFlavorRejection = (tau.isTauIDAvailable("byVVVLooseDeepTau2018v2p5VSe") && tau.isTauIDAvailable("byVLooseDeepTau2018v2p5VSmu")) && (tau.tauID("byVVVLooseDeepTau2018v2p5VSe") && tau.tauID("byVLooseDeepTau2018v2p5VSmu"));
+    passesLightFlavorRejection = ((tau.isTauIDAvailable("byVVVLooseDeepTau2018v2p5VSe") && tau.tauID("byVVVLooseDeepTau2018v2p5VSe")) ||
+                                  (tau.isTauIDAvailable("byVVVLooseDeepTau2017v2p1VSe") && tau.tauID("byVVVLooseDeepTau2017v2p1VSe"))) &&
+                                 ((tau.isTauIDAvailable("byVVVLooseDeepTau2018v2p5VSe") && tau.tauID("byVLooseDeepTau2018v2p5VSmu")) ||
+                                  (tau.isTauIDAvailable("byVLooseDeepTau2017v2p1VSmu") && tau.tauID("byVLooseDeepTau2017v2p1VSmu")));
 
     if(passesDecayModeReconstruction && passesLightFlavorRejection && (dR < deltaRToClosestTauHad_  || deltaRToClosestTauHad_  < 0.0)) {
       deltaRToClosestTauHad_ = dR;

--- a/Collections/src/Tau.cc
+++ b/Collections/src/Tau.cc
@@ -155,28 +155,32 @@ osu::Tau::passesLightFlavorRejection () const
 {
   bool flag = true;
 
-  // This were the selections used for Run 2; they were changed in Run 3 to use the DeepTau selections and a
+  // These were the selections used for Run 2; they were changed in Run 3 to use the DeepTau selections and a
   // distinct decay mode ID https://twiki.cern.ch/twiki/bin/view/CMS/TauIDRecommendationForRun3
   // The new IDs can be found in https://github.com/cms-sw/cmssw/blob/388ec50d980a31e7edb67eba169d45743d6623f5/Validation/RecoTau/python/RecoTauValidationMiniAOD_cfi.py (not sure if it is updated, though)
 
-  // if (this->isTauIDAvailable ("againstElectronLooseMVA5"))
-  //   flag = flag && (this->tauID ("againstElectronLooseMVA5") > 0.5);
-  // else if (this->isTauIDAvailable ("againstElectronLooseMVA6"))
-  //   flag = flag && (this->tauID ("againstElectronLooseMVA6") > 0.5);
-  // else
-  //   {
-  //     edm::LogWarning ("osu_Tau") << "Tau IDs \"againstElectronLooseMVA5\" and \"againstElectronLooseMVA6\" unavailable.";
-  //     flag = flag && false;
-  //   }
+#if DATA_FORMAT_IS_2017
+  if (this->isTauIDAvailable ("againstElectronLooseMVA5"))
+    flag = flag && (this->tauID ("againstElectronLooseMVA5") > 0.5);
+  else if (this->isTauIDAvailable ("againstElectronLooseMVA6"))
+    flag = flag && (this->tauID ("againstElectronLooseMVA6") > 0.5);
+  else
+    {
+      edm::LogWarning ("osu_Tau") << "Tau IDs \"againstElectronLooseMVA5\" and \"againstElectronLooseMVA6\" unavailable.";
+      flag = flag && false;
+    }
 
-  // if (this->isTauIDAvailable ("againstMuonLoose3"))
-  //   flag = flag && (this->tauID ("againstMuonLoose3") > 0.5);
-  // else
-  //   {
-  //     edm::LogWarning ("osu_Tau") << "Tau ID \"againstMuonLoose3\" unavailable.";
-  //     flag = flag && false;
-  //   }
+  if (this->isTauIDAvailable ("againstMuonLoose3"))
+    flag = flag && (this->tauID ("againstMuonLoose3") > 0.5);
+  else
+    {
+      edm::LogWarning ("osu_Tau") << "Tau ID \"againstMuonLoose3\" unavailable.";
+      flag = flag && false;
+    }
 
+#elif DATA_FORMAT_IS_2022
+  // The Tau IDs is done like this so that the 2018v2p5 algorithm has priority over the 2017v2p1, which is the recommendation from the Tau POG
+  // The 2018v2p5 doesn't exist in the PromptReco files, but exist in the rereco MiniAOD
   if (this->isTauIDAvailable ("byVVVLooseDeepTau2018v2p5VSe"))
     flag = flag && (this->tauID ("byVVVLooseDeepTau2018v2p5VSe") > 0.5);
   else if (this->isTauIDAvailable ("byVVVLooseDeepTau2017v2p1VSe"))
@@ -198,6 +202,7 @@ osu::Tau::passesLightFlavorRejection () const
       edm::LogWarning ("osu_Tau") << "Tau ID \"byVLooseDeepTau2017v2p1VSmu\" and \"byVLooseDeepTau2018v2p5VSmu\" unavailable.";
       flag = flag && false;
     }
+#endif
 
   return flag;
 }

--- a/Collections/src/Tau.cc
+++ b/Collections/src/Tau.cc
@@ -179,9 +179,11 @@ osu::Tau::passesLightFlavorRejection () const
 
   if (this->isTauIDAvailable ("byVVVLooseDeepTau2018v2p5VSe"))
     flag = flag && (this->tauID ("byVVVLooseDeepTau2018v2p5VSe") > 0.5);
+  else if (this->isTauIDAvailable ("byVVVLooseDeepTau2017v2p1VSe"))
+    flag = flag && (this->tauID ("byVVVLooseDeepTau2017v2p1VSe") > 0.5);
   else
     {
-      edm::LogWarning ("osu_Tau") << "Tau IDs \"byVVVLooseDeepTau2018v2p5VSe\" unavailable.";
+      edm::LogWarning ("osu_Tau") << "Tau IDs \"byVVVLooseDeepTau2017v2p1VSe\" and \"byVVVLooseDeepTau2018v2p5VSe\" unavailable.";
       flag = flag && false;
     }
 
@@ -189,9 +191,11 @@ osu::Tau::passesLightFlavorRejection () const
   // This should probably be checked with Tau POG experts
   if (this->isTauIDAvailable ("byVLooseDeepTau2018v2p5VSmu"))
     flag = flag && (this->tauID ("byVLooseDeepTau2018v2p5VSmu") > 0.5);
+  else if (this->isTauIDAvailable ("byVLooseDeepTau2017v2p1VSmu"))
+    flag = flag && (this->tauID ("byVLooseDeepTau2017v2p1VSmu") > 0.5);
   else
     {
-      edm::LogWarning ("osu_Tau") << "Tau ID \"byVLooseDeepTau2018v2p5VSmu\" unavailable.";
+      edm::LogWarning ("osu_Tau") << "Tau ID \"byVLooseDeepTau2017v2p1VSmu\" and \"byVLooseDeepTau2018v2p5VSmu\" unavailable.";
       flag = flag && false;
     }
 

--- a/Collections/src/Tau.cc
+++ b/Collections/src/Tau.cc
@@ -361,6 +361,12 @@ osu::Tau::match_HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v () const
   return match_HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v_;
 }
 
+const bool
+osu::Tau::match_HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v () const
+{
+  return match_HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v_;
+}
+
 void
 osu::Tau::set_match_HLT_LooseIsoPFTau50_Trk30_eta2p1_v (const bool flag)
 {
@@ -371,6 +377,12 @@ void
 osu::Tau::set_match_HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v (const bool flag)
 {
   match_HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v_ = flag;
+}
+
+void
+osu::Tau::set_match_HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v (const bool flag)
+{
+  match_HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v_ = flag;
 }
 
 #endif

--- a/Configuration/python/CollectionProducer_cff.py
+++ b/Configuration/python/CollectionProducer_cff.py
@@ -371,7 +371,9 @@ collectionProducer.tracks = cms.EDProducer ("OSUTrackProducer",
     graphPathDS = cms.FileInPath('OSUT3Analysis/Collections/data/graph.pb'),
     inputTensorNameDS = cms.string("input"),
     inputTrackTensorNameDS = cms.string("input_track"),
-    outputTensorNameDS = cms.string("model_1/output_xyz/Softmax")
+    outputTensorNameDS = cms.string("model_1/output_xyz/Softmax"),
+
+    muonTriggerFilter = cms.string("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered")
 )
 
 '''print("This is the electron vidVetoIDMap", collectionProducer.tracks.eleVIDVetoIdMap)


### PR DESCRIPTION
This PR changes some files with Run 3 information. The changes made in the Tau-related files might not be used in the framework, because we don't have a cut if a tau is matched to any trigger objects, but it is for completeness.

The changes in `Collections/plugins/OSUGenericTrackProducer.cc` will have some impact in the `info` and `trackInfo` objects, since some methods that are used needed some updates.

These changes compile, but still need to be tested to check if they are working correctly.