### PR TITLE
Hotfix: Use InputTag within VInputTag for eventvariables

### DIFF
--- a/Configuration/python/processingUtilities.py
+++ b/Configuration/python/processingUtilities.py
@@ -740,7 +740,7 @@ def add_channels (process,
                 channelPath += objectProducer
                 setattr (process, "objectProducer" + str (add_channels.producerIndex), objectProducer)
                 # Use the eventvariables producered in the above specific producers.
-                setattr(objectProducer.collections, "eventvariables" ,cms.VInputTag ("objectProducer" + str (add_channels.producerIndex - 1), "eventvariables"))
+                setattr(objectProducer.collections, "eventvariables" ,cms.VInputTag(cms.InputTag("objectProducer" + str (add_channels.producerIndex - 1), "eventvariables")))
                 if not hasattr (filteredCollections, "eventvariables"):
                     filteredCollections.eventvariables = cms.VInputTag ()
                 # Add the eventvariables produced in this module to the filteredCollections for the plotter after to use.


### PR DESCRIPTION
Hotfix for https://github.com/OSU-CMS/OSUT3Analysis/pull/285: Using VInputTag with multiple string arguments creates several InputTags. Instead, we want a single InputTag with multiple labels.

https://github.com/cms-sw/cmssw/blob/master/FWCore/ParameterSet/python/Types.py#L1269